### PR TITLE
Remove old Achiever vars from app.json and fix BYPASS_OAUTH use

### DIFF
--- a/app.json
+++ b/app.json
@@ -62,34 +62,13 @@
       "description": "Allows login without using OAuth mechanism",
       "value": "true"
     },
-    "ACHIEVER_API_ENDPOINT": {
+    "ACHIEVER_V2_ENDPOINT": {
       "required": true
     },
-    "ACHIEVER_APPROVED_COURSE_TEMPLATES_WORKFLOW_ID": {
+    "ACHIEVER_V2_PASSWORD": {
       "required": true
     },
-    "ACHIEVER_FACE_TO_FACE_FUTURE_COURSES_WORKFLOW_ID": {
-      "required": true
-    },
-    "ACHIEVER_ONLINE_FUTURE_COURSES_WORKFLOW_ID": {
-      "required": true
-    },
-    "ACHIEVER_COURSE_OCCURRENCE_FEE_WORKFLOW_ID": {
-      "required": true
-    },
-    "ACHIEVER_COURSE_OCCURRENCE_WORKFLOW_ID": {
-      "required": true
-    },
-    "ACHIEVER_COURSES_FOR_DELEGATE_WORKFLOW_ID": {
-      "required": true
-    },
-    "ACHIEVER_DB_CONNECTION_ID": {
-      "required": true
-    },
-    "ACHIEVER_COURSE_TEMPLATE_SUBJECT_DETAILS_WORKFLOW_ID": {
-      "required": true
-    },
-    "ACHIEVER_COURSE_TEMPLATE_AGE_RANGE_WORKFLOW_ID": {
+    "ACHIEVER_V2_USERNAME": {
       "required": true
     },
     "PROXY_URL": {

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -46,7 +46,7 @@ end
 
 OmniAuth.config.on_failure = AuthController.action(:failure)
 
-if ENV['BYPASS_OAUTH'].present?
+if ActiveModel::Type::Boolean.new.cast(ENV.fetch('BYPASS_OAUTH', false))
   puts 'Faking OAuth login for review apps'
   OmniAuth.config.test_mode = true
   OmniAuth.config.mock_auth[:stem] = OmniAuth::AuthHash.new(


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Remove unused ACHIEVER_* variables from app.json
- Add new ACHIEVER_V2_* vars to app.json
- Make sure we are checking for a truthy value of BYPASS_OAUTH rather than just presence!


## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*