### PR TITLE
552: Show the Teacher Reference Number on the user's certificate for CSA

### DIFF
--- a/app/views/programmes/cs-accelerator/certificate.html.erb
+++ b/app/views/programmes/cs-accelerator/certificate.html.erb
@@ -32,6 +32,9 @@
         <ul class="govuk-list">
           <li>Date awarded: <strong><%= @transition.created_at.strftime('%d/%m/%Y') %></strong></li>
           <li>Certificate: <strong><%= certificate_number(@transition.metadata['certificate_number'], @transition.created_at) %></strong></li>
+          <% if current_user.teacher_reference_number %>
+            <li>Teacher Reference Number: <strong><%= current_user.teacher_reference_number %></strong></li>
+          <% end %>
         </ul>
       </div>
     </div>

--- a/spec/views/programmes/cs-accelerator/certificate.html_spec.rb
+++ b/spec/views/programmes/cs-accelerator/certificate.html_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe('programmes/cs-accelerator/certificate', type: :view) do
 
   before do
     # assessment
+    user.update(teacher_reference_number: 'TRNTEST')
     allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
     @programme = programme
     achievement.set_to_complete(certificate_number: 0)
@@ -19,7 +20,11 @@ RSpec.describe('programmes/cs-accelerator/certificate', type: :view) do
     expect(rendered).to have_css('h1', text: programme.title)
   end
 
-  it 'has the passed date correctly' do
+  it 'shows the passed date correctly' do
     expect(rendered).to have_css('.govuk-list li strong', text: '03/02/2001')
+  end
+
+  it 'shows the TRN correctly' do
+    expect(rendered).to have_css('.govuk-list li strong', text: user.teacher_reference_number)
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [552](https://github.com/NCCE/teachcomputing.org-issues/issues/552) 

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Add TRN to certificate

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*