### PR TITLE
756: Change use of black #000000 in places where we should use #333448

### DIFF
--- a/app/assets/stylesheets/components/_aside.scss
+++ b/app/assets/stylesheets/components/_aside.scss
@@ -13,7 +13,7 @@ $aside-padding: 1rem;
   }
 
   &__title {
-    color: $black;
+    color: $grey-dark-x;
     padding-top: $aside-padding;
   }
 

--- a/app/assets/stylesheets/components/pages/_courses.scss
+++ b/app/assets/stylesheets/components/pages/_courses.scss
@@ -168,7 +168,7 @@
     padding: 10px 0;
   }
   &-prompt {
-    color: $black;
+    color: $grey-dark-x;
     margin-right: 20px;
     @include govuk-media-query($until: tablet) {
       display: none;

--- a/app/assets/stylesheets/components/pages/_resources.scss
+++ b/app/assets/stylesheets/components/pages/_resources.scss
@@ -24,7 +24,7 @@
 .resources-year {
   padding-bottom: 30px;
   &__heading {
-    border-bottom: 1px solid $black;
+    border-bottom: 1px solid $grey-dark-x;
     font-family: $font-family-body;
     margin-bottom: 30px;
     padding-bottom: 20px;
@@ -38,7 +38,7 @@
 }
 
 .resources-aside {
-  background-color: $grey-x-light;
+  background-color: $concrete;
   padding: 1rem;
   &__title {
     background-image: url(/images/resources/documents-icon.svg);

--- a/app/assets/stylesheets/components/programmes/_exam-activity.scss
+++ b/app/assets/stylesheets/components/programmes/_exam-activity.scss
@@ -28,7 +28,7 @@
     }
 
     padding: 0 10px;
-    color: $black;
+    color: $grey-dark-x;
     display: flex;
     align-items: center;
 

--- a/app/assets/stylesheets/settings/_typography.scss
+++ b/app/assets/stylesheets/settings/_typography.scss
@@ -4,7 +4,7 @@
 .govuk-heading-xl {
   font-family: $font-family-heading;
   font-weight: 400;
-  color: $black;
+  color: $grey-dark-x;
 }
 
 .govuk-body {


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-505.herokuapp.com/courses, https://teachcomputing-staging-pr-505.herokuapp.com/resources, https://teachcomputing-staging-pr-505.herokuapp.com/certificate/cs-accelerator
* Closes [756](https://github.com/NCCE/teachcomputing.org-issues/issues/756)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Change use of $black colour on:

- Asides
- Courses filter
- Headings default
- Resources page
- CSA 'Exam' section

Left on the button 'focus' state and (until redesign) the home page

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*