### PR TITLE
436: Create DB Seeds to populate CS Accelerator

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "teachcomputing",
   "scripts": {
-    "postdeploy": "bin/rails db:migrate && bin/rails activities:seed"
+    "postdeploy": "bin/rails db:migrate && bin/rails db:seed"
   },
   "env": {
     "RAILS_ENV": {

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,2 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+require File.expand_path('../seeds/activities', __FILE__)
+require File.expand_path('../seeds/programmes', __FILE__)

--- a/db/seeds/activities.rb
+++ b/db/seeds/activities.rb
@@ -1,0 +1,209 @@
+Activity.find_or_create_by(slug: 'diagnostic-tool') do |activity|
+  activity.title = 'Taken diagnostic tool'
+  activity.credit = 10
+  activity.slug = 'diagnostic-tool'
+  activity.category = 'action'
+  activity.self_certifiable = true
+  activity.provider = 'system'
+end
+
+Activity.find_or_create_by(slug: 'registered-with-the-national-centre') do |activity|
+  activity.title = 'Registered with the National Centre'
+  activity.credit = 5
+  activity.slug = activity.title.parameterize
+  activity.category = 'action'
+  activity.self_certifiable = false
+  activity.provider = 'system'
+end
+
+Activity.find_or_create_by(slug: 'teaching-physical-computing-with-raspberry-pi-and-python') do |activity|
+  activity.title = 'Teaching Physical Computing with Raspberry Pi and Python'
+  activity.credit = 20
+  activity.slug = activity.title.parameterize
+  activity.category = 'online'
+  activity.self_certifiable = true
+  activity.provider = 'future-learn'
+end
+
+Activity.find_or_create_by(slug: 'how-computers-work-demystifying-computation') do |activity|
+  activity.title = 'How Computers Work: Demystifying Computation'
+  activity.credit = 20
+  activity.slug = activity.title.parameterize
+  activity.category = 'online'
+  activity.self_certifiable = true
+  activity.provider = 'future-learn'
+end
+
+Activity.find_or_create_by(slug: 'programming-101-an-introduction-to-python-for-educators') do |activity|
+  activity.title = 'Programming 101: An Introduction to Python for Educators'
+  activity.credit = 20
+  activity.slug = activity.title.parameterize
+  activity.category = 'online'
+  activity.self_certifiable = true
+  activity.provider = 'future-learn'
+end
+
+Activity.find_or_create_by(slug: 'programming-102-think-like-a-computer-scientist') do |activity|
+  activity.title = 'Programming 102: Think like a Computer Scientist'
+  activity.credit = 20
+  activity.slug = activity.title.parameterize
+  activity.category = 'online'
+  activity.self_certifiable = true
+  activity.provider = 'future-learn'
+end
+
+Activity.find_or_create_by(slug: 'representing-data-with-images-and-sound-bringing-data-to-life') do |activity|
+  activity.title = 'Representing Data with Images and Sound: Bringing Data to Life'
+  activity.credit = 20
+  activity.slug = activity.title.parameterize
+  activity.category = 'online'
+  activity.self_certifiable = true
+  activity.provider = 'future-learn'
+end
+
+Activity.find_or_create_by(slug: 'object-oriented-programming-in-python-create-your-own-adventure-game') do |activity|
+  activity.title = 'Object-oriented Programming in Python: Create Your Own Adventure Game'
+  activity.credit = 20
+  activity.slug = activity.title.parameterize
+  activity.category = 'online'
+  activity.self_certifiable = true
+  activity.provider = 'future-learn'
+end
+
+Activity.find_or_create_by(slug: 'an-introduction-to-computer-networking-for-teachers') do |activity|
+  activity.title = 'An Introduction to Computer Networking for Teachers'
+  activity.credit = 20
+  activity.slug = activity.title.parameterize
+  activity.category = 'online'
+  activity.self_certifiable = true
+  activity.provider = 'future-learn'
+end
+
+Activity.find_or_create_by(slug: 'understanding-maths-and-logic-in-computer-science') do |activity|
+  activity.title = 'Understanding Maths and Logic in Computer Science'
+  activity.credit = 20
+  activity.slug = activity.title.parameterize
+  activity.category = 'online'
+  activity.self_certifiable = true
+  activity.provider = 'future-learn'
+end
+
+Activity.find_or_create_by(slug: 'understanding-computer-systems') do |activity|
+  activity.title = 'Understanding Computer Systems'
+  activity.credit = 20
+  activity.slug = activity.title.parameterize
+  activity.category = 'online'
+  activity.self_certifiable = true
+  activity.provider = 'future-learn'
+end
+
+Activity.find_or_create_by(slug: 'teaching-programming-in-primary-schools') do |activity|
+  activity.title = 'Teaching Programming in Primary Schools'
+  activity.credit = 10
+  activity.slug = activity.title.parameterize
+  activity.category = 'online'
+  activity.self_certifiable = true
+  activity.provider = 'future-learn'
+end
+
+Activity.find_or_create_by(slug: 'scratch-to-python-moving-from-block-to-text-based-programming') do |activity|
+  activity.title = 'Scratch to Python: Moving from Block- to Text-based Programming'
+  activity.credit = 10
+  activity.slug = activity.title.parameterize
+  activity.category = 'online'
+  activity.self_certifiable = true
+  activity.provider = 'future-learn'
+end
+
+Activity.find_or_create_by(slug: 'algorithms-in-gcse-computer-science') do |activity|
+  activity.title = 'Algorithms in GCSE computer science'
+  activity.credit = 20
+  activity.slug = activity.title.parameterize
+  activity.course_id = 'a6b10502-6788-4ebc-b465-41eafb1e2a18'
+  activity.category = 'face-to-face'
+  activity.provider = 'stem-learning'
+end
+
+Activity.find_or_create_by(slug: 'data-and-computer-systems-in-gcse-computer-science') do |activity|
+  activity.title = 'Data and computer systems in GCSE computer science'
+  activity.credit = 20
+  activity.slug = activity.title.parameterize
+  activity.course_id = '7159562d-4b1a-44f3-b4d7-3e677b9898f2'
+  activity.category = 'face-to-face'
+  activity.provider = 'stem-learning'
+end
+
+Activity.find_or_create_by(slug: 'ncce-facilitator-development-program-stage-one') do |activity|
+  activity.title = 'NCCE facilitator development program (stage one)'
+  activity.credit = 0
+  activity.slug = activity.title.parameterize
+  activity.course_id = 'ec9bf026-49da-4542-abb9-2551f862d8d5'
+  activity.category = 'face-to-face'
+  activity.provider = 'stem-learning'
+end
+
+Activity.find_or_create_by(slug: 'ncce-train-the-trainer') do |activity|
+  activity.title = 'NCCE Train the Trainer'
+  activity.credit = 0
+  activity.slug = activity.title.parameterize
+  activity.course_id = '88715914-72ee-4b26-a22b-4f2d610ed267'
+  activity.category = 'face-to-face'
+  activity.provider = 'stem-learning'
+end
+
+Activity.find_or_create_by(slug: 'networks-and-cyber-security-in-gcse-computer-science') do |activity|
+  activity.title = 'Networks and Cyber Security in GCSE computer science'
+  activity.credit = 20
+  activity.slug = activity.title.parameterize
+  activity.course_id = '0650b45c-e4b3-4c8b-bd90-7a1428fe2986'
+  activity.category = 'face-to-face'
+  activity.provider = 'stem-learning'
+end
+
+Activity.find_or_create_by(slug: 'outstanding-teaching-of-key-stage-1-computing') do |activity|
+  activity.title = 'Outstanding teaching of key stage 1 computing'
+  activity.credit = 40
+  activity.slug = activity.title.parameterize
+  activity.course_id = '488bed9b-515b-4295-a488-62b5bb6bf852'
+  activity.category = 'face-to-face'
+  activity.provider = 'stem-learning'
+end
+
+Activity.find_or_create_by(slug: 'outstanding-teaching-of-key-stage-2-computing') do |activity|
+  activity.title = 'Outstanding teaching of key stage 2 computing'
+  activity.credit = 40
+  activity.slug = activity.title.parameterize
+  activity.course_id = '16aeecbd-d202-4f42-bad3-f86c8f671547'
+  activity.category = 'face-to-face'
+  activity.provider = 'stem-learning'
+end
+
+Activity.find_or_create_by(slug: 'primary-programming-and-algorithms') do |activity|
+  activity.title = 'Primary programming and algorithms'
+  activity.credit = 40
+  activity.slug = activity.title.parameterize
+  activity.course_id = '68f5b6c5-556d-4b66-8159-7cd6019da6f3'
+  activity.category = 'face-to-face'
+  activity.provider = 'stem-learning'
+end
+
+Activity.find_or_create_by(slug: 'python-programming-essentials-for-gcse-computer-science') do |activity|
+  activity.title = 'Python programming essentials for GCSE computer science'
+  activity.credit = 20
+  activity.slug = activity.title.parameterize
+  activity.course_id = '92f4f86e-0237-4ecc-a905-2f6c62d6b5ae'
+  activity.category = 'face-to-face'
+  activity.provider = 'stem-learning'
+end
+
+Activity.find_or_create_by(slug: 'cs-accelerator-assessment') do |activity|
+  activity.title = 'CS Accelerator Assessment'
+  activity.credit = 30
+  activity.slug = activity.title.parameterize
+  activity.category = 'assessment'
+  activity.provider = 'classmarker'
+end
+
+Activity.all.each do |a|
+  puts "Created activity #{a.title} (#{a})"
+end

--- a/db/seeds/programmes.rb
+++ b/db/seeds/programmes.rb
@@ -1,0 +1,45 @@
+cs_accelerator = Programme.find_or_create_by(slug: 'cs-accelerator') do |programme|
+  programme.title = 'GCSE computer science subject knowledge'
+  programme.slug = 'cs-accelerator'
+  programme.description = 'If you’re a secondary school teacher without a post A level qualification in computer science or a related subject then the Computer Science Accelerator Programme is specifically designed to help you.'
+end
+
+puts "Created Programme: #{cs_accelerator.title} (#{cs_accelerator})"
+
+activity = Activity.find_by(slug: 'cs-accelerator-assessment')
+
+assessment = Assessment.find_or_create_by(programme_id: cs_accelerator.id) do |assessment|
+  assessment.programme_id = cs_accelerator.id
+  assessment.activity_id = activity.id
+  assessment.link = 'https://www.classmarker.com/online-test/start/?quiz=7jq5caf0e6ab8da3'
+  assessment.class_marker_test_id = '1071279'
+end
+
+puts "Created assessment: #{assessment.activity.title} (#{assessment})"
+
+slugs = %w[
+  registered-with-the-national-centre
+  diagnostic-tool
+  algorithms-in-gcse-computer-science
+  data-and-computer-systems-in-gcse-computer-science
+  networks-and-cyber-security-in-gcse-computer-science
+  python-programming-essentials-for-gcse-computer-science
+  teaching-physical-computing-with-raspberry-pi-and-python
+  how-computers-work-demystifying-computation
+  programming-101-an-introduction-to-python-for-educators
+  programming-102-think-like-a-computer-scientist
+  representing-data-with-images-and-sound-bringing-data-to-life
+  object-oriented-programming-in-python-create-your-own-adventure-game
+  an-introduction-to-computer-networking-for-teachers
+  understanding-maths-and-logic-in-computer-science
+  understanding-computer-systems
+  cs-accelerator-assessment
+]
+
+slugs.each do |slug|
+  activity = Activity.find_by(slug: slug)
+  unless activity.programmes.include?(cs_accelerator)
+    puts "Adding: #{activity.title} to #{cs_accelerator.slug}"
+    activity.programmes << cs_accelerator
+  end
+end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-310.herokuapp.com/cs-accelerator
* Closes [436](https://github.com/NCCE/teachcomputing.org-issues/issues/436)
## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Add seed files for Activities and Programme (includes Assessment).
Make sure this is called in app.json so Review Apps will be pre-populuated.

If it works, the /cs-accelerator link should behave correctly and you should be able to enrol, then complete a couple of CS Acclerator achievements (self certify Python 101 & 102?)

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*