### PR TITLE
ensure log in is a post

### DIFF
--- a/app/views/pages/resources/_aside.html.erb
+++ b/app/views/pages/resources/_aside.html.erb
@@ -14,7 +14,7 @@
   <p class="govuk-body">
   <% if live %>
     <%= link_to_if current_user, "Access year #{year} resources", resource_url, class: 'govuk-button ncce-button__pink ncce-aside__button', role: 'button', draggable: 'false' do
-        link_to 'Log in to access', "#{auth_url}?source_uri=#{request.original_fullpath}#year-#{year}", class: 'govuk-button ncce-button__pink ncce-aside__button', role: 'button', draggable: 'false'
+        link_to 'Log in to access', "#{auth_url}?source_uri=#{request.original_fullpath}#year-#{year}", method: :post, class: 'govuk-button ncce-button__pink ncce-aside__button', role: 'button', draggable: 'false'
     end %>
   <% else %>
     <%= button_to 'Coming soon', '#', class: 'govuk-button ncce-button__pink ncce-aside__button', role: 'button', draggable: 'false', disabled: true %>


### PR DESCRIPTION
## Status

* Current Status: Ready
* Review App: https://teachcomputing-staging-pr-440.herokuapp.com/resources
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/656

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Log in on the resources page was not a `post` so was 404ing.