### PR TITLE
increase cache expiry for courses

### DIFF
--- a/app/lib/achiever.rb
+++ b/app/lib/achiever.rb
@@ -21,7 +21,7 @@ class Achiever
     params = build_params(workflow_id, workflow_params)
     request = build_request(params)
 
-    result = Rails.cache.fetch("#{workflow_id}-#{Date.today}", expires_in: 30.minutes) do
+    result = Rails.cache.fetch("#{workflow_id}-#{Date.today}", expires_in: 6.hours) do
       RestClient.get(request).body
     end
 
@@ -34,7 +34,7 @@ class Achiever
     params = build_params(workflow_id, workflow_params)
     request = build_request(params)
 
-    result = Rails.cache.fetch("#{workflow_id}-#{Date.today}", expires_in: 30.minutes) do
+    result = Rails.cache.fetch("#{workflow_id}-#{Date.today}", expires_in: 6.hours) do
       RestClient.get(request).body
     end
 


### PR DESCRIPTION
## Status

* Current Status: Ready
* Related to https://github.com/NCCE/teachcomputing.org-issues/issues/200

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Increase the cache expiry to 6 hours for courses.