### PR TITLE
Add missing 'full-width' override to CS Accelerator enrol & complete pages

### DIFF
--- a/app/views/pages/cs-accelerator.html.erb
+++ b/app/views/pages/cs-accelerator.html.erb
@@ -1,5 +1,5 @@
 <% title "CS Accelerator - Teach Computing" %>
-<%= render 'pages/certification/hero' %>
+<%= render 'pages/certification/hero', full_width: true  %>
 <div class="govuk-width-container">
   <div class="govuk-main-wrapper govuk-main-wrapper--xl">
     <div class="govuk-grid-row">

--- a/app/views/programmes/cs-accelerator/complete.html.erb
+++ b/app/views/programmes/cs-accelerator/complete.html.erb
@@ -1,4 +1,4 @@
-<%= render 'pages/certification/hero' %>
+<%= render 'pages/certification/hero', full_width: true  %>
 <div class="govuk-width-container">
   <div class="govuk-main-wrapper govuk-main-wrapper--xl">
     <div class="govuk-grid-row">


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-467.herokuapp.com/cs-accelerator
* Related to [695](https://github.com/NCCE/teachcomputing.org-issues/issues/695)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Missed the full-width override from CS Accelerator 'enrol' & 'complete' pages.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*