### PR TITLE
Set the default text colour and override, fix contrast issue.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,10 +1,10 @@
-// Override Gov UK fonts
+// Override Gov UK fonts & colours
 @import 'settings/_fonts.scss';
+@import 'settings/_colors.scss';
 
 @import 'govuk-frontend/all';
 
 // import NCCE settings
-@import 'settings/_colors.scss';
 @import 'settings/_links.scss';
 @import 'settings/_section-breaks.scss';
 @import 'settings/_typography.scss';

--- a/app/assets/stylesheets/components/pages/home/_stay-updated.scss
+++ b/app/assets/stylesheets/components/pages/home/_stay-updated.scss
@@ -31,7 +31,6 @@
 }
 
 .ncce-stay-updated__date {
-	color: #a3a3a3;
 	margin-bottom: 0;
 	margin-top: 0.5rem;
 }

--- a/app/assets/stylesheets/settings/_colors.scss
+++ b/app/assets/stylesheets/settings/_colors.scss
@@ -20,3 +20,6 @@ $ncce-pink: #de01a5;
 $ncce-pink-flash: #f5b2e4;
 $ncce-pink-light: #fbf3f9;
 $ncce-dark-pink: #b10b86;
+$ncce-black: #000;
+
+$govuk-text-colour: $ncce-dark-x-grey;

--- a/app/assets/stylesheets/settings/_typography.scss
+++ b/app/assets/stylesheets/settings/_typography.scss
@@ -3,6 +3,7 @@
 .govuk-heading-l,
 .govuk-heading-xl {
   font-family: $font-family-heading;
+  color: $ncce-black;
 }
 
 .govuk-body {


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [#196](https://github.com/NCCE/teachcomputing.org-issues/issues/196)
## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Override the Gov UK's default text colour by setting the variable before
including their framework.
Then set the heading colour to black as per design:
https://app.goabstract.com/projects/339c2b20-cd5f-11e8-875d-d51d716fe670/branches/master/commits/a728e916f97df7c35d34be0b2264216447748634/files/85B426E8-801F-46C0-8409-050BE8D9C108/layers/AA530122-2B5B-4D9B-877B-18F78A9A262C?mode=design
Remove colour override for the news article 'dates' on homepage.
