### PR TITLE
408: Make sure the user's details are included in link to assessment.

### DIFF
--- a/app/controllers/assessment_attempts_controller.rb
+++ b/app/controllers/assessment_attempts_controller.rb
@@ -5,7 +5,7 @@ class AssessmentAttemptsController < ApplicationController
     assessment_attempt = AssessmentAttempt.new(assessment_attempts_params)
     if assessment_attempt.save
       ExpireAssessmentAttemptJob.set(wait: 2.hours).perform_later(assessment_attempt)
-      redirect_to @assessment.link
+      redirect_to assessment_url(assessment_attempt.user)
     else
       flash[:error] = 'Whoops something went wrong'
       redirect_to programme_path(@assessment.programme.id)
@@ -20,5 +20,9 @@ class AssessmentAttemptsController < ApplicationController
 
     def assessment_attempts_params
       params.require(:assessment_attempt).permit(:assessment_id, :user_id)
+    end
+
+    def assessment_url(user)
+      "#{@assessment.link}?cm_e=#{user.email}&cm_user_id=#{user.id}"
     end
 end

--- a/app/views/programmes/_cs-accelerator.html.erb
+++ b/app/views/programmes/_cs-accelerator.html.erb
@@ -17,7 +17,7 @@
       <ul class="govuk-list ncce-activity-list">
           <li class="ncce-activity-list__item ncce-activity-list__item--incomplete">
             <span class="ncce-activity-list__item-text"> Pass the final exam </span>
-            <%= link_to_if(can_take_accelerator_test?(current_user, @programme), 'Take the final exam', assessment_attempts_path(assessment_attempt: { assessment_id: @programme.assessment.id, user_id: current_user }), class: 'govuk-button ncce-button__pink ncce-button__pink--rounded') do %>
+            <%= link_to_if(can_take_accelerator_test?(current_user, @programme), 'Take the final exam', assessment_attempts_path(assessment_attempt: { assessment_id: @programme.assessment.id, user_id: current_user }), method: :post, class: 'govuk-button ncce-button__pink ncce-button__pink--rounded') do %>
               <span class="ncce-activity-list__item-sub-text">The exam will be available when all the above is complete</span>
             <% end %>
           </li>

--- a/spec/requests/assessment_attempts/create_spec.rb
+++ b/spec/requests/assessment_attempts/create_spec.rb
@@ -18,8 +18,9 @@ RSpec.describe AssessmentAttemptsController do
 
       it 'redirects to the assessment link path' do
         post assessment_attempts_path(assessment_attempt: { assessment_id: assessment.id, user_id: user.id })
-        expect(response).to redirect_to(assessment.link)
+        expect(response).to redirect_to(/#{assessment.link}\?cm_e=#{user.email}&cm_user_id=#{user.id}/)
       end
+
 
       it 'queues ExpireAssessmentAttemptJob job' do
         expect do


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-286.herokuapp.com/
* Closes [408](https://github.com/NCCE/teachcomputing.org-issues/issues/408)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

When we redirect the 'Assessment' to ClassMarker, pre-populate the user's details.  Amend test.
Change the 'Take exam' button to POST

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*