### PR TITLE
251: add an endpoint to act as a static CSS url for external apps.

### DIFF
--- a/app/controllers/asset_endpoint_controller.rb
+++ b/app/controllers/asset_endpoint_controller.rb
@@ -1,0 +1,6 @@
+class AssetEndpointController < ApplicationController
+    def css_endpoint
+      redirect_to "#{helpers.asset_path("application", type: :stylesheet)}"
+    end
+  end
+  

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -21,8 +21,4 @@ class PagesController < ApplicationController
     end
     render template: 'pages/login', locals: { auth_uri: auth_uri }
   end
-
-  def css_endpoint
-    redirect_to "#{helpers.asset_path("application", type: :stylesheet)}"
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,7 @@ Rails.application.routes.draw do
 
   end
 
-  get '/external/assets/ncce.css', to: 'pages#css_endpoint', as: :css_endpoint
+  get '/external/assets/ncce.css', to: 'asset_endpoint#css_endpoint', as: :css_endpoint
 
   require 'sidekiq/web'
   if Rails.env.production?

--- a/spec/requests/asset_endpoint/asset_endpoint_spec.rb
+++ b/spec/requests/asset_endpoint/asset_endpoint_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe PagesController do
+RSpec.describe AssetEndpointController do
   describe '#css_endpoint' do
     context 'css_redirect' do
       before do


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Related to [#251](https://github.com/NCCE/teachcomputing.org-issues/issues/251)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Add a static URL that will redirect to our application CSS.
So the STEM site may be able to consume our CSS file externally without us telling them the URL each time we deploy - this would enable them to host pages using our styles, e.g. login.
