### PR TITLE
Add removal of tmp server.pid file to Docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - '5432:5432'
   web:
     build: .
-    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/app
       - node_modules:/app/node_modules # ensures we retain node_modules from docker build


### PR DESCRIPTION
Resolves the issue where randomly we need to remove the `service.pid` file 