### PR TITLE
Fix namespace for constants in the get_course_info rake task

### DIFF
--- a/lib/tasks/refresh_achiever_cache.rake
+++ b/lib/tasks/refresh_achiever_cache.rake
@@ -1,8 +1,8 @@
 namespace :achiever do
   task get_course_info: :environment do
     methods = [Achiever::Course::Template::RESOURCE_PATH,
-               Achiever::Course::Template::FACE_TO_FACE_RESOURCE_PATH,
-               Achiever::Course::Template::ONLINE_RESOURCE_PATH,
+               Achiever::Course::Occurrence::FACE_TO_FACE_RESOURCE_PATH,
+               Achiever::Course::Occurrence::ONLINE_RESOURCE_PATH,
                Achiever::Course::AgeGroup::RESOURCE_PATH,
                Achiever::Course::Subject::RESOURCE_PATH]
     methods.each do |method_id|


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes *add issue numbers or delete*
* Related to *add issue numbers or delete*

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* namespace / path for course occurrence constants was incorrect in the task `achiever:get_course_info`

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*