### PR TITLE
wrap bulk of fetch_course_list around some caching

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -34,13 +34,15 @@ class CoursesController < ApplicationController
   def fetch_course_list
     courses = @achiever.approved_course_templates
     @course_occurrences = @achiever.future_face_to_face_courses + @achiever.future_online_courses
-
-    courses.each do |course|
-      @achiever.course_template_subject_details(course)
-      @achiever.course_template_age_range(course)
-      @course_occurrences.each do |course_occurrence|
-        if course_occurrence.course_template_no == course.course_template_no
-          course.occurrences.push(course_occurrence)
+    
+    Rails.cache.fetch("fetch_course_list-#{Date.today}", expires_in: 3.hours) do
+      courses.each do |course|
+        @achiever.course_template_subject_details(course)
+        @achiever.course_template_age_range(course)
+        @course_occurrences.each do |course_occurrence|
+          if course_occurrence.course_template_no == course.course_template_no
+            course.occurrences.push(course_occurrence)
+          end
         end
       end
     end


### PR DESCRIPTION
## Status

* Current Status: Ready
* Related to https://github.com/NCCE/teachcomputing.org-issues/issues/439

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Continued looking into datadog I can see that the `index` action is where the bulk of the waiting time for users is. Even though we do cache our API responses from Achiever I think we would benefit the filtering we do for each course as this is time-consuming. Iv set it to expire every 3 hours so we dont see any issues with new courses not appearing. 