### PR TITLE
692: Add 'Resources' link to secondary header nav.

### DIFF
--- a/app/views/components/_header.html.erb
+++ b/app/views/components/_header.html.erb
@@ -52,6 +52,9 @@
                   <%= link_to 'Secondary teachers', secondary_path, class: 'govuk-header__link' %>
                 </li>
               <% end %>
+              <li class="ncce-header__navigation-item-cert">
+                <%= link_to 'Resources', resources_path, class: 'govuk-header__link' %>
+              </li>
             </ul>
           </li>
         </ul>

--- a/spec/views/components/_header_spec.rb
+++ b/spec/views/components/_header_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe('components/_header', type: :view) do
     expect(rendered).to have_xpath('//a[@href = "/"][contains(@class, "govuk-header__link")]', count: 1)
   end
 
+  it 'shows a link to resources' do
+    render
+    expect(rendered).to have_link('Resources', href: resources_path)
+  end
+
   context 'when a user is signed in' do
     before do
       allow(view).to receive(:current_user).and_return(user)


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [692](https://github.com/NCCE/teachcomputing.org-issues/issues/692)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Add 'Resources' link to secondary header nav & test.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*