### PR TITLE
593: Fix issue where clicking on 'X' wasn't closing modal.

### DIFF
--- a/app/views/components/_system_message.html.erb
+++ b/app/views/components/_system_message.html.erb
@@ -1,12 +1,11 @@
 <div class="modal micromodal-slide" id="maintenance-modal" aria-hidden="true">
-  <div class="modal__overlay" tabindex="-1" data-micromodal-close>
+  <div class="modal__overlay" tabindex="-1">
     <div class="modal__container" role="dialog" aria-modal="true"
       aria-labelledby="modal-1-title">
       <header>
-        <button class="modal__header-close" aria-label="Close modal">
-          <h2 class="govuk-heading-m" id="modal-1-title"
-            data-micromodal-close>Scheduled maintenance</h2>
-          <%= image_tag 'close-blue.svg', alt: '', class: 'modal__header-close-icon' %>
+        <button class="modal__header-close" aria-label="Close modal" data-micromodal-close>
+          <h2 class="govuk-heading-m" id="modal-1-title" data-micromodal-close>Scheduled maintenance</h2>
+          <%= image_tag 'close-blue.svg', alt: '', class: 'modal__header-close-icon', 'data-micromodal-close': true %>
         </button>
       </header>
       <main class="modal__content" id="modal-1-content">


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Related to [593](https://github.com/NCCE/teachcomputing.org-issues/issues/593)
## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Needed to add the data-micromodal-close attribute everywhere that is clickable to close...
Remove from overlay as it's too easy to dismiss accidentally

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*