### PR TITLE
Fixes for a11y - mainly contrast, a couple of alt '' tags.

### DIFF
--- a/app/assets/stylesheets/components/_aside.scss
+++ b/app/assets/stylesheets/components/_aside.scss
@@ -7,9 +7,6 @@
 		color: $ncce-white;
 	}
 
-	&__text--dark {
-		color: $ncce-grey-manatee;
-	}
 	&__title {
 		color: $ncce-white;
 		font-weight: 700;

--- a/app/assets/stylesheets/components/pages/certification/_pathway.scss
+++ b/app/assets/stylesheets/components/pages/certification/_pathway.scss
@@ -52,8 +52,4 @@
   &__step:last-child:after {
     border-left: none;
   }
-
-  &__text--lighter {
-    color: $ncce-grey-dark;
-  }
 }

--- a/app/views/dashboard/_activity.html.erb
+++ b/app/views/dashboard/_activity.html.erb
@@ -57,7 +57,7 @@
       will be soon as well, but for now you can add them manually. We will also be
       including the credits you’ve earned that will
       help you track your progress towards <%= link_to 'certification', certification_path,
-      class: 'ncce-link ncce-link--on-dark' %>.
+      class: 'ncce-link' %>.
       </p>
     </div>
   </div>

--- a/app/views/pages/certification/_pathway.html.erb
+++ b/app/views/pages/certification/_pathway.html.erb
@@ -13,7 +13,7 @@
         </span>
           Participate</h2>
         <p class="govuk-body">Complete 40 hours of CPD, both online and local to you</p>
-        <p class="govuk-body-s pathway__text--lighter">(Your release time is covered, paid to your school after completion of face-to-face courses)</p>
+        <p class="govuk-body-s">(Your release time is covered, paid to your school after completion of face-to-face courses)</p>
     </li>
     <li class="pathway__step">
       <h2 class="govuk-heading-s pathway__step-title">
@@ -21,7 +21,7 @@
         </span>
           Complete</h2>
         <p class="govuk-body">Complete your learning programme by carrying out a short test</p>
-        <p class="govuk-body-s pathway__text--lighter">(Any extra funding support is paid to your school after completion of the test)</p>
+        <p class="govuk-body-s">(Any extra funding support is paid to your school after completion of the test)</p>
     </li>
     <li class="pathway__step">
       <h2 class="govuk-heading-s pathway__step-title">

--- a/app/views/pages/cs-accelerator.html.erb
+++ b/app/views/pages/cs-accelerator.html.erb
@@ -27,11 +27,10 @@
             <% end %>
             <P class="govuk-body-s ncce-aside__text">Begin your journey towards being a fully qualified GCSE computer science teacher!</p>
             <ol class="govuk-list govuk-list--number ncce-aside__text govuk-body-s cs-accelerator-aside__list">
-              <% if current_user %>
-                <li class="ncce-aside__text--dark"><%= image_tag("/images/favicon.png", size: '', alt: 'Completed icon', class: 'ncce-aside__check-mark') %>
-              <% else %>
-                <li>
-              <% end %>Create your account with STEM Learning, and log in</li>
+              <li>
+                 <%= image_tag("/images/favicon.png", size: '', alt: 'Completed icon', class: 'ncce-aside__check-mark') if current_user %>
+                Create your account with STEM Learning, and log in
+              </li>
               <li>Enrol with the click of the button</li>
               <li>Use your personal dashboard to track your progress towards certification</li>
               <li>Find and book onto coursed until you have enough credits to take the final test</li>

--- a/app/views/programmes/_exam_activity.html.erb
+++ b/app/views/programmes/_exam_activity.html.erb
@@ -8,9 +8,9 @@
     <%= image_tag(%"/images/notepad-right.svg", alt: '', class: 'certification-progress__image certification-progress__image--mobile-exam') %>
     <span class="ncce-activity-list__item-text ncce-activity-list__item-text--exam">Pass the final test</span>
     <ul class="govuk-body-s ncce-exam-activity__remarks">
-      <li><%= image_tag 'question-mark.svg' %> 25 multiple-choice questions</li>
-      <li><%= image_tag 'time-30-minutes.svg' %> 30 minute time limit</li>
-      <li><%= image_tag 'tick-plain.svg' %> Pass mark of 65%</li>
+      <li><%= image_tag 'question-mark.svg', alt: '' %> 25 multiple-choice questions</li>
+      <li><%= image_tag 'time-30-minutes.svg', alt: '' %> 30 minute time limit</li>
+      <li><%= image_tag 'tick-plain.svg', alt: '' %> Pass mark of 65%</li>
     </ul>
     <ul class="govuk-list govuk-list--bullet govuk-body-s ncce-exam-activity__rules"">
       <li>You must finish in one sitting</li>


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Fix contrast on 'pathway diagram text' and aside (logged in) on /cs-accelerator
Add empty alt tags to 'exam activity' icons on /certificates/cs-accelerator
Fix link colour on dashboard.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*