### PR TITLE
switch context so it gets cleared before its set so its passed to Raven

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -19,9 +19,9 @@ module OmniAuth::Strategies
     end
 
     def user_info
+      Raven::Context.clear!
       response ||= access_token.get('/idp/module.php/oauth2/userinfo.php')
       raven_context(response)
-      Raven::Context.clear!
       response.parsed
     end
 


### PR DESCRIPTION
## Status

* Current Status: Ready
* Review App: *populate this once the PR has been created*
* Related to https://github.com/NCCE/teachcomputing.org-issues/issues/443

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Moved where the context is set so its actually passed down. This may help us debug the OAuth flow. If it doesnt I am going to press on passing down the entire response to see what additional info is passed from the response.