### PR TITLE
557: Add basic primary page

### DIFF
--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -19,6 +19,10 @@ class Programme < ApplicationRecord
     Programme.find_by(slug: 'cs-accelerator')
   end
 
+  def self.primary
+    Programme.find_by(slug: 'primary')
+  end
+
   def user_completed?(user = nil)
     if slug == 'cs-accelerator'
       return user.achievements

--- a/app/views/pages/primary.html.erb
+++ b/app/views/pages/primary.html.erb
@@ -1,0 +1,50 @@
+<%= render 'pages/certification/hero' %>
+<div class="govuk-width-container">
+  <div class="govuk-main-wrapper govuk-main-wrapper--xl">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-m">Welcome to the Primary Computing Programme</h1>
+          <p class="govuk-body">The Primary Computing Programme is a professional development programme... </p>
+          <%= render 'pages/certification/pathway'%>
+          <p class="govuk-body">The programme is suitable for those already teaching or planning to teach primary computer science and will help teachers to fill potential gaps in their knowledge. Generous financial support is available for schools, including bursaries to help cover the costs associated with CPD participation. </p>
+          <h2 class="govuk-heading-s">Benefits for you:</h2>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>update your skills and be recognised for your subject knowledge</li>
+            <li>feel more confident to teach this high demand subject across the curriculum</li>
+            <li>choose from face-to-face and online modules to suit your learning needs</li>
+            <li>save time on lesson planning and gain inspirational teaching ideas </li>
+            <li>call on a team of champions on hand to support you throughout the programme</li>
+          </ul>
+          <p class="govuk-body"><strong>We hope you find the programme supportive and that it helps to give you the confidence to teach computer science across the curriculum. </strong></p>
+        </div>
+        <div class="govuk-grid-column-one-third">
+          <aside class="ncce-aside">
+            <% if current_user %>
+              <h2 class="govuk-heading-m ncce-aside__title">Enrol</h2>
+            <% else%>
+              <h2 class="govuk-heading-m ncce-aside__title">How to enrol</h2>
+            <% end %>
+            <P class="govuk-body-s ncce-aside__text">Begin your journey towards being a fully qualified priamry computer science teacher!</p>
+            <ol class="govuk-list govuk-list--number ncce-aside__text govuk-body-s cs-accelerator-aside__list">
+              <li>
+                 <%= image_tag("/images/favicon.png", size: '', alt: 'Completed icon', class: 'ncce-aside__check-mark') if current_user %>
+                Create your account with STEM Learning, and log in
+              </li>
+              <li>Enrol with the click of the button</li>
+              <li>Use your personal dashboard to track your progress towards certification</li>
+              <li>Find and book onto courses until you have enough credits to take the final test</li>
+              <li>Pass the test and receive your qualification</li>
+            </ol>
+            <% if current_user %>
+              <p class="govuk-body"><%= link_to 'Enrol on this certificate', user_programme_enrolment_path(slug: Programme.primary.slug, :user_programme_enrolment => { user_id: current_user.id, programme_id: Programme.primary.id }), method: :post, class: 'govuk-button ncce-button__pink ncce-aside__button', role: 'button', draggable: 'false' %></p>
+            <% else %>
+              <p class="govuk-body"><%= link_to 'Create an account', signup_stem_path, class: 'govuk-button ncce-button__pink ncce-aside__button', role: 'button', draggable: 'false' %></p>
+              <p class="govuk-body-s ncce-aside__text">Already have a STEM Learning account? Simply <%= link_to 'Log in', login_url, class: 'ncce-link ncce-link--on-dark', role: 'button', draggable: 'false' %></p>
+            <% end %>
+          </aside>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,9 @@ Rails.application.routes.draw do
 
   get '/about', to: 'pages#page', as: :about, defaults: { page_slug: 'about' }
   get '/cs-accelerator', to: 'pages#static_programme_page', as: :cs_accelerator, defaults: { page_slug: 'cs-accelerator' }
