### PR TITLE
493: Show current filter params in flash message #a11y

### DIFF
--- a/app/assets/stylesheets/components/_flash.scss
+++ b/app/assets/stylesheets/components/_flash.scss
@@ -16,5 +16,9 @@
 
   &__error {
 		background-color: $ncce-pink-flash;
-	}
+  }
+
+  a {
+    margin-left: 1rem;
+  }
 }

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -7,12 +7,15 @@ class CoursesController < ApplicationController
 
   def index
     @courses = fetch_course_list
+    total_courses = @courses.length
 
     @locations = course_locations(@course_occurrences)
     @levels = course_levels(@courses)
     @topics = course_tags(@courses)
     @workstreams = course_workstreams(@courses)
     @courses = filter_courses(@courses)
+
+    alert_filter_params(total_courses, @courses.length)
 
     render :index
   end
@@ -72,6 +75,21 @@ class CoursesController < ApplicationController
       end
       has_level && has_location && has_topic && has_workstream
     end
+  end
+
+  def alert_filter_params(total_count, filtered_count)
+    filter_strings = []
+    filter_strings.push("level = #{@current_level}") if @current_level
+    filter_strings.push("topic = #{@current_topic}") if @current_topic
+    filter_strings.push("location = #{@current_location}") if @current_location
+    filter_strings.push("programme = #{@current_workstream}") if @current_workstream
+
+    return unless filter_strings.length.positive?
+
+    notice = "You are filtering with #{filter_strings.join(', ')}."
+    notice += " Showing #{filtered_count} courses from a total of #{total_count}"
+    notice += " #{view_context.link_to('Remove filter', courses_path)}"
+    flash.now[:notice] = notice
   end
 
   def compare_location(course, location)

--- a/app/views/programmes/_face_to_face_activity.html.erb
+++ b/app/views/programmes/_face_to_face_activity.html.erb
@@ -25,7 +25,7 @@
   <li class="ncce-activity-list__item ncce-activity-list__item--incomplete">
     <span class="ncce-activity-list__item-text"> Complete your first face
       to face course </span>
-    <%= link_to 'Find a face to face course', courses_path(location: 'Face to face'), class: 'govuk-button ncce-button__pink ncce-button__pink--rounded' %>
+    <%= link_to 'Find a face to face course', courses_path(location: 'Face to face', workstream: 'CS Accelerator'), class: 'govuk-button ncce-button__pink ncce-button__pink--rounded' %>
   </li>
 <% end %>
 
@@ -56,6 +56,6 @@
   <li class="ncce-activity-list__item ncce-activity-list__item--incomplete">
     <span class="ncce-activity-list__item-text"> Complete your second face
     to face course </span>
-    <%= link_to 'Find a face to face course', courses_path(location: 'Face to face'), class: 'govuk-button ncce-button__pink ncce-button__pink--rounded' %>
+    <%= link_to 'Find a face to face course', courses_path(location: 'Face to face', workstream: 'CS Accelerator'), class: 'govuk-button ncce-button__pink ncce-button__pink--rounded' %>
   </li>
 <% end %>

--- a/app/views/programmes/_online_activity.html.erb
+++ b/app/views/programmes/_online_activity.html.erb
@@ -24,7 +24,7 @@
 <% else%>
   <li class="ncce-activity-list__item ncce-activity-list__item--incomplete">
     <span class="ncce-activity-list__item-text"> Complete your first online course </span>
-    <%= link_to 'Find an online course', courses_path(location: 'Online'), class: 'govuk-button ncce-button__pink ncce-button__pink--rounded' %>
+    <%= link_to 'Find an online course', courses_path(location: 'Online', workstream: 'CS Accelerator'), class: 'govuk-button ncce-button__pink ncce-button__pink--rounded' %>
   </li>
 <% end %>
 
@@ -54,6 +54,6 @@
 <% else %>
   <li class="ncce-activity-list__item ncce-activity-list__item--incomplete">
     <span class="ncce-activity-list__item-text"> Complete your second online course </span>
