### PR TITLE
844: Fix issue with icon sizes on Courses page.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,7 @@
 @import 'components/_aside.scss';
 @import 'components/_card.scss';
 @import 'components/_text-photo-hero.scss';
+@import 'components/_icons.scss';
 @import 'components/pages/home/_hero.scss';
 @import 'components/pages/home/_jobs.scss';
 @import 'components/pages/home/_mailing.scss';

--- a/app/assets/stylesheets/components/_icons.scss
+++ b/app/assets/stylesheets/components/_icons.scss
@@ -1,0 +1,32 @@
+@mixin icon($image, $position: left center, $width: 20px, $height: 20px, $spacing: 7px) {
+  background-image: image-url($image);
+  background-position: $position;
+  background-repeat: no-repeat;
+  background-size: $width $height;
+  @if $position == left or $position == left top or $position == left bottom {
+    padding-left: $spacing + $width;
+  }  @else if $position == right or $position == right top or $position == right bottom {
+    padding-right: $spacing + $width;
+  }
+}
+
+.icon-online {
+  @include icon('laptop.svg', left bottom);
+}
+
+.icon-calendar {
+  @include icon('calendar.svg');
+}
+
+.icon-clock {
+  @include icon('clock.svg');
+}
+
+.icon-map-pin {
+  @include icon('map-pin.svg');
+}
+
+.icon-resources {
+  @include icon('resources-black.svg', left top, 30px, 30px, 5px);
+  min-height: 30px;
+}

--- a/app/assets/stylesheets/components/pages/_courses.scss
+++ b/app/assets/stylesheets/components/pages/_courses.scss
@@ -74,21 +74,13 @@
 			padding: 0;
 			font-size: 0.875rem;
 		}
-		&-icon {
+		&-location {
 			font-weight: 700;
 			display: inline-block;
-			padding: 0;
 			font-size: 0.9375rem;
-			text-indent: 1.1rem;
-			background-image: image-url('map-pin.svg');
-			background-position: left center;
-			background-repeat: no-repeat;
-
 		}
-		&-icon--online {
-			background-image: image-url('laptop.svg');
-			text-indent: 1.3rem;
-
+		&-location.icon-online {
+      background-position-y: center !important;
 		}
 	}
 }

--- a/app/assets/stylesheets/components/pages/_landing-page.scss
+++ b/app/assets/stylesheets/components/pages/_landing-page.scss
@@ -53,7 +53,7 @@
   }
 }
 
-.icons {
+.landing-page__icons {
   margin-bottom: 10px;
   span {
     clear: both;
@@ -68,7 +68,6 @@
     }
 
     margin-right: 30px;
-    padding-left: 1.7rem;
   }
 
   span:last-child {
@@ -80,40 +79,4 @@
     content: "";
     display: block;
   }
-}
-
-.icon-online {
-  background-image: image-url('laptop.svg');
-  background-position: left center;
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-}
-
-.icon-calendar {
-  background-image: image-url('calendar.svg');
-  background-position: left center;
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-}
-
-.icon-clock {
-  background-image: image-url('clock.svg');
-  background-position: left center;
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-}
-
-.icon-face-to-face {
-  background-image: image-url('map-pin.svg');
-  background-position: left center;
-  background-repeat: no-repeat;
-  background-size: 20px 20px;
-}
-
-.icon-resources {
-  background-image: image-url('resources-black.svg');
-  background-position: left top;
-  background-repeat: no-repeat;
-  min-height: 30px;
-  padding-left: 2.2rem;
 }

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -44,8 +44,7 @@ module CoursesHelper
     strip_tags(unescaped_str)
   end
 
-  def course_meta_css_class(isOnlineCourse)
-    cssClass = "ncce-courses__meta-icon"
-    isOnlineCourse ? "#{cssClass} #{cssClass}--online" : "#{cssClass}"
+  def course_meta_icon_class(isOnlineCourse)
+    isOnlineCourse ? 'icon-online' : 'icon-map-pin'
   end
 end

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -107,7 +107,7 @@
               <ul class="govuk-list govuk-body-s ncce-courses__meta">
                 <% course.occurrences.each do |oc| %>
                   <li class="govuk-grid-row ncce-courses__meta-item">
