### PR TITLE
682: Escape course filter input to prevent HTML injection via XSS methods

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -37,7 +37,7 @@ class CoursesController < ApplicationController
 
         if params[:certificate].present?
           @current_certificate = Programme.find_by(slug: params[:certificate])
-          has_certificate = c.by_certificate(params[:certificate])
+          has_certificate = c.by_certificate(params[:certificate]) if @current_certificate
         end
 
         if params[:level].present?
@@ -63,9 +63,9 @@ class CoursesController < ApplicationController
 
     def alert_filter_params
       filter_strings = []
-      filter_strings.push("<strong>Level</strong>: #{@current_level}") if @current_level
-      filter_strings.push("<strong>Topic</strong>: #{@current_topic}") if @current_topic
-      filter_strings.push("<strong>Location</strong>: #{@current_location}") if @current_location
+      filter_strings.push("<strong>Level</strong>: #{ERB::Util.html_escape(@current_level)}") if @current_level
+      filter_strings.push("<strong>Topic</strong>: #{ERB::Util.html_escape(@current_topic)}") if @current_topic
+      filter_strings.push("<strong>Location</strong>: #{ERB::Util.html_escape(@current_location)}") if @current_location
       filter_strings.push("<strong>Certificate</strong>: #{@current_certificate.title}") if @current_certificate
 
       return if filter_strings.empty?

--- a/spec/requests/courses/index_spec.rb
+++ b/spec/requests/courses/index_spec.rb
@@ -338,6 +338,38 @@ RSpec.describe CoursesController do
           expect(flash[:notice]).to match(/<strong>Level<\/strong>: Key stage 4/)
         end
       end
+
+      context 'filter escapes input' do
+        before do
+          programme
+          get courses_path, params: {
+            certificate: '<h1>Not a cert</h1>',
+            level: '<p>My XSS is excessive</p>',
+            topic: '<script>alert("boom")</script>',
+            location: '<svg onload=alert(1)>'
+          }
+        end
+
+        it 'has correct number of courses' do
+          expect(assigns(:courses).count).to eq(0)
+        end
+
+        it 'level param is escaped' do
+          expect(flash[:notice]).to match(/&lt;p&gt;My XSS is excessive&lt;\/p&gt;/)
+        end
+
+        it 'topic param is escaped' do
+          expect(flash[:notice]).to match(/&lt;script&gt;alert\(&quot;boom&quot;\)&lt;\/script&gt;/)
+        end
+
+        it 'location param is escaped' do
+          expect(flash[:notice]).to match(/&lt;svg onload=alert\(1\)&gt;/)
+        end
+
+        it 'invalid certificate does not cause filtering' do
+          expect(flash[:notice]).not_to match(/&lt;h1&gt;Not a cert&lt;\/h1&gt;/)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [682](https://github.com/NCCE/teachcomputing.org-issues/issues/682)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- escape filter parameters in courses
- don't try to filter by programme when the 'certificate' filter value is invalid

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*