-    <%= link_to 'Find an online course', courses_path(location: 'Online'), class: 'govuk-button ncce-button__pink ncce-button__pink--rounded' %>
+    <%= link_to 'Find an online course', courses_path(location: 'Online', workstream: 'CS Accelerator'), class: 'govuk-button ncce-button__pink ncce-button__pink--rounded' %>
   </li>
 <% end %>

--- a/spec/requests/courses/index_spec.rb
+++ b/spec/requests/courses/index_spec.rb
@@ -85,6 +85,10 @@ RSpec.describe CoursesController do
       it 'renders the correct template' do
         expect(response).to render_template('index')
       end
+
+      it 'doesn\'t show a flash notice' do
+        expect(flash[:notice]).to_not be_present
+      end
     end
 
     context 'when using filtering' do
@@ -105,6 +109,18 @@ RSpec.describe CoursesController do
 
         it 'initalises current topic' do
           expect(assigns(:current_topic)).to eq('Mathematics')
+        end
+
+        it 'shows a flash notice' do
+          expect(flash[:notice]).to be_present
+        end
+
+        it 'flash notice has correct info' do
+          expect(flash[:notice]).to match(/topic = Mathematics/)
+        end
+
+        it 'flash notice has a link to remove filtering' do
+          expect(flash[:notice]).to match(/<a href="#{courses_path}">Remove filter<\/a>/)
         end
       end
 
@@ -132,6 +148,14 @@ RSpec.describe CoursesController do
 
         it 'initalises current location' do
           expect(assigns(:current_location)).to eq('York')
+        end
+
+        it 'shows a flash notice' do
+          expect(flash[:notice]).to be_present
+        end
+
+        it 'flash notice has correct info' do
+          expect(flash[:notice]).to match(/location = York/)
         end
       end
 
@@ -161,6 +185,14 @@ RSpec.describe CoursesController do
         it 'initalises current location' do
           expect(assigns(:current_location)).to eq('Online')
         end
+
+        it 'shows a flash notice' do
+          expect(flash[:notice]).to be_present
+        end
+
+        it 'flash notice has correct info' do
+          expect(flash[:notice]).to match(/location = Online/)
+        end
       end
 
       context 'when filtering by Face to face location' do
@@ -189,6 +221,14 @@ RSpec.describe CoursesController do
         it 'initalises current location' do
           expect(assigns(:current_location)).to eq('Face to face')
         end
+
+        it 'shows a flash notice' do
+          expect(flash[:notice]).to be_present
+        end
+
+        it 'flash notice has correct info' do
+          expect(flash[:notice]).to match(/location = Face to face/)
+        end
       end
 
       context 'when filtering by level' do
@@ -208,6 +248,14 @@ RSpec.describe CoursesController do
 
         it 'initalises current level' do
           expect(assigns(:current_level)).to eq('Key stage 4')
+        end
+
+        it 'shows a flash notice' do
+          expect(flash[:notice]).to be_present
+        end
+
+        it 'flash notice has correct info' do
+          expect(flash[:notice]).to match(/level = Key stage 4/)
         end
       end
 
@@ -229,6 +277,14 @@ RSpec.describe CoursesController do
         it 'initalises current level' do
           expect(assigns(:current_workstream)).to eq('National Centre - Non-Core')
         end
+
+        it 'shows a flash notice' do
+          expect(flash[:notice]).to be_present
+        end
+
+        it 'flash notice has correct info' do
+          expect(flash[:notice]).to match(/programme = National Centre - Non-Core/)
+        end
       end
 
       context 'when filtering by level and location' do
@@ -249,6 +305,14 @@ RSpec.describe CoursesController do
           expect(course.occurrences.map(&:address_town)).to include('York')
         end
 
+        it 'shows a flash notice' do
+          expect(flash[:notice]).to be_present
+        end
+
+        it 'flash notice has correct info' do
+          expect(flash[:notice]).to match(/location = York/)
+          expect(flash[:notice]).to match(/level = Key stage 4/)
+        end
       end
 
       context 'when filtering by level and topic' do
