### PR TITLE
564: Add hubs link to footer

### DIFF
--- a/app/views/components/_footer.html.erb
+++ b/app/views/components/_footer.html.erb
@@ -18,6 +18,9 @@
             <%= link_to 'Bursaries', bursary_path, class: 'govuk-footer__link ncce-link ncce-link--on-dark' %>
           </li>
           <li class="govuk-footer__list-item">
+            <%= link_to 'Computing Hubs', hubs_path, class: 'govuk-footer__link ncce-link ncce-link--on-dark' %>
+          </li>
+          <li class="govuk-footer__list-item">
             <%= link_to 'News', news_path, class: 'govuk-footer__link ncce-link ncce-link--on-dark' %>
           </li>
           <li class="govuk-footer__list-item">


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-381.herokuapp.com/
* Closes [564](https://github.com/NCCE/teachcomputing.org-issues/issues/564)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Add 'Computing Hubs' link to footer.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*