### PR TITLE
253: Fix link text for BCS on home page.

### DIFF
--- a/app/views/pages/home/_jobs.html.erb
+++ b/app/views/pages/home/_jobs.html.erb
@@ -14,7 +14,7 @@
             <%= link_to 'Jobs at STEM Learning', 'https://www.stem.org.uk/stem-learning-vacancies', class: 'ncce-link', target: '_blank' %>
           </p>
           <p class="govuk-body">
-            <%= link_to 'Jobs at the British Computing Society', 'https://www.bcs.org/category/9091', class: 'ncce-link', target: '_blank' %>
+            <%= link_to 'Jobs at BCS, The Chartered Institute for IT', 'https://www.bcs.org/category/9091', class: 'ncce-link', target: '_blank' %>
           </p>
           <h2 class="govuk-heading-m">Become a hub</h2>
           <p class="govuk-body">


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [263](https://github.com/NCCE/teachcomputing.org-issues/issues/263)
* Related to *add issue numbers or delete*

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Change link text on home page 'Jobs' section

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*