### PR TITLE
Add basic auth

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,3 +1,5 @@
 ACHIEVER_API_ENDPOINT=https://bookingsystem-dev.stem.org.uk:8080/WorkflowAPI/Dev/_services/workflowservice.asmx/ExecuteWorkflow
 ACHIEVER_DB_CONNECTION_ID=CHANGEME
 ACHIEVER_FUTURE_COURSES_WORKFLOW_ID=CHANGEME
+BASIC_AUTH_USER=username
+BASIC_AUTH_PASSWORD=password

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@
 
 # Ignore .env file
 .env
+
+# test files
+coverage
+spec/examples.txt

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,10 @@
 class ApplicationController < ActionController::Base
-  http_basic_authenticate_with name: ENV['BASIC_AUTH_USER'], password: ENV['BASIC_AUTH_PASSWORD'] if ENV['BASIC_AUTH_PASSWORD']
+  before_action :authenticate
+
+  def authenticate
+    return unless ENV['BASIC_AUTH_PASSWORD']
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV['BASIC_AUTH_PASSWORD'] && password == ENV['BASIC_AUTH_PASSWORD']
+    end
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,5 @@ module Project
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
-    config.web_console.whitelisted_ips = '172.25.0.0/16'
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,7 +55,8 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  config.web_console.whiny_requests = false
+  config.web_console.whitelisted_ips = '172.25.0.0/16'
+  # config.web_console.whiny_requests = false
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationController, :type => :controller do
+  before(:each) do
+    allow(controller).to receive(:authenticate_or_request_with_http_basic)
+  end
+
+  describe 'before_action' do
+    describe '#authenticate' do
+      context 'when BASIC_AUTH_PASSWORD is set' do
+        it 'authenticate gets called' do
+          ENV.stub(:[]).with('BASIC_AUTH_PASSWORD').and_return('password')
+          controller.send(:authenticate)
+          expect(controller).to have_received(:authenticate_or_request_with_http_basic)
+        end
+      end
+
+      context 'when BASIC_AUTH_PASSWORD is not set' do
+        it 'authenticate does not get called' do
+          controller.send(:authenticate)
+          expect(controller).not_to have_received(:authenticate_or_request_with_http_basic)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related to: https://github.com/NCCE/private-teachcomputing.org-issues/issues/17

Adds basic auth requirement if ENV var `BASIC_AUTH_PASSWORD` is set (primarily for staging).

Relevant Terraform PR is incoming (which'll set the two ENV vars for the staging app).

Todo:
- [x] Tests