### PR TITLE
Add logging of requests and timing to the Achiever API calls.

### DIFF
--- a/app/lib/achiever.rb
+++ b/app/lib/achiever.rb
@@ -24,7 +24,7 @@ class Achiever
     request = build_request(params)
 
     result = Rails.cache.fetch("#{workflow_id}-#{Date.today}", expires_in: 6.hours) do
-      RestClient.get(request).body
+      make_request(request)
     end
 
     course_templates(parse_results(result))
@@ -37,7 +37,7 @@ class Achiever
     request = build_request(params)
 
     result = Rails.cache.fetch("#{workflow_id}-#{course.course_template_no}-#{Date.today}", expires_in: 6.hours) do
-      RestClient.get(request).body
+      make_request(request)
     end
 
     course.subject_details = CourseTemplateSubjectDetails.new(parse_results(result))
@@ -51,7 +51,7 @@ class Achiever
     request = build_request(params)
 
     result = Rails.cache.fetch("#{workflow_id}-#{course.course_template_no}-#{Date.today}", expires_in: 6.hours) do
-      RestClient.get(request).body
+      make_request(request)
     end
 
     course.age_range = CourseTemplateAgeRange.new(parse_results(result))
@@ -65,7 +65,7 @@ class Achiever
     request = build_request(params)
 
     result = Rails.cache.fetch("#{workflow_id}-#{Date.today}", expires_in: 6.hours) do
-      RestClient.get(request).body
+      make_request(request)
     end
 
     courses(parse_results(result))
@@ -78,7 +78,7 @@ class Achiever
     request = build_request(params)
 
     result = Rails.cache.fetch("#{workflow_id}-#{Date.today}", expires_in: 6.hours) do
-      RestClient.get(request).body
+      make_request(request)
     end
 
     courses(parse_results(result))
@@ -91,7 +91,7 @@ class Achiever
     request = build_request(params)
 
     result = Rails.cache.fetch("#{workflow_id}-#{id}-#{Date.today}", expires_in: 12.hours) do
-      RestClient.get(request).body
+      make_request(request)
     end
 
     parse_results(result)
@@ -103,11 +103,19 @@ class Achiever
     params = build_params(workflow_id, workflow_params)
     request = build_request(params)
 
-    result = RestClient.get(request).body
+    result = make_request(request)
     parse_results(result)
   end
 
   private
+
+  def make_request(request)
+    beginning_time = Time.now
+    response = RestClient.get(request)
+    end_time = Time.now
+    Rails.logger.debug "make_request time: #{(end_time - beginning_time)*1000} ms.  Request:\n#{request}\n\n"
+    response.body
+  end
 
   def build_request(params)
     @uri.query = URI.encode_www_form(sXmlParams: params)


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-315.herokuapp.com/courses
* Related to [429](https://github.com/NCCE/teachcomputing.org-issues/issues/429) & [430](https://github.com/NCCE/teachcomputing.org-issues/issues/430)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Because we are seeing issues in production with timing, it might be useful to
keep an eye on this.
Currently production & staging config is set to use :debug level for logging -
in future we may want to raise this unless we need to look at a problem?

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*