### PR TITLE
ensure connection size cannot go over 20 connection size for hobby plan

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,5 +5,5 @@ Sidekiq.configure_client do |config|
 end
 
 Sidekiq.configure_server do |config|
-  config.redis = { url: ENV['REDIS_URL'], size: 20 }
+  config.redis = { url: ENV['REDIS_URL'], size: 15 }
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,7 @@
 development:
   :concurrency: 1
+staging:
+  :concurrency: 3
 production:
   :concurrency: 3
 :queues:


### PR DESCRIPTION
## Status

* Current Status: Ready
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/270

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Lowers the size for redis connections so we don't go over the max 20 connections for hobby tier. 15 is more than enough for our use in staging and production. 
