### PR TITLE
753: Tweak Primary Cert landing page according to review:

### DIFF
--- a/app/assets/stylesheets/components/pages/certification/_pathway.scss
+++ b/app/assets/stylesheets/components/pages/certification/_pathway.scss
@@ -1,6 +1,5 @@
 .pathway-wrapper {
   border-radius: 10px;
-  background-color: $concrete;
   padding: 15px;
   font-family: $font-family-body;
   margin-bottom: 40px;

--- a/app/assets/stylesheets/settings/_colors.scss
+++ b/app/assets/stylesheets/settings/_colors.scss
@@ -41,3 +41,7 @@ $govuk-text-colour: $grey-dark-x;
 .light-blue-bg {
   background-color: $foam;
 }
+
+.light-grey-bg {
+  background-color: $concrete;
+}

--- a/app/assets/stylesheets/settings/_links.scss
+++ b/app/assets/stylesheets/settings/_links.scss
@@ -77,3 +77,26 @@ a:not([class]) {
 .ncce-link--heading {
   font-family: $font-family-heading;
 }
+
+.light-blue-bg,
+.light-grey-bg {
+  .ncce-link,
+  a[class=""],
+  a:not([class]) {
+    &:link {
+      color: $grey-dark-x;
+    }
+    &:visited {
+      color: $tapestry;
+    }
+    &:hover {
+      color: $deep-cerulean;
+    }
+    &:focus {
+      color: $white;
+    }
+    &:active {
+      color: $white;
+    }
+  }
+}

--- a/app/views/pages/certification/_pathway.html.erb
+++ b/app/views/pages/certification/_pathway.html.erb
@@ -1,4 +1,4 @@
-<div class="pathway-wrapper">
+<div class="pathway-wrapper light-grey-bg">
   <h2 class="govuk-heading-s">You'll be supported at every step along the way
   </h2>
   <ol class="pathway">

--- a/app/views/pages/primary-certificate.html.erb
+++ b/app/views/pages/primary-certificate.html.erb
@@ -6,22 +6,23 @@
       <div class="govuk-grid-column">
         <div class="govuk-grid-column-two-thirds">
           <h1 class="govuk-heading-m">Welcome to the Primary Computing Programme</h1>
-          <p class="govuk-body">This is a professional development programme designed to support teachers from <i>all</i> backgrounds who want to improve their knowledge of computing. Certification can help you cover new areas while also reinforcing the skills you already have. Think of it as a refresher course that can help you identify and overcome your problem areas.</p>
-          <div class="pathway-wrapper">
+          <p class="govuk-body">This is a professional development programme designed to support teachers from all backgrounds who want to improve their knowledge of computing. Certification can help you cover new areas while also reinforcing the skills you already have. Think of it as a refresher course that can help you identify and overcome your problem areas.</p>
+          <div class="pathway-wrapper light-grey-bg">
             <ol class="pathway">
+
               <li class="pathway__step">
                 <h2 class="govuk-heading-s pathway__step-title">
                   <span class="pathway__step-circle">
                   </span>
                     Register & plan</h2>
-                  <p class="govuk-body"><%= link_to 'Create an account', create_account_url, :class => 'ncce-link' %> and discover courses suited to you using our diagnostic tool</p>
+                  <p class="govuk-body"><% unless current_user %><%= link_to 'Create an account', create_account_url, :class => 'ncce-link' %><% else %>Enrol<% end %> and discover courses suited to you</p>
               </li>
               <li class="pathway__step">
                 <h2 class="govuk-heading-s pathway__step-title">
                   <span class="pathway__step-circle">
                   </span>
                     Participate</h2>
-                  <p class="govuk-body">Complete a tailored of CPD, both online and local to you</p>
+                  <p class="govuk-body">Complete a tailored programme of CPD, both online and local to you</p>
               </li>
               <li class="pathway__step">
                 <h2 class="govuk-heading-s pathway__step-title">
@@ -50,11 +51,11 @@
           <p class="govuk-body">The programme is suitable for those already teaching or planning to teach computing and will help teachers to fill potential gaps in their knowledge.</p>
           <h2 class="govuk-heading-s">Benefits for you:</h2>
           <ul class="govuk-list govuk-list--bullet">
-            <li>update your skills and be recognised for your subject knowledge</li>
-            <li>feel more confident to teach this high demand subject across the curriculum</li>
-            <li>choose from face-to-face and online modules to suit your learning needs</li>
-            <li>save time on lesson planning and gain inspirational teaching ideas </li>
-            <li>meet teachers in your area to share ideas</li>
+            <li>Update your skills and be recognised for your subject knowledge</li>
+            <li>Feel more confident to teach this high demand subject across the curriculum</li>
+            <li>Choose from face-to-face and online modules to suit your learning needs</li>
+            <li>Save time on lesson planning and gain inspirational teaching ideas </li>
+            <li>Meet teachers in your area to share ideas</li>
           </ul>
           <p class="govuk-body"><strong>We hope you find the programme supportive and that it helps to give you the confidence to teach computing in your school. </strong></p>
         </div>
@@ -67,13 +68,15 @@
             <% end %>
             <P class="govuk-body-s ncce-aside__text">Start your journey!</p>
             <ol class="govuk-list govuk-list--number ncce-aside__text govuk-body-s cs-accelerator-aside__list">
+              <% unless current_user %>
               <li>
                 Create your account with STEM Learning, and log in
               </li>
+              <% end %>
               <li>Enrol with the click of the button</li>
-              <li>Use your personal dashboard to track your progress</li>
-              <li>Find and book onto courses</li>
-              <li>Receive your certificate</li>
+              <li>Complete an enrolment questionaire to gauge your confidence with computing</li>
+              <li>We will recommend a training package for you to complete</li>
+              <li>Complete the required training & community activities to receive your qualification</li>
             </ol>
             <% if current_user %>
               <p class="govuk-body"><%= link_to 'Enrol on this certificate', user_programme_enrolment_path(slug: Programme.primary_certificate.slug, :user_programme_enrolment => { user_id: current_user.id, programme_id: Programme.primary_certificate.id }), method: :post, class: 'govuk-button button--aside', role: 'button', draggable: 'false' %></p>


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [753](https://github.com/NCCE/teachcomputing.org-issues/issues/753)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Aside copy update from design
- Links colours need updating
- Steps says create an account when logged in, it should say 'Enrol'
- Remove emphasis from all in the copy
- Capitalise 'Benefit' list items

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*