### PR TITLE
683: Prevent 'open redirect' issue when creating an achievement.

### DIFF
--- a/app/controllers/achievements_controller.rb
+++ b/app/controllers/achievements_controller.rb
@@ -14,7 +14,7 @@ class AchievementsController < ApplicationController
       flash[:error] = "Whoops something went wrong adding the activity to your Record of Achievement"
     end
 
-    redirect_to request.referrer || dashboard_path
+    redirect_back_or dashboard_path
   end
 
   def destroy

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,4 +18,14 @@ class ApplicationController < ActionController::Base
   def redirect_to_dashboard
     redirect_to dashboard_path if current_user
   end
+
+  def redirect_back_or(default)
+    forwarding_url = session[:forwarding_url]
+    session.delete(:forwarding_url)
+    redirect_to(forwarding_url || default)
+  end
+
+  def store_internal_location
+    session[:forwarding_url] = request.original_fullpath if request.get?
+  end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,6 +1,7 @@
 class DashboardController < ApplicationController
   layout 'full-width'
   before_action :authenticate_user!
+  before_action :store_internal_location
 
   def show
     @achievements = current_user.achievements.in_state(:complete)

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -4,6 +4,7 @@ class ProgrammesController < ApplicationController
   before_action :find_programme, only: %i[show complete certificate]
   before_action :user_enrolled?, only: %i[show complete certificate]
   before_action :user_completed_diagnostic?, only: %i[show], if: -> { @programme.slug == 'primary-certificate' }
+  before_action :store_internal_location, only: %i[show], if: -> { @programme.slug == 'primary-certificate' }
 
   def show
     return redirect_to programme_complete_path(@programme.slug) if @programme.user_completed?(current_user)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationController, type: :controller do
+  let(:url) { '/test/123' }
+  let(:url_fallback) { '/test/456' }
+
   before(:each) do
     allow(controller).to receive(:authenticate_or_request_with_http_basic)
   end
@@ -20,6 +23,52 @@ RSpec.describe ApplicationController, type: :controller do
           controller.send(:authenticate)
           expect(controller).not_to have_received(:authenticate_or_request_with_http_basic)
         end
+      end
+    end
+  end
+
+  describe '#store_internal_location' do
+    before do
+      allow_any_instance_of(ActionController::TestRequest).to receive_messages(get?: true, original_fullpath: url)
+      controller.store_internal_location
+    end
+
+    it 'stores the current request path in the session' do
+      expect(session[:forwarding_url]).to eq(url)
+    end
+  end
+
+  describe '#redirect_back_or' do
+    before do
+      allow_any_instance_of(described_class).to receive(:redirect_to)
+    end
+
+    context 'when forwarding_url is set' do
+      before do
+        session[:forwarding_url] = url
+        controller.redirect_back_or url_fallback
+      end
+
+      it 'redirects to the session url' do
+        expect(controller).to have_received(:redirect_to).with(url)
+      end
+
+      it 'deletes the forwarding url from the session' do
+        expect(session[:forwarding_url]).to eq(nil)
+      end
+    end
+
+    context 'when forwarding_url is not set' do
+      before do
+        controller.redirect_back_or url_fallback
+      end
+
+      it 'redirects to the session url' do
+        expect(controller).to have_received(:redirect_to).with(url_fallback)
+      end
+
+      it 'deletes the forwarding url from the session' do
+        expect(session[:forwarding_url]).to eq(nil)
       end
     end
   end

--- a/spec/requests/achievements/create_spec.rb
+++ b/spec/requests/achievements/create_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe AchievementsController do
   let(:user) { create(:user) }
   let(:activity) { create(:activity, :stem_learning) }
-  let (:referrer) { 'https://testing123.com' }
+  let(:programme) { create(:programme, slug: 'primary-certificate') }
+  let(:primary_certificate_path) { '/certificate/primary-certificate' }
 
   describe 'POST #create' do
     before do
@@ -82,21 +83,24 @@ RSpec.describe AchievementsController do
       end
     end
 
-    context 'with referrer header' do
+    context 'with achievement from primary certificate page' do
       subject do
+        programme
+        allow_any_instance_of(UserProgrammeAchievements).to receive_messages(online_achievements: [], face_to_face_achievements: [], diagnostic_achievements: [], community_activities: [])
+        allow_any_instance_of(ProgrammesController).to receive_messages('user_completed_diagnostic?': true, 'user_enrolled?': true)
+        get primary_certificate_path
         post achievements_path,
              params: {
                achievement: { activity_id: nil }
-             },
-             headers: { 'HTTP_REFERER' => referrer }
+            }
       end
 
       before do
         subject
       end
 
-      it 'redirects to the referrer if specified' do
-          expect(response).to redirect_to(referrer)
+      it 'redirects back to the primary certificate page' do
+        expect(response).to redirect_to(primary_certificate_path)
       end
     end
 


### PR DESCRIPTION
## Status

* Current Status: WIP
* Review App: *populate this once the PR has been created*
* Closes *add issue numbers or delete*
* Related to *add issue numbers or delete*

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Allow use of a session variable to redirect the user back to the previous page
- when they create an achievement.  Defaults to the dashboard (if no session is set)
- Add methods in ApplicationController and test.
- Rejig spec's to test redirection.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*