### PR TITLE
Restrict times we can run hourly tasks for completed_course checking.

### DIFF
--- a/lib/tasks/schedule_completed_course_jobs.rake
+++ b/lib/tasks/schedule_completed_course_jobs.rake
@@ -14,8 +14,8 @@ namespace :completed_course_jobs do
   def can_run_now?
     now = Time.zone.now
     weekday_working_hours = (now.wday >= 1 && now.wday <= 5 && now.hour >= 8 && now.hour <= 17)
-    weekend_midnight = (now.wday.zero? || now.wday == 6) && now.hour == 8
-    cli_override = ENV['override_time'].present?
-    weekday_working_hours || weekend_midnight || cli_override
+    weekend_morning = (now.wday.zero? || now.wday == 6) && now.hour == 8
+    force_job_run = ENV['force_job_run'].present?
+    weekday_working_hours || weekend_midnight || force_job_run
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [556](https://github.com/NCCE/teachcomputing.org-issues/issues/556)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Restrict the scheduling of the FetchUsersCompletedCoursesFromAchieverJob to hourly weekdays 8-5 or once a day at weekends.  Allowing an override if we pass arg from command line.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*