### PR TITLE
847: Fix the card colour on Secondary landing page (should be 'purple')

### DIFF
--- a/app/views/pages/secondary-teachers.html.erb
+++ b/app/views/pages/secondary-teachers.html.erb
@@ -78,7 +78,7 @@
     <div class="govuk-main-wrapper--xl">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <div class="card card--secondary-certificate card--bottom-glyph">
+          <div class="card card--cs-accelerator card--bottom-glyph">
             <h3 class="govuk-heading-m card__heading">Teach GCSE computer science</h3>
             <p class="govuk-body card__text">The Computer Science Accelerator
               Programme is a certified professional development programme


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-558.herokuapp.com/secondary-teachers
* Closes [847](https://github.com/NCCE/teachcomputing.org-issues/issues/847)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Fix the card colour on 2ndary landing page.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*