### PR TITLE
Increase cache values ready for migration

### DIFF
--- a/app/lib/achiever.rb
+++ b/app/lib/achiever.rb
@@ -23,7 +23,7 @@ class Achiever
     params = build_params(workflow_id, workflow_params)
     request = build_request(params)
 
-    result = Rails.cache.fetch("#{workflow_id}-#{Date.today}", expires_in: 7.days) do
+    result = Rails.cache.fetch("#{workflow_id}-#{Date.today}", expires_in: 14.days) do
       make_request(request)
     end
 
@@ -36,7 +36,7 @@ class Achiever
     params = build_params(workflow_id, workflow_params)
     request = build_request(params)
 
-    result = Rails.cache.fetch("#{workflow_id}-#{course.course_template_no}-#{Date.today}", expires_in: 7.days) do
+    result = Rails.cache.fetch("#{workflow_id}-#{course.course_template_no}-#{Date.today}", expires_in: 14.days) do
       make_request(request)
     end
 
@@ -50,7 +50,7 @@ class Achiever
     params = build_params(workflow_id, workflow_params)
     request = build_request(params)
 
-    result = Rails.cache.fetch("#{workflow_id}-#{course.course_template_no}-#{Date.today}", expires_in: 7.days) do
+    result = Rails.cache.fetch("#{workflow_id}-#{course.course_template_no}-#{Date.today}", expires_in: 14.days) do
       make_request(request)
     end
 
@@ -64,7 +64,7 @@ class Achiever
     params = build_params(workflow_id, workflow_params)
     request = build_request(params)
 
-    result = Rails.cache.fetch("#{workflow_id}-#{Date.today}", expires_in: 7.days) do
+    result = Rails.cache.fetch("#{workflow_id}-#{Date.today}", expires_in: 14.days) do
       make_request(request)
     end
 
@@ -77,7 +77,7 @@ class Achiever
     params = build_params(workflow_id, workflow_params)
     request = build_request(params)
 
-    result = Rails.cache.fetch("#{workflow_id}-#{Date.today}", expires_in: 7.days) do
+    result = Rails.cache.fetch("#{workflow_id}-#{Date.today}", expires_in: 14.days) do
       make_request(request)
     end
 
@@ -90,7 +90,7 @@ class Achiever
     params = build_params(workflow_id, workflow_params)
     request = build_request(params)
 
-    result = Rails.cache.fetch("#{workflow_id}-#{id}-#{Date.today}", expires_in: 7.days) do
+    result = Rails.cache.fetch("#{workflow_id}-#{id}-#{Date.today}", expires_in: 14.days) do
       make_request(request)
     end
 


### PR DESCRIPTION
## Status

Ready

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Setting cache for our endpoints to 14 days. If we experience any issues with the migration it gives us 14 days to work with STEM & Smart Impact to fix `/courses` 
