### PR TITLE
Set the BYPASS_OAUTH variable for review apps to 'true'

### DIFF
--- a/app.json
+++ b/app.json
@@ -60,7 +60,7 @@
     },
     "BYPASS_OAUTH": {
       "description": "Allows login without using OAuth mechanism",
-      "required": true
+      "value": "true"
     },
     "ACHIEVER_API_ENDPOINT": {
       "required": true


### PR DESCRIPTION
## Status

* Current Status: Ready for (tech) review
* Review App: *populate this once the PR has been created*
* Closes (don't close automatically because of terraform fix)
* Related to [254](https://github.com/NCCE/teachcomputing.org-issues/issues/254)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

It shouldn't be in the terraform config / staging vars for Heroku as we only
want it to exist for review apps - setting the value in app.json will do that.

After deploying to staging and TF PR is deployed, make sure login works on staging.