### PR TITLE
Increase cache expiration for f2f and online courses

### DIFF
--- a/app/lib/achiever.rb
+++ b/app/lib/achiever.rb
@@ -64,7 +64,7 @@ class Achiever
     params = build_params(workflow_id, workflow_params)
     request = build_request(params)
 
-    result = Rails.cache.fetch("#{workflow_id}-#{Date.today}", expires_in: 12.hours) do
+    result = Rails.cache.fetch("#{workflow_id}-#{Date.today}", expires_in: 24.hours) do
       make_request(request)
     end
 
@@ -77,7 +77,7 @@ class Achiever
     params = build_params(workflow_id, workflow_params)
     request = build_request(params)
 
-    result = Rails.cache.fetch("#{workflow_id}-#{Date.today}", expires_in: 12.hours) do
+    result = Rails.cache.fetch("#{workflow_id}-#{Date.today}", expires_in: 24.hours) do
       make_request(request)
     end
 


### PR DESCRIPTION
## Status

* Current Status: Ready
* Related https://github.com/NCCE/teachcomputing.org-issues/issues/439

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Increase the cache for getting f2f and online courses. This means the cache wont expire at the same time as the course template calls, hopefully speeding up the load times. 