### PR TITLE
685: Add config for secure session cookies

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -114,4 +114,10 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.middleware.use Rack::Attack
+
+  # Enable secure cookies (will only work on https)
+  config.session_store :cookie_store,
+                       key: '_teach_computing_session',
+                       secure: true,
+                       httponly: true
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -105,4 +105,10 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.middleware.use Rack::Attack
+
+  # Enable secure cookies (will only work on https)
+  config.session_store :cookie_store,
+                       key: '_teach_computing_session',
+                       secure: true,
+                       httponly: true
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-533.herokuapp.com/login
* Closes [685](https://github.com/NCCE/teachcomputing.org-issues/issues/685)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Set the config so use secure: true for staging / production.
(This can only be done in dev if you use the https url from ngrok or similar)

To check - remove any cookies for this URL.  Login and inspect the cookies (Firefox, use dev-tools Storage->Cookies and click on the domain.  Right click on the 'table header' to add the column for 'Secure' if it's not there.  Session cookie should come up as 'true' (compare to production & staging now)

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*