### PR TITLE
ensure correct env vars are used for cache

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,9 +58,9 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   config.cache_store = :mem_cache_store,
-                       (ENV['MEMCACHIER_SERVERS'] || '').split(','),
-                       { username: ENV['MEMCACHIER_USERNAME'],
-                         password: ENV['MEMCACHIER_PASSWORD'],
+                       (ENV['MEMCACHEDCLOUD_SERVERS'] || '').split(','),
+                       { username: ENV['MEMCACHEDCLOUD_USERNAME'],
+                         password: ENV['MEMCACHEDCLOUD_PASSWORD'],
                          failover: true,
                          socket_timeout: 1.5,
                          socket_failure_delay: 0.2,


### PR DESCRIPTION
## Status

* Current Status: Ready
* Related to https://github.com/NCCE/teachcomputing.org-issues/issues/200

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Well turns out I had wrong memcache env vars set. My bad.
