### PR TITLE
416: Redirect to the 'complete' page if user has passed assessment.

### DIFF
--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -7,6 +7,7 @@ class ProgrammesController < ApplicationController
   before_action :list_achievements_by_category, only: [:show, :complete]
   before_action :get_passed_programme_assessment
   before_action :passed_programme_assessment?, only: [:complete, :certificate]
+  before_action :show_completed_page?, only: [:show]
   before_action :get_assessment_state_details, only: [:show]
   before_action :get_certificate_details, only: [:certificate]
 
@@ -66,6 +67,10 @@ class ProgrammesController < ApplicationController
 
     def passed_programme_assessment?
       redirect_to programme_path(@programme.slug) unless @passed_assessment
+    end
+
+    def show_completed_page?
+      redirect_to programme_complete_path(@programme.slug) if @passed_assessment
     end
 
     def get_certificate_details

--- a/spec/requests/programmes/complete_spec.rb
+++ b/spec/requests/programmes/complete_spec.rb
@@ -119,6 +119,11 @@ RSpec.describe ProgrammesController do
           it 'assigns the assessment passed state correctly' do
             expect(assigns(:passed_assessment)).to eq (true)
           end
+
+          it 'redirects show to complete' do
+            get programme_path('cs-accelerator')
+            expect(response).to redirect_to(programme_complete_path('cs-accelerator'))
+          end
         end
       end
 


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [416](https://github.com/NCCE/teachcomputing.org-issues/issues/416)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Add before_action to redirect the request and test.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*