### PR TITLE
Fix dashboard title padding for ROA section.

### DIFF
--- a/app/assets/stylesheets/components/dashboard/_show.scss
+++ b/app/assets/stylesheets/components/dashboard/_show.scss
@@ -9,6 +9,7 @@
 
 .ncce-dashboard__title {
   text-align: center;
+  padding: 1.5rem 0;
 }
 
 .ncce-dashboard__activities {


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-297.herokuapp.com/dashboard

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Fix dashboard title padding for ROA section.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*