### PR TITLE
Add fonts.gstatic.com to font-src

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,7 +6,7 @@
 
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self, :https
-  policy.font_src    :self, :https, :data
+  policy.font_src    :self, :https, :data, 'fonts.gstatic.com'
   policy.img_src     :self, :https, :data
   policy.object_src  :none
   policy.script_src  :self, :https, 'www.google-analytics.com', 'www.googletagmanager.com', 'tagmanager.google.com'


### PR DESCRIPTION
## Status

* Current Status: Ready for review

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Whitelists fonts.gstatic.com in the CSP font-src declaration