-                    <span class="govuk-grid-column-one-third <%= course_meta_css_class(oc.online_cpd) %>">
+                    <span class="govuk-grid-column-one-third ncce-courses__meta-location <%= course_meta_icon_class(oc.online_cpd) %>">
                     <%= oc.address_town %></span>
                     <span class="govuk-grid-column-two-thirds ncce-courses__meta-date"><%= activity_dates(oc.start_date, oc.end_date) %></span>
                   </li>

--- a/app/views/pages/primary-teachers.html.erb
+++ b/app/views/pages/primary-teachers.html.erb
@@ -31,7 +31,7 @@
             <source src="//view.vzaar.com/21003295/download/sd_lower" type="video/mp4">
             <track class="track" src="/images/primary-teachers/PrimaryPedagogy.vtt" kind="subtitles" srclang="EN" label="English">
           </video>
-          <p class="govuk-body-s icons"><strong><span class="icon-online">Free
+          <p class="govuk-body-s landing-page__icons"><strong><span class="icon-online">Free
                 online course</span><span class="icon-calendar">4
                 weeks</span><span class="icon-clock">2 hours per
                 week</span></strong></p>
@@ -50,8 +50,8 @@
             <li>Sequence and repetition (KS2)</li>
             <li>Selection and variables (KS2)</li>
           </ul>
-          <p class="govuk-body-s icons"><strong><span
-                class="icon-face-to-face">Face to face course</span><span
+          <p class="govuk-body-s landing-page__icons"><strong><span
+                class="icon-map-pin">Face to face course</span><span
                 class="icon-calendar">1 day</span></strong></p>
         </div>
       </div>

--- a/app/views/pages/secondary-teachers.html.erb
+++ b/app/views/pages/secondary-teachers.html.erb
@@ -41,7 +41,7 @@
             <source src="//view.vzaar.com/20654375/download/sd_lower" type="video/mp4">
             <track class="track" src="/images/secondary-teachers/ProgrammingWithGUIs.vtt" kind="subtitles" srclang="EN" label="English">
           </video>
-          <p class="govuk-body-s icons"><strong><span class="icon-online">Free
+          <p class="govuk-body-s landing-page__icons"><strong><span class="icon-online">Free
                 online course</span><span class="icon-calendar">3
                 weeks</span><span class="icon-clock">2 hours per
                 week</span></strong></p>
@@ -62,8 +62,8 @@
             <li>Sub-programs</li>
             <li>Data structures including arrays</li>
           </ul>
-          <p class="govuk-body-s icons"><strong><span
-                class="icon-face-to-face">Face to face course</span><span
+          <p class="govuk-body-s landing-page__icons"><strong><span
+                class="icon-map-pin">Face to face course</span><span
                 class="icon-calendar">2 days</span></strong></p>
         </div>
       </div>

--- a/spec/helpers/courses_helper_spec.rb
+++ b/spec/helpers/courses_helper_spec.rb
@@ -59,13 +59,13 @@ describe CoursesHelper, type: :helper do
     end
   end
 
-  describe('course_meta_css_class') do
+  describe('course_meta_icon_class') do
     it 'returns icon for offline courses' do
-      expect(helper.course_meta_css_class(false)).to eq 'ncce-courses__meta-icon'
+      expect(helper.course_meta_icon_class(false)).to eq 'icon-map-pin'
     end
 
     it 'returns icon for online courses' do
-      expect(helper.course_meta_css_class(true)).to eq 'ncce-courses__meta-icon ncce-courses__meta-icon--online'
+      expect(helper.course_meta_icon_class(true)).to eq 'icon-online'
     end
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [844](https://github.com/NCCE/teachcomputing.org-issues/issues/844)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Replacing the icons with SVGs of different size broke the look.
- Refactor icons to have a mixin with common values.
- Split to a separate file.
- Use icons consistently in Landing & Courses pages - split generic & specific CSS.
- Update helper spec for courses.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*