### PR TITLE
555: Add a rake task to retrieve course information from achiever.

### DIFF
--- a/lib/tasks/refresh_achiever_cache.rake
+++ b/lib/tasks/refresh_achiever_cache.rake
@@ -1,0 +1,20 @@
+require(Rails.root.join('app', 'lib', 'achiever.rb'))
+
+namespace :achiever do
+  task get_course_info: :environment do
+    beginning_time = Time.zone.now
+    achiever = Achiever.new
+    courses = achiever.approved_course_templates
+    face_2_face_courses = achiever.future_face_to_face_courses
+    online_courses = achiever.future_online_courses
+
+    courses.each do |course|
+      achiever.course_template_subject_details(course)
+      achiever.course_template_age_range(course)
+    end
+
+    end_time = Time.zone.now
+    puts "Achiever currently has #{courses.count} courses with #{face_2_face_courses.count} F2F & #{online_courses.count} online occurrences"
+    puts "Time: #{(end_time - beginning_time)} s."
+  end
+end


### PR DESCRIPTION
## Status

* Current Status: WIP
* Review App: *populate this once the PR has been created*
* Closes [555](https://github.com/NCCE/teachcomputing.org-issues/issues/555)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Add a rake task to go and get all the course templates, occurrences & tags from achiever - so we can hopefully use an automated system to update the cached courses and avoid the timeouts for users.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*