+  get '/primary', to: 'pages#static_programme_page', as: :primary, defaults: { page_slug: 'primary' },
+                  constraints: ->(_request) { Programme.primary.enrollable? }
+
   get '/accelerator', to: redirect('/cs-accelerator')
   get '/bursary', to: 'pages#page', as: :bursary, defaults: { page_slug: 'bursary' }
   get '/certification', to: 'pages#page', as: :certification, defaults: { page_slug: 'certification' }

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Programme, type: :model do
   let(:programme) { create(:programme, slug: 'cs-accelerator') }
   let(:programmes) { create_list(:programme, 3) }
+  let(:primary_programme) { create(:programme, slug: 'primary') }
   let(:non_enrollable_programme) { create(:programme, enrollable: false ) }
   let(:user) { create(:user) }
   let(:user_programme_enrolment) { create(:user_programme_enrolment, user_id: user.id, programme_id: programme.id) }
@@ -61,6 +62,16 @@ RSpec.describe Programme, type: :model do
 
     it 'returns the cs-accelerator record' do
       expect(Programme.cs_accelerator).to eq programme
+    end
+  end
+
+  describe '#primary' do
+    before do
+      primary_programme
+    end
+
+    it 'returns the primary record' do
+      expect(Programme.primary).to eq primary_programme
     end
   end
 

--- a/spec/requests/programmes/show_spec.rb
+++ b/spec/requests/programmes/show_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe ProgrammesController do
   let(:user) { create(:user) }
   let(:programme) { create(:programme, slug: 'cs-accelerator') }
+  let(:non_enrollable_programme) { create(:programme, slug: 'non-enrollable', enrollable: false) }
+
   let(:assessment) { create(:assessment, programme_id: programme.id) }
   let(:user_programme_enrolment) do
     create(:user_programme_enrolment,
@@ -92,6 +94,13 @@ RSpec.describe ProgrammesController do
       it 'redirects if not enrolled' do
         get programme_path('cs-accelerator')
         expect(response).to redirect_to(cs_accelerator_path)
+      end
+
+      it 'handles non-enrollable programme' do
+        non_enrollable_programme
+        expect do
+          get programme_path('non-enrollable')
+        end.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       describe 'and enrolled' do

--- a/spec/views/pages/primary.html_spec.rb
+++ b/spec/views/pages/primary.html_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe('pages/primary', type: :view) do
+  let(:user) { create(:user) }
+  let(:programme) { create(:programme, slug: 'primary') }
+
+  before do
+    render
+  end
+
+  it 'has a heading' do
+    expect(rendered).to have_css('.govuk-heading-m', text: 'Welcome to the Primary Computing Programme')
+  end
+
+  it 'has diagram' do
+    expect(rendered).to have_css('.pathway-wrapper', count: 1)
+  end
+
+  it 'has aside section' do
+    expect(rendered).to have_css('.ncce-aside', count: 1)
+  end
+
+  context 'when a user is signed in' do
+    before do
+      programme
+      allow(view).to receive(:current_user).and_return(user)
+      render
+    end
+
+    it 'has Enrol title' do
+      expect(rendered).to have_css('.ncce-aside__title', text: 'Enrol')
+    end
+
+    it 'has Enrol button' do
+      expect(rendered).to have_css('.ncce-aside__button', text: 'Enrol on this certificate')
+    end
+
+    it 'shows the create account step as complete' do
+      expect(rendered).to have_css('.ncce-aside__check-mark', count: 1)
+    end
+  end
+
+  context 'when there is not signed in user' do
+    before do
+      allow(view).to receive(:current_user).and_return(nil)
+      render
+    end
+
+    it 'has How to enrol title' do
+      expect(rendered).to have_css('.ncce-aside__title', text: 'How to enrol')
+    end
+
+    it 'has Account button' do
+      expect(rendered).to have_css('.ncce-aside__button', text: 'Create an account')
+    end
+
+    it 'has a Log in link' do
+      expect(rendered).to have_css('.ncce-link', text: 'Log in')
+    end
+
+    it 'doesn\'t show the create account step as complete' do
+      expect(rendered).to have_css('.ncce-aside__check-mark', count: 0)
+    end
+  end
+end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-382.herokuapp.com/primary
* Closes [557](https://github.com/NCCE/teachcomputing.org-issues/issues/557)
## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Add primary intro page using same text / layout as CSA page.
Add helper method to model for finding it.
Update / add specs.
Add route.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*