### PR TITLE
643: Add missing FutureLearn course and report missing ids to Raven

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,10 +2,12 @@ require File.expand_path('../seeds/activities/action', __FILE__)
 require File.expand_path('../seeds/activities/face-to-face', __FILE__)
 require File.expand_path('../seeds/activities/online', __FILE__)
 require File.expand_path('../seeds/activities/assessment', __FILE__)
-require File.expand_path('../seeds/activities/community', __FILE__)
+# Glen commented out until these activities have finalised info
+# require File.expand_path('../seeds/activities/community', __FILE__)
 Activity.all.each do |a|
   puts "Created activity #{a.title} (#{a})"
 end
 require File.expand_path('../seeds/programmes/cs_accelerator', __FILE__)
-require File.expand_path('../seeds/programmes/primary-certificate', __FILE__)
-require File.expand_path('../seeds/programmes/secondary-certificate', __FILE__)
+# Glen commented out until these programmes have finalised info
+# require File.expand_path('../seeds/programmes/primary-certificate', __FILE__)
+# require File.expand_path('../seeds/programmes/secondary-certificate', __FILE__)

--- a/db/seeds/activities/online.rb
+++ b/db/seeds/activities/online.rb
@@ -127,3 +127,13 @@ Activity.find_or_create_by(slug: 'introduction-to-cybersecurity-for-teachers') d
   activity.future_learn_course_id = '030261f8-1e96-4a70-a329-e3eb8b868915'
   activity.provider = 'future-learn'
 end
+
+Activity.find_or_create_by(slug: 'programming-with-guis') do |activity|
+  activity.title = 'Programming with GUIs'
+  activity.credit = 20
+  activity.slug = 'programming-with-guis'
+  activity.category = 'online'
+  activity.self_certifiable = false
+  activity.future_learn_course_id = '645ec51f-0b46-4102-a364-90647057f4f2'
+  activity.provider = 'future-learn'
+end

--- a/spec/jobs/process_future_learn_csv_export_job_spec.rb
+++ b/spec/jobs/process_future_learn_csv_export_job_spec.rb
@@ -19,13 +19,16 @@ RSpec.describe ProcessFutureLearnCsvExportJob, type: :job do
     2019-01-07,4,user4@example.com,Name 4,https://www.futurelearn.com/profiles/4,99%,0,0%,2019-05-03 10:45:45 UTC,1234,
     2019-01-07,5,user5@example.com,Name 5,https://www.futurelearn.com/profiles/5,59%,0,0%,,1234,
     2019-01-07,6,user6@example.com,Name 6,https://www.futurelearn.com/profiles/6,44%,0,0%,2019-05-03 10:45:45 UTC,1234,
-    2019-01-07,6,user6@example.com,Name 6,https://www.futurelearn.com/profiles/6,23%,0,0%,,5678,'
+    2019-01-07,6,user6@example.com,Name 6,https://www.futurelearn.com/profiles/6,23%,0,0%,,5678,
+    2019-01-07,1,user1@example.com,Name 1,https://www.futurelearn.com/profiles/1,23%,0,0%,,91011,
+    2019-01-07,2,user2@example.com,Name 2,https://www.futurelearn.com/profiles/2,23%,0,0%,,91011,'
   end
 
   describe '#perform' do
     before do
       [user_one, user_two, user_three, user_four, user_five, user_six, activity_one, activity_two]
       dropped_achievement.transition_to(:dropped)
+      allow(Raven).to receive(:capture_message)
       ProcessFutureLearnCsvExportJob.perform_now(csv_contents, import)
     end
 
@@ -41,6 +44,18 @@ RSpec.describe ProcessFutureLearnCsvExportJob, type: :job do
 
     it 'does not create an achievement if a user cannot be found' do
       expect(user_three.achievements.where(activity_id: activity_one.id).exists?).to eq false
+    end
+
+    it 'does not create an achievement if an activity cannot be found' do
+      expect(user_one.achievements.where(activity_id: '91011').exists?).to eq false
+    end
+
+    it 'sends a message to Raven if an activity cannot be found' do
+      expect(Raven).to have_received(:capture_message).with(/91011/)
+    end
+
+    it 'only sends one message to Raven for 2 rows with the same missing course' do
+      expect(Raven).to have_received(:capture_message).once
     end
 
     context 'when steps completed is less than 60' do


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [643](https://github.com/NCCE/teachcomputing.org-issues/issues/643)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Throw an error when a FutureLearn course id is missing a matching Activity and
then send a message to Raven with details.  Try to only do this once for each
course id.
Add spec's to test this.
Add missing course to seeds.
Comment out seeding of Primary & Secondary programmes along with incomplete
'community' activities temporarily until these are complete so we can
still run 'db:seed' in production without them for now.

## Steps to perform after deploying to production

`rails db:seed`