### PR TITLE
358: Fix issue with removing achievements.

### DIFF
--- a/app/models/achievement.rb
+++ b/app/models/achievement.rb
@@ -6,7 +6,7 @@ class Achievement < ApplicationRecord
 
   validates :user_id, uniqueness: { scope: [:activity_id] }
 
-  has_many :achievement_transitions, autosave: false
+  has_many :achievement_transitions, autosave: false, dependent: :destroy
 
   def state_machine
     @state_machine ||= StateMachines::AchievementStateMachine.new(self, transition_class: AchievementTransition)

--- a/db/migrate/20190429110311_update_foreign_key_acheivement_transitions_achievement.rb
+++ b/db/migrate/20190429110311_update_foreign_key_acheivement_transitions_achievement.rb
@@ -1,0 +1,9 @@
+class UpdateForeignKeyAcheivementTransitionsAchievement < ActiveRecord::Migration[5.2]
+  def change
+    # remove the old foreign_key
+    remove_foreign_key :achievement_transitions, :achievements
+
+    # add the new foreign_key
+    add_foreign_key :achievement_transitions, :achievements, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_29_080853) do
+ActiveRecord::Schema.define(version: 2019_04_29_110311) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -105,5 +105,5 @@ ActiveRecord::Schema.define(version: 2019_04_29_080853) do
     t.index ["stem_user_id"], name: "index_users_on_stem_user_id", unique: true
   end
 
-  add_foreign_key "achievement_transitions", "achievements"
+  add_foreign_key "achievement_transitions", "achievements", on_delete: :cascade
 end

--- a/spec/models/achievement_spec.rb
+++ b/spec/models/achievement_spec.rb
@@ -52,4 +52,15 @@ RSpec.describe Achievement, type: :model do
     it { is_expected.to delegate_method(:current_state).to(:state_machine).as(:current_state) }
     it { is_expected.to delegate_method(:transition_to).to(:state_machine).as(:transition_to) }
   end
+
+  describe 'destroy' do
+    before do
+      achievement
+      achievement.transition_to(:complete)
+    end
+
+    it 'deletes transitions' do
+      expect { achievement.destroy }.to change { AchievementTransition.count }.by(-1)
+    end
+  end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [358](https://github.com/NCCE/teachcomputing.org-issues/issues/358)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

When an Achievement had transitions associated with it, trying to remove this failed.
This seems to occur when achievements are created by importing from Future Learn - the online
courses are still self-certifiable, so a user may have tried to remove this, but failed.
Added a migration to fix the foreign keys on AchievementTransition and a test covering the error.

## Steps to perform after deploying to production

Run / check migrations.
Check that an achievement added by importing Future Learn CSV can be deleted.