### PR TITLE
551: Add note about clicking button == 1 x attempt to CSA exam 'rules'

### DIFF
--- a/app/views/programmes/cs-accelerator/_exam_activity.html.erb
+++ b/app/views/programmes/cs-accelerator/_exam_activity.html.erb
@@ -16,6 +16,7 @@
       <li>You must finish in one sitting</li>
       <li>You can go back and change your answers</li>
       <li>You can skip a question</li>
+      <li>Please be advised, clicking "Take the final test" will start an attempt</li>
     </ul>
   </li>
   <li class="govuk-body-s ncce-activity-list__item ncce-activity-list__item--position ncce-exam-activity__attempts">

--- a/spec/views/programmes/cs-accelerator/_exam_activity.html_spec.rb
+++ b/spec/views/programmes/cs-accelerator/_exam_activity.html_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe('programmes/cs-accelerator/_exam_activity', type: :view) do
     end
 
     it 'shows the exam activity points' do
-      expect(rendered).to have_css('ul>li', count: 6)
+      expect(rendered).to have_css('ul>li', count: 7)
     end
 
     it 'shows the certificate graphic' do


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-375.herokuapp.com/
* Closes [551](https://github.com/NCCE/teachcomputing.org-issues/issues/551)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Add a rule bullet explaining that when the user clicks the button, this is counted as an attempt.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*