@@ -270,6 +334,15 @@ RSpec.describe CoursesController do
           assigns(:courses).each do |course|
             expect(course.key_stages).to eq(['Key stage 3', 'Key stage 2'])
           end
+        end
+
+        it 'shows a flash notice' do
+          expect(flash[:notice]).to be_present
+        end
+
+        it 'flash notice has correct info' do
+          expect(flash[:notice]).to match(/topic = Mathematics/)
+          expect(flash[:notice]).to match(/level = Key stage 2/)
         end
       end
 
@@ -306,6 +379,16 @@ RSpec.describe CoursesController do
         it 'doesn\'t exclude other occurrence locations' do
           course = assigns(:courses).first
           expect(course.occurrences.map(&:address_town)).to include('Cambridge')
+        end
+
+        it 'shows a flash notice' do
+          expect(flash[:notice]).to be_present
+        end
+
+        it 'flash notice has correct info' do
+          expect(flash[:notice]).to match(/topic = Mathematics/)
+          expect(flash[:notice]).to match(/location = York/)
+          expect(flash[:notice]).to match(/level = Key stage 2/)
         end
       end
 
@@ -350,6 +433,17 @@ RSpec.describe CoursesController do
             expect(course.workstream).to eq('National Centre - Core')
           end
         end
+
+        it 'shows a flash notice' do
+          expect(flash[:notice]).to be_present
+        end
+
+        it 'flash notice has correct info' do
+          expect(flash[:notice]).to match(/topic = Mathematics/)
+          expect(flash[:notice]).to match(/location = York/)
+          expect(flash[:notice]).to match(/level = Key stage 2/)
+          expect(flash[:notice]).to match(/programme = National Centre - Core/)
+        end
       end
 
       context 'filter by level, location, topic and alternate workstream' do
@@ -364,6 +458,17 @@ RSpec.describe CoursesController do
 
         it 'has correct number of courses' do
           expect(assigns(:courses).length).to be(0)
+        end
+
+        it 'shows a flash notice' do
+          expect(flash[:notice]).to be_present
+        end
+
+        it 'flash notice has correct info' do
+          expect(flash[:notice]).to match(/topic = Mathematics/)
+          expect(flash[:notice]).to match(/location = York/)
+          expect(flash[:notice]).to match(/level = Key stage 2/)
+          expect(flash[:notice]).to match(/programme = National Centre - Non-Core/)
         end
       end
     end

--- a/spec/views/programmes/_face_to_face_activity.html_spec.rb
+++ b/spec/views/programmes/_face_to_face_activity.html_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe('programmes/_face_to_face_activity', type: :view) do
     end
 
     it 'links to face to face courses' do
-      expect(rendered).to have_link('Find a face to face course', href: '/courses?location=Face+to+face')
+      expect(rendered).to have_link('Find a face to face course', href: '/courses?location=Face+to+face&workstream=CS+Accelerator')
     end
 
     it 'has prompt text' do

--- a/spec/views/programmes/_online_activity.html_spec.rb
+++ b/spec/views/programmes/_online_activity.html_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe('programmes/_online_activity', type: :view) do
     end
 
     it 'links to online courses' do
-      expect(rendered).to have_link('Find an online course', href: '/courses?location=Online')
+      expect(rendered).to have_link('Find an online course', href: '/courses?location=Online&workstream=CS+Accelerator')
     end
 
     it 'has prompt text' do


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-337.herokuapp.com/courses?location=Online
* Closes [493](https://github.com/NCCE/teachcomputing.org-issues/issues/493)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

The screen-reader will read the flash message when the page is loaded.
Also helps other users with a clear indication of what they are filtering.
May eventually be superceded by rework on filtering page, but for now, this
should suffice.
Also fix issue with CS Accelerator 'Find course' links - make sure they are
only looking for CS Accelerator courses!
Add & fix tests.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*