### PR TITLE
415: Tidy up focus outlines for buttons and form-fields.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,7 @@
 @import 'components/_feedback.scss';
 @import 'components/_flash.scss';
 @import 'components/_button.scss';
+@import 'components/_form-fields.scss';
 @import 'components/_aside.scss';
 @import 'components/pages/home/_hero.scss';
 @import 'components/pages/home/_jobs.scss';

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -8,14 +8,12 @@
 
   &:hover {
     background-color: $ncce-black;
-    box-shadow: 0 4px 0 $ncce-black;
-    outline-color: $ncce-black;
   }
 
   &:focus {
-    background-color: $ncce-black !important;
-    color: $ncce-white !important;
-    outline-color: $ncce-black !important;
+    background-color: $ncce-black;
+    color: $ncce-white;
+    outline-color: $ncce-black;
   }
 
   @include govuk-media-query($from: desktop) {
@@ -31,15 +29,13 @@
   width: calc(100% - 2rem);
 
   @include govuk-media-query($from: tablet) {
-    margin-left: 0;
+    margin: 0;
     width: auto;
-    margin-bottom: 0;
   }
 
-  &:hover,
   &:focus {
-    box-shadow: 0 4px 0 $ncce-dark-pink;
-    outline-color: $ncce-white !important;
+    box-shadow: 0 0 0 2px $ncce-black;
+    outline-color: rgba(255, 255, 255, 0);
   }
 
 }

--- a/app/assets/stylesheets/components/_form-fields.scss
+++ b/app/assets/stylesheets/components/_form-fields.scss
@@ -1,0 +1,39 @@
+.govuk-input:focus,
+.govuk-radios__input:focus,
+.govuk-textarea:focus {
+  outline-color: $ncce-pink;
+}
+
+.govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  box-shadow: 0 0 0 3px $ncce-pink;
+}
+
+.govuk-select:focus {
+  box-shadow: 0 0 0 2px $ncce-pink;
+  outline-color: $ncce-white;
+  outline-offset: 2px;
+}
+
+.ncce-select {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: image-url('chevron.svg');
+  background-position: calc(100% - 10px) 50%;
+  background-repeat: no-repeat;
+  border-radius: 5px;
+  font-size: 1rem;
+  height: 2.5rem;
+  margin-right: 20px;
+  padding-right: 30px;
+  @include govuk-media-query($until: 900px) {
+    margin: 0 20px 20px 0;
+  }
+  @include govuk-media-query($until: tablet) {
+    margin: 0 0 20px;
+    width: 100%;
+  }
+  &:focus {
+    outline-color: rgba(255, 255, 255, 0);
+  }
+}

--- a/app/assets/stylesheets/components/dashboard/_activity-list.scss
+++ b/app/assets/stylesheets/components/dashboard/_activity-list.scss
@@ -232,10 +232,7 @@
 }
 
 .ncce-activity-form__select {
-  border-radius: 6px;
-  font-size: 1rem;
   margin-bottom: 1rem;
-  height: 2.5rem;
 }
 
 .ncce-activity-form__button--pink {

--- a/app/assets/stylesheets/components/pages/_courses.scss
+++ b/app/assets/stylesheets/components/pages/_courses.scss
@@ -182,26 +182,7 @@
       display: none;
     }
   }
-  &-select {
-    appearance: none;
-    -moz-appearance: none;
-    -webkit-appearance: none;
-    border-radius: 5px;
-    background-image: image-url('chevron.svg');
-    background-position: calc(100% - 10px) 50%;
-    background-repeat: no-repeat;
-    height: 2.5rem;
-    margin-right: 20px;
-    padding-right: 30px;
-    font-size: 1rem;
-    @include govuk-media-query($until: 900px) {
-      margin: 0 20px 20px 0;
-    }
-    @include govuk-media-query($until: tablet) {
-      width: 100%;
-      margin: 0 0 20px;
-    }
-  }
+
   &-button {
     margin-bottom: 0;
     padding: 9px 15px 6px;

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -51,21 +51,21 @@
               options_for_select(@levels, @current_level),
               {
                 include_blank: 'Any level',
-                class: 'govuk-select ncce-courses__filter-select js-course-filter-select',
+                class: 'govuk-select ncce-select js-course-filter-select',
                 'aria-label': 'Filter by level' }
             %>
             <%= select_tag :location,
               options_for_select(@locations, @current_location),
               {
                 include_blank: 'Any location',
-                class: 'govuk-select ncce-courses__filter-select js-course-filter-select',
+                class: 'govuk-select ncce-select js-course-filter-select',
                 'aria-label': 'Filter by location' }
             %>
             <%= select_tag :topic,
               options_for_select(@topics, @current_topic),
               {
                 include_blank: 'Any topic',
-                class: 'govuk-select ncce-courses__filter-select js-course-filter-select',
+                class: 'govuk-select ncce-select js-course-filter-select',
                 'aria-label': 'Filter by topic' }
             %>
             <%= hidden_field_tag :workstream, @current_workstream %>

--- a/app/views/dashboard/_activity.html.erb
+++ b/app/views/dashboard/_activity.html.erb
@@ -43,7 +43,7 @@
               <%= f.select :activity_id,
                 options_for_select(Activity.user_removable.available_for(current_user).collect { |activity| [ activity.title, activity.id ] }),
                 { include_blank: 'Select an activity' },
-                { class: 'govuk-select ncce-activity-form__select',
+                { class: 'govuk-select ncce-select ncce-activity-form__select',
                   'aria-label': 'Select an activity' }
               %>
               <%= f.submit 'Add course', class: 'govuk-button ncce-button__pink ncce-activity-form__button--pink' %>

--- a/spec/views/courses/index.html_spec.rb
+++ b/spec/views/courses/index.html_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe('courses/index', type: :view) do
     end
 
     it 'renders filter selects' do
-      expect(rendered).to have_css('.ncce-courses__filter-select', count: 3)
+      expect(rendered).to have_css('.ncce-select', count: 3)
     end
 
     it 'renders hidden workstream field' do
@@ -82,15 +82,15 @@ RSpec.describe('courses/index', type: :view) do
     end
 
     it 'renders location select' do
-      expect(rendered).to have_css('.ncce-courses__filter-select option', text: 'Cambridge')
+      expect(rendered).to have_css('.ncce-select option', text: 'Cambridge')
     end
 
     it 'renders level select' do
-      expect(rendered).to have_css('.ncce-courses__filter-select option', text: 'Key stage 2')
+      expect(rendered).to have_css('.ncce-select option', text: 'Key stage 2')
     end
 
     it 'renders topic select' do
-      expect(rendered).to have_css('.ncce-courses__filter-select option', text: 'Algorithms')
+      expect(rendered).to have_css('.ncce-select option', text: 'Algorithms')
     end
 
     it 'renders filter submit' do


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [415](https://github.com/NCCE/teachcomputing.org-issues/issues/415)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Don't have an outline on :hover for buttons (same as GDS).
Use box-shadow for outline on :focus for rounded buttons.
Add overrides for form fields outline colour.
Combine select styling into common class for NCCE and fix views / tests.

## Steps to perform after deploying to production