### PR TITLE
Fix issue where layout wasn't specified for the 'View Certificate' page.

### DIFF
--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -18,8 +18,10 @@ class ProgrammesController < ApplicationController
   end
 
   def certificate
+    return redirect_to programme_path(@programme.slug) unless @programme.passed_programme_assessment?(current_user)
+
     get_certificate_details
-    redirect_to programme_path(@programme.slug) unless @programme.passed_programme_assessment?(current_user)
+    render layout: 'certificate'
   end
 
   private
@@ -44,7 +46,7 @@ class ProgrammesController < ApplicationController
       @num_attempts = attempts.count
       @can_take_test_at = 0
       @currently_taking_test = false
-      
+
       if @num_attempts.positive?
         last_attempt = attempts.last
         if last_attempt.current_state == StateMachines::AssessmentAttemptStateMachine::STATE_FAILED.to_s && @num_attempts >= 2


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-353.herokuapp.com/certificate/cs-accelerator/view-certificate

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

The certificate page shouldn't have a header & footer, so has a different layout.  Think this dropped off in some recent changes.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*