### PR TITLE
Change release task to generate the sitemap.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -C config/puma.rb
-release: bin/rails db:migrate
+release: bash ./release-tasks.sh

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+bin/rails db:migrate
+if [ "$RAILS_ENV" == "production" ]; then
+    bin/rails sitemap:refresh
+fi


### PR DESCRIPTION
## Status

* Current Status: WIP
* Review App:
* Closes [#198](https://github.com/NCCE/teachcomputing.org-issues/issues/198)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Add an environment dependent command to regenerate the sitemap in production.
Needs separate file - we don't want to deploy it in non-prod env?
https://devcenter.heroku.com/articles/release-phase#specifying-release-phase-tasks
https://mikerogers.io/2018/03/27/heroku-release-tasks-and-rails.html

Not sure how to test?

## Steps to perform after deploying to production

Check that https://teachcomputing.org/sitemap.xml.gz exists.