### PR TITLE
Add tagmanager.google.com to CSP allowed domains

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -9,7 +9,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.font_src    :self, :https, :data
   policy.img_src     :self, :https, :data
   policy.object_src  :none
-  policy.script_src  :self, :https, 'www.google-analytics.com', 'www.googletagmanager.com'
+  policy.script_src  :self, :https, 'www.google-analytics.com', 'www.googletagmanager.com', 'tagmanager.google.com'
   policy.style_src   :self, :https, :unsafe_inline
 
   policy.report_uri 'https://sentry.io/api/1370995/security/?sentry_key=f6ac7f0efe2242db8a1439f5059fafad'


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App: *populate this once the PR has been created*

## What's changed?

Whitelists the tagmanager.google.com domain in the CSP.