### PR TITLE
Try to improve behaviour of background-image scaling

### DIFF
--- a/app/assets/stylesheets/components/pages/home/_hero.scss
+++ b/app/assets/stylesheets/components/pages/home/_hero.scss
@@ -69,14 +69,14 @@
 
   @include govuk-media-query($from: 1024px) {
     background-image: url('/images/home/splash-pink.svg');
-    background-position: 187px 0;
+    background-position: 11.5rem 0.15rem;
 
     @-moz-document url-prefix() {
-      background-position: 194px 0;
+      background-position: 12rem 0.15rem;
     }
 
     background-repeat: no-repeat;
-    background-size: 120px;
+    background-size: 7.5rem;
     border: 9px solid $ncce-black;
     font-size: 2.8em;
     line-height: 1.2;


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-393.herokuapp.com/

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

On the home hero, the pink bits were fixed size.  When font-size
is increased, try to make this scale and move in proportion (best effort)

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*