### PR TITLE
759: Tweak Primary Certificate 'complete' page.

### DIFF
--- a/app/assets/stylesheets/components/_aside.scss
+++ b/app/assets/stylesheets/components/_aside.scss
@@ -8,8 +8,8 @@ $aside-padding: 1rem;
   border-top-style: solid;
   border-top-width: 3px;
 
-  &__text {
-    color: $black;
+  &__text--s {
+    font-size: 1.0625rem;
   }
 
   &__title {

--- a/app/views/programmes/primary-certificate/_achievement_list_complete.html.erb
+++ b/app/views/programmes/primary-certificate/_achievement_list_complete.html.erb
@@ -1,5 +1,5 @@
 
-<ul class="govuk-list ncce-activity-list ncce-activity-list--programme" role="list">
+<ul class="govuk-list ncce-activity-list" role="list">
   <% @complete_achievements.each do |achievement| %>
     <li class="ncce-activity-list__item">
       <span class="ncce-activity-list__item-text"><%= achievement.activity.title %></span>

--- a/app/views/programmes/primary-certificate/complete.html.erb
+++ b/app/views/programmes/primary-certificate/complete.html.erb
@@ -1,9 +1,9 @@
 <%= render 'pages/certification/hero' %>
 <div class="govuk-width-container">
-  <div class="govuk-main-wrapper govuk-main-wrapper--xl">
+  <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-m">Congratulations! You have been awarded the Teach Primary computing certificate.</h1>
+        <p class="govuk-body-l">Congratulations! You have been awarded the Teach Primary computing certificate.</p>
         <p class="govuk-body">
           <%= link_to 'Download your certificate', programme_certificate_path(@programme.slug), class: 'govuk-button button', role: 'button', draggable: 'false' %>
         </p>
@@ -13,8 +13,8 @@
       <div class="govuk-grid-column-one-third">
         <div class="ncce-aside">
           <h2 class="govuk-heading-m ncce-aside__title">Share your success</h2>
-          <p class="govuk-body ncce-aside__text">Do you know someone who would benefit from this programme? Invite them to join and discuss what you’ve learnt with someone you know.</p>
-          <p class="govuk-body ncce-aside__text">You can also
+          <p class="govuk-body ncce-aside__text--s">Do you know someone who would benefit from this programme? Invite them to join and discuss what you’ve learnt with someone you know.</p>
+          <p class="govuk-body ncce-aside__text--s">You can also
             <a href="https://twitter.com/WeAreComputing?ref_src=twsrc%5Etfw" class="ncce-link" data-related="WeAreComputing" data-lang="en" data-show-count="false" data-dnt="true" target="_blank">follow @WeAreComputing</a> on Twitter
           </p>
         </div>
@@ -24,7 +24,7 @@
 </div>
 <div class="ncce-programmes-activity">
   <div class="govuk-width-container">
-    <div class="govuk-main-wrapper">
+    <div class="govuk-main-wrapper govuk-main-wrapper--xl">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <h2 class="govuk-heading-m ncce-programmes-activity__title">Your learning journey</h2>


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [759](https://github.com/NCCE/teachcomputing.org-issues/issues/759)
## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Gap between hero and content to big. 1 logo block please.
- Congrats heading should be large paragraph
- Extra padding above 'your learning journey'
- Fix aside font size - may need doing on other pages?
- Remove extra padding at bottom of activity list.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*