### PR TITLE
Add the 3 new FL courses as activities

### DIFF
--- a/lib/tasks/populate_activities.rake
+++ b/lib/tasks/populate_activities.rake
@@ -62,6 +62,33 @@ namespace :activities do
       activity.provider = 'future-learn'
     end
 
+    Activity.find_or_create_by(slug: 'an-introduction-to-computer-networking-for-teachers') do |activity|
+      activity.title = 'An Introduction to Computer Networking for Teachers'
+      activity.credit = 0
+      activity.slug = activity.title.parameterize
+      activity.category = 'cpd'
+      activity.self_certifiable = true
+      activity.provider = 'future-learn'
+    end
+
+    Activity.find_or_create_by(slug: 'understanding-maths-and-logic-in-computer-science') do |activity|
+      activity.title = 'Understanding Maths and Logic in Computer Science'
+      activity.credit = 0
+      activity.slug = activity.title.parameterize
+      activity.category = 'cpd'
+      activity.self_certifiable = true
+      activity.provider = 'future-learn'
+    end
+
+    Activity.find_or_create_by(slug: 'understanding-computer-systems') do |activity|
+      activity.title = 'Understanding Computer Systems'
+      activity.credit = 0
+      activity.slug = activity.title.parameterize
+      activity.category = 'cpd'
+      activity.self_certifiable = true
+      activity.provider = 'future-learn'
+    end
+
     Activity.find_or_create_by(slug: 'algorithms-in-gcse-computer-science') do |activity|
       activity.title = 'Algorithms in GCSE computer science'
       activity.credit = 0


### PR DESCRIPTION
## Status

* Current Status: Ready
* Review App: *populate this once the PR has been created*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/283

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Three new FL courses have been added. They need to be self certifiable and also appear in the FL import section in the admin. This PR makes this happen.

## Steps to perform after deploying to production

`heroku run bin/rails activities:seed -app teachcomputing-production`

this should be ran on Moday 