### PR TITLE
664: Add default colours for links with no classes and fix links with bg

### DIFF
--- a/app/assets/stylesheets/components/dashboard/_activity-list.scss
+++ b/app/assets/stylesheets/components/dashboard/_activity-list.scss
@@ -73,13 +73,11 @@
 
 .ncce-activity-list__item-activity {
   @extend .ncce-activity-list__item-indent;
-  background-color: $foam;
   font-weight: 700;
   padding: 0.7rem;
 }
 
 .ncce-activity-list__item-description {
-  background-color: $foam;
   font-size: 0.875rem;
   font-weight: normal;
   line-height: 1.31579;

--- a/app/assets/stylesheets/components/programmes/_recommendation.scss
+++ b/app/assets/stylesheets/components/programmes/_recommendation.scss
@@ -1,5 +1,4 @@
 .recommendation {
-    background-color: $foam;
     display: flex;
     flex-direction: column;
     font-size: 0.875rem;

--- a/app/assets/stylesheets/settings/_colors.scss
+++ b/app/assets/stylesheets/settings/_colors.scss
@@ -37,3 +37,7 @@ $tapestry: #a94e91;
 $foam: #e3f6fc;
 
 $govuk-text-colour: $grey-dark-x;
+
+.light-blue-bg {
+  background-color: $foam;
+}

--- a/app/assets/stylesheets/settings/_links.scss
+++ b/app/assets/stylesheets/settings/_links.scss
@@ -1,40 +1,64 @@
-.ncce-link {
+.ncce-link,
+a[class=""],
+a:not([class]) {
   font-family: $font-family-body;
 
 	&:link {
 		color: $deep-cerulean;
 	}
 	&:visited {
-		color: $purple;
+		color: $tapestry;
 	}
 	&:hover {
-		color: $pink;
+		color: $grey-dark-x;
 	}
 	&:focus {
+		background-color: $deep-cerulean;
 		color: $white;
-		background-color: $pink;
-		outline-color: $pink;
+		outline-color: $deep-cerulean;
 	}
 	&:active {
-		background-color: $pink;
+		background-color: $deep-cerulean;
 		color: $white;
-	}
+  }
+}
 
-  &--on-dark {
-  	&:link {
-  		color: $grey-x-light;
-  	}
-  	&:visited {
-  		color: $grey;
-  	}
-  	&:hover {
-  		color: $white;
-  	}
+.ncce-link--on-dark {
+  &:link {
+    color: $grey-x-light;
+  }
+  &:visited {
+    color: $grey;
+  }
+  &:hover {
+    color: $white;
+  }
+  &:focus {
+    color: $white;
+  }
+  &:active {
+    color: $grey-dark-x;
+  }
+}
+
+.light-blue-bg {
+  .ncce-link,
+  a[class=""],
+  a:not([class]) {
+    &:link {
+      color: $grey-dark-x;
+    }
+    &:visited {
+      color: $tapestry;
+    }
+    &:hover {
+      color: $deep-cerulean;
+    }
     &:focus {
       color: $white;
     }
     &:active {
-      color: $black;
+      color: $white;
     }
   }
 }

--- a/app/views/programmes/_achievements.html.erb
+++ b/app/views/programmes/_achievements.html.erb
@@ -4,7 +4,7 @@
       <li class="ncce-activity-list__item">
         <span class="ncce-activity-list__item-text"><%= presenter.completed_text(index) %>
         </span>
-        <span class="ncce-activity-list__item-activity">
+        <span class="ncce-activity-list__item-activity light-blue-bg">
           <span class="govuk-tag govuk-phase-banner__content__tag ncce-activity-list__tag" aria-hidden="true">Complete</span>
           <span class="ncce-activity-list__course"><%= presenter.activity.title %></span>
         </span>
@@ -12,7 +12,7 @@
     <% else %>
       <li class="ncce-activity-list__item ncce-activity-list__item--inprogress">
         <span class="ncce-activity-list__item-text"><%= presenter.prompt_text(index) %></span>
-        <span class="ncce-activity-list__item-activity">
+        <span class="ncce-activity-list__item-activity light-blue-bg">
           <span class="govuk-tag govuk-phase-banner__content__tag ncce-activity-list__tag">In progress</span>
           <span class="ncce-activity-list__course"><%= presenter.activity.title %></span>
         <span>

--- a/app/views/programmes/_community_achievements.html.erb
+++ b/app/views/programmes/_community_achievements.html.erb
@@ -4,7 +4,7 @@
       <span class="ncce-activity-list__item-text">
         <span><%= presenter.title %></span>
         <% if presenter.description.present? %>
-          <span class="ncce-activity-list__item-description"><%= presenter.description %></span>
+          <span class="ncce-activity-list__item-description light-blue-bg"><%= presenter.description %></span>
         <% end %>
       </span>
       <% unless presenter.completed? %>

--- a/app/views/programmes/primary-certificate/_recommendation.html.erb
+++ b/app/views/programmes/primary-certificate/_recommendation.html.erb
@@ -1,5 +1,5 @@
 <% if recommendation %>
-  <span class="recommendation">
+  <span class="recommendation light-blue-bg">
     <span class="recommendation__title">Our recommendation</span>
     <span class="recommendation__text"><%= recommendation[:description] %></span>
     <span class="recommendation__link"><%= link_to recommendation[:title], recommendation[:link], class: 'ncce-link' %></span>

--- a/public/error-pages/errors.css
+++ b/public/error-pages/errors.css
@@ -9,6 +9,9 @@
   src: url(/assets/Objectivity-Medium-a99dfe46456ea219f75ce66ce5bcdfa7ea36a5d16ba0c75d4adcc96b4cbe3a9b.woff) format("woff"), url(/assets/Objectivity-Medium-671b7f75ca405969201a2819647145872f3fe9c7b14f1381f43bb0291fee643d.woff2) format("woff2"), url(/assets/Objectivity-Medium-93abed3bd2868c28c782bebcc66428ea7a7f0deab6d6666fd078b7289a43aea8.otf) format("opentype");
   font-weight: 400;
 }
+.light-blue-bg {
+  background-color: #e3f6fc;
+}
 .govuk-link {
   font-family: "Roboto", sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -4568,25 +4571,37 @@
     width: 25% !important;
   }
 }
-.ncce-link {
+.ncce-link,
+a[class=""],
+a:not([class]) {
   font-family: "Roboto", sans-serif;
 }
-.ncce-link:link {
+.ncce-link:link,
+a[class=""]:link,
+a:not([class]):link {
   color: #007fa2;
 }
-.ncce-link:visited {
-  color: #7b1ec0;
+.ncce-link:visited,
+a[class=""]:visited,
+a:not([class]):visited {
+  color: #a94e91;
 }
-.ncce-link:hover {
-  color: #de01a5;
+.ncce-link:hover,
+a[class=""]:hover,
+a:not([class]):hover {
+  color: #333448;
 }
-.ncce-link:focus {
+.ncce-link:focus,
+a[class=""]:focus,
+a:not([class]):focus {
+  background-color: #007fa2;
   color: #ffffff;
-  background-color: #de01a5;
-  outline-color: #de01a5;
+  outline-color: #007fa2;
 }
-.ncce-link:active {
-  background-color: #de01a5;
+.ncce-link:active,
+a[class=""]:active,
+a:not([class]):active {
+  background-color: #007fa2;
   color: #ffffff;
 }
 .ncce-link--on-dark:link {
@@ -4602,7 +4617,32 @@
   color: #ffffff;
 }
 .ncce-link--on-dark:active {
-  color: #000000;
+  color: #333448;
+}
+.light-blue-bg .ncce-link:link,
+.light-blue-bg a[class=""]:link,
+.light-blue-bg a:not([class]):link {
+  color: #333448;
+}
+.light-blue-bg .ncce-link:visited,
+.light-blue-bg a[class=""]:visited,
+.light-blue-bg a:not([class]):visited {
+  color: #a94e91;
+}
+.light-blue-bg .ncce-link:hover,
+.light-blue-bg a[class=""]:hover,
+.light-blue-bg a:not([class]):hover {
+  color: #007fa2;
+}
+.light-blue-bg .ncce-link:focus,
+.light-blue-bg a[class=""]:focus,
+.light-blue-bg a:not([class]):focus {
+  color: #ffffff;
+}
+.light-blue-bg .ncce-link:active,
+.light-blue-bg a[class=""]:active,
+.light-blue-bg a:not([class]):active {
+  color: #ffffff;
 }
 .ncce-link__icon {
   width: 30px;
@@ -4922,7 +4962,7 @@
   margin-left: 1rem;
 }
 .ncce-button__pink {
-  background-color: #de01a5;
+  background-color: #007fa2;
   box-shadow: none;
   font-size: 1.188rem;
   font-weight: bold;
@@ -4930,7 +4970,7 @@
   padding: 12px 25px;
 }
 .ncce-button__pink[disabled] {
-  background-color: #de01a5;
+  background-color: #007fa2;
 }
 .ncce-button__pink:hover, .ncce-button__pink[disabled]:hover {
   background-color: #000000;
@@ -5840,7 +5880,7 @@
 }
 .ncce-courses__filter-container {
   padding: 0;
-  background-color: #d1d0e5;
+  background-color: #f2f2f2;
 }
 .ncce-courses__filter-container--sticky {
   position: fixed;
@@ -6157,18 +6197,22 @@
   }
 }
 .ncce-activity-list__item-activity {
-  background-color: #e3f6fc;
   font-weight: 700;
   padding: 0.7rem;
 }
 .ncce-activity-list__item-description {
-  font-size: 1rem;
-  margin-bottom: 1.25rem;
+  font-size: 0.875rem;
+  font-weight: normal;
+  line-height: 1.31579;
+  margin-bottom: 4px;
+  padding: 0.625rem;
 }
 @media (min-width: 40.0625em) {
   .ncce-activity-list__item-description {
-    font-size: 1.188rem;
+    font-size: 1rem;
     margin-bottom: 0;
+    padding: 0.75rem;
+    width: calc(80% - 2.8rem);
   }
 }
 .ncce-activity-list__item--incomplete {
@@ -6741,6 +6785,9 @@
   box-sizing: border-box;
   text-align: left;
 }
+.ihavedonethis__popup .button {
+  margin-bottom: 0;
+}
 .ihavedonethis__popup .govuk-input {
   border: 0;
 }
@@ -6769,26 +6816,35 @@
 }
 .ihavedonethis--progressive .ihavedonethis__button {
   display: inline-block;
+  width: calc(100% - 2rem);
+  margin-left: 2rem;
+}
+@media (min-width: 40.0625em) {
+  .ihavedonethis--progressive .ihavedonethis__button {
+    width: auto;
+    margin-left: 0;
+  }
 }
 .ihavedonethis__group {
   display: inline-block;
   margin-bottom: 1rem;
+  width: 100%;
 }
 .recommendation {
-  background-color: #e3f6fc;
   display: flex;
   flex-direction: column;
-  font-size: 16px;
+  font-size: 0.875rem;
   margin-bottom: 1rem;
   margin-left: 2rem;
-  padding: 0.5rem;
+  padding: 0.625rem;
   width: auto;
 }
 @media (min-width: 48.0625em) {
   .recommendation {
+    font-size: 1rem;
     margin-bottom: 0;
     margin-left: 2.8rem;
-    padding: 1rem;
+    padding: 0.75rem;
     width: 80%;
   }
 }


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-495.herokuapp.com/certificate/primary-certificate
* Closes [664](https://github.com/NCCE/teachcomputing.org-issues/issues/664)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Add default catch-all rule for unstyled links.
- Tweak hover and visited colours along with focus for links on white bg.
- Make sure any links without a class get styled with our colours.
- Add override / change for links on the light blue tint BG.


## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*