### PR TITLE
674: Add link to revision guide

### DIFF
--- a/app/views/programmes/cs-accelerator/_exam_activity.html.erb
+++ b/app/views/programmes/cs-accelerator/_exam_activity.html.erb
@@ -17,6 +17,9 @@
       <li>You can go back and change your answers</li>
       <li>You can skip a question</li>
       <li>Please be advised, clicking "Take the final test" will start an attempt</li>
+      <% if @user_programme_assessment.enough_credits_for_test? %>
+        <li><%= link_to 'Revision Guide', "#{ENV.fetch('STATIC_FILE_PATH')}/CS_Accelerator_Revision_Guide.pdf", class: 'ncce-link' %></li>
+      <% end %>
     </ul>
   </li>
   <li class="govuk-body-s ncce-activity-list__item ncce-activity-list__item--position ncce-exam-activity__attempts">

--- a/spec/views/programmes/cs-accelerator/_exam_activity.html_spec.rb
+++ b/spec/views/programmes/cs-accelerator/_exam_activity.html_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe('programmes/cs-accelerator/_exam_activity', type: :view) do
       expect(rendered).to have_css('ul>li', count: 7)
     end
 
+    it 'doesn\'t show the revision guide' do
+      expect(rendered).not_to have_css('.ncce-link', text: 'Revision Guide')
+    end
+
     it 'shows the certificate graphic' do
       expect(rendered).to have_css('.certification-progress__image--exam', count: 1)
     end
@@ -43,6 +47,10 @@ RSpec.describe('programmes/cs-accelerator/_exam_activity', type: :view) do
     before do
       allow(@user_programme_assessment).to receive_messages(enough_credits_for_test?: true, can_take_test_at: 0)
       render
+    end
+
+    it 'shows the revision guide' do
+      expect(rendered).to have_css('.ncce-link', text: 'Revision Guide')
     end
 
     it 'tells the user they can take the test' do


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [674](https://github.com/NCCE/teachcomputing.org-issues/issues/674)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Upload revision guide PDF to S3
- Add link to revision guide
- Only show if the user has enough credits to take the test

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*