### PR TITLE
Fix copy on offer page

### DIFF
--- a/app/views/pages/offer.html.erb
+++ b/app/views/pages/offer.html.erb
@@ -11,40 +11,58 @@
 
           <h3 class="govuk-heading-s">A one-stop shop for computing education</h3>
           <ul class="govuk-list govuk-list--bullet">
-            <li>Face-to-face CPD</li>
-            <li>Online CPD</li>
-            <li>Certification</li>
-            <li>Resources, support and guidance</li>
+            <li><a href="#face-to-face-cpd">Face-to-face CPD</a></li>
+            <li><a href="#online-cpd">Online CPD</a></li>
+            <li><a href="#certification">Certification</a></li>
+            <li><a href="#resources">Resources, support and guidance</a></li>
           </ul>
 
-          <h3 class="govuk-heading-s">Face-to-face CPD</h3>
+          <h3 class="govuk-heading-s"><a id="face-to-face-cpd">Face-to-face CPD</a></h3>
           <p class="govuk-body">Whether you are new to teaching computing and computer science, or are more experienced and want to help your students achieve their full potential, we have the CPD for you.</p>
           <p class="govuk-body-s"><a class="govuk-button ncce-button__pink ncce-about__link" href="/login">Browse available CPD courses from your dashboard</a></p>
+          
+          <h4 class="govuk-heading-s">National Centre for Computing Education face-to-face CPD</h4>
           <p class="govuk-body">We have developed a selection of bursary-supported, face-to-face courses for teachers looking to gain confidence in teaching across the computing curriculum. There are currently a selection of primary courses available to book at venues across England, with more courses coming soon.</p>
+          <ul class="govuk-list">
+            <li>Outstanding teaching of key stage 1 computing</li>
+            <li>Outstanding teaching of key stage 2 computing</li>
+            <li>Primary programming and algorithms</li>
+          </ul>
+          <p class="govuk-body-s"><a class="govuk-button ncce-button__pink ncce-about__link" href="/login">Browse available CPD courses from your dashboard</a></p>
 
-          <h3 class="govuk-heading-s">The Computer Science Accelerator Programme</h3>
-          <p class="govuk-body">The Computer Science Accelerator Programme is designed to support secondary teachers of computing or computer science without a post A level qualification in computer science or a related subject.</p>
+          <h4 class="govuk-heading-s">The Computer Science Accelerator Programme</h4>
+          <p class="govuk-body">If you’re a secondary school teacher without a post A level qualification in computer science or a related subject then the Computer Science Accelerator Programme is specifically designed to help you. <a href="/accelerator">Find out more</a></p>
+          <p class="govuk-body">Face-to-face courses currently available are:</p>
+          <ul class="govuk-list">
+            <li>Algorithms in GCSE computer science</li>
+            <li>Python programming essentials for GCSE computer science</li>
+            <li>Data and computer systems in GCSE computer science</li>
+            <li>Networks and cyber-security in GCSE computer science</li>
+          </ul>
           <p class="govuk-body-s"><a class="govuk-button ncce-button__pink ncce-about__link" href="/accelerator">Browse available CPD courses from your dashboard</a></p>
 
-          <h3 class="govuk-heading-s">A Level CPD</h3>
+          <h4 class="govuk-heading-s">A Level CPD</h4>
           <p class="govuk-body">We are currently developing a comprehensive programme of support including face-to-face training for teachers and students in England for AS/A level computer science. You can read more about this in our <a href="/news/a-level">recent article</a>.</p>
 
-          <h3 class="govuk-heading-s">Online CPD</h3>
+          <h3 class="govuk-heading-s"><a id="online-cpd">Online CPD</a></h3>
           <p class="govuk-body">We have created a number of free, online courses available on the FutureLearn Platform which you can access at a time and place that suits you. Interact with your peers and access the support of expert moderators, who are available to support you throughout your learning.</p>
           <p class="govuk-body">Some of the courses form part of the Computer Science Accelerator Programme, and can contribute towards the 40 hours of CPD required to complete the programme.</p>
           <p class="govuk-body-s"><a class="govuk-button ncce-button__pink ncce-about__link" href="/login">Browse available CPD courses from your dashboard</a></p>
           <p class="govuk-body-s govuk-!-font-size-14">More coming online in the next few months.</p>
-          <p class="govuk-heading-s">Certification</p>
+          <h3 class="govuk-heading-s"><a id="certification">Certification</a></h3>
           <p class="govuk-body">We are working on a system of certification to provide a pathway to chartered status for teachers of computing education. More details will be available soon.</p>
           <p class="govuk-body-s"><a class="govuk-button ncce-button__pink ncce-about__link" href="/certification">Find out more about certification</a></p>
 
-          <h3 class="govuk-heading-s">Resources, support and guidance</h3>
-          <p class="govuk-body">Explore curriculum-linked computing resources and network with other teachers and experts in your local community to get ideas and support for your computing lessons.</p>
-          <p class="govuk-body">We are currently developing a collection of free quality assured learning materials to give you new ideas and inspiration for planning, delivering and assessing learning.</p>
-          <p class="govuk-body">In the meantime, you can browse computing-related resources on the <a class="ncce-link" href="https://www.stem.org.uk/">STEM Learning website</a>, <a class="ncce-link" href="https://projects.raspberrypi.org">Raspberry Pi Projects</a> or the <a class="ncce-link" href="https://community.computingatschool.org.uk/resources/landing">Computing at School website</a> to get ideas and support for your computing lessons.</p>
+          <h3 class="govuk-heading-s"><a id="resources">Resources, support and guidance</a></h3>
+          <p class="govuk-body">Once you have registered you’ll be able to access a wide range of free resources, support and guidance, as well as network with other computing teachers and experts in your local area.</p>
+          <h4 class="govuk-heading-s">Resources</h4>
+          <p class="govuk-body">The STEM Learning website has plenty of ideas and free resources to support you in the classroom.</p>
+          <p class="govuk-body-s"><a class="govuk-button ncce-button__pink ncce-about__link" href="https://www.stem.org.uk/resources/search?f%5B0%5D=field_subject%3A92&f%5B1%5D=type%3Aelibrary_resource">Access resources</a></p>
+          <p class="govuk-body">We are developing a collection of quality assured learning materials which you will be able to access straight from your dashboard, to give you inspiration for planning, delivering and assessing learning.</p>
 
           <h3 class="govuk-heading-s">CAS local communities</h3>
-          <p class="govuk-body">A CAS Local Community meet up is a meeting for those who wish to share ideas for developing the teaching of computing in their schools, their classrooms and their community.</p>
+          <p class="govuk-body">A CAS Local Community meeting is a great way to share ideas and network with fellow computing teachers in your locality. Getting involved in CAS is easy, follow the link below to join the community.</p>
+          <p class="govuk-body">As well as having face-to-face meetings the CAS is a great way to discuss topics and view resources to help you deliver engaging teaching in the classroom.</p>
           <p class="govuk-body-s"><a class="govuk-button ncce-button__pink ncce-about__link" href="https://www.computingatschool.org.uk/">Find your local community</a></p>
         </div>
 


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-130.herokuapp.com/
* Closes [#160](https://github.com/NCCE/teachcomputing.org-issues/issues/160)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Added / updated copy from Google Doc, including anchor links to page sections.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*