### PR TITLE
822: Show the user's 'status' on the programme 'cards' on landing pages.

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -86,7 +86,7 @@
   background-image: none;
 }
 
-.card__status {
+.card > .status-block {
   @include status_block();
   display: inline-block;
   margin-bottom: 20px;

--- a/app/assets/stylesheets/components/pages/certification/_hero.scss
+++ b/app/assets/stylesheets/components/pages/certification/_hero.scss
@@ -104,7 +104,7 @@
   }
 }
 
-.hero__status {
+.hero__wrapper > .status-block {
   @include status_block();
   float: left;
   margin: 0;

--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -1,0 +1,18 @@
+class LandingPagesController < ApplicationController
+  layout 'full-width'
+  before_action :find_programme
+
+  def primary_teachers
+    render "landing_pages/primary-teachers"
+  end
+
+  def secondary_teachers
+    render "landing_pages/secondary-teachers"
+  end
+
+  private
+
+    def find_programme
+      @programme = Programme.enrollable.find_by!(slug: params[:slug])
+    end
+end

--- a/app/views/dashboard/programmes/_hero.html.erb
+++ b/app/views/dashboard/programmes/_hero.html.erb
@@ -6,16 +6,7 @@
         <div class="govuk-grid-column-two-thirds">
           <% current_user.programmes.each do |programme| %>
             <div class="card card--<%= programme.slug %>">
-              <% if current_user && programme.user_enrolled?(current_user) %>
-                <% case  current_user.user_programme_enrolments.find_by(programme_id: programme.id).current_state %>
-                  <% when 'enrolled' %>
-                    <span class="govuk-body-m card__status">You are enrolled</span>
-                  <% when 'pending' %>
-                    <span class="govuk-body-m card__status">Programme complete</span>
-                  <% when 'complete' %>
-                    <span class="govuk-body-m card__status">Certificate awarded</span>
-                  <% end %>
-              <% end %>
+              <%= render 'pages/certification/programme-enrolment-status', programme: programme %>
               <h3 class="govuk-heading-m card__heading"><%= link_to programme.title, programme_path(programme.slug), class: 'ncce-link' %></h3>
               <p class="govuk-body card__text">Certificate awarded by BCS, The Chartered Institute for IT</p>
               <% credits = credits_for_programme(current_user, programme) %>

--- a/app/views/landing_pages/primary-teachers.html.erb
+++ b/app/views/landing_pages/primary-teachers.html.erb
@@ -72,6 +72,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <div class="card card--primary-certificate">
+          <%= render 'pages/certification/programme-enrolment-status', programme: @programme %>
           <h2 class="govuk-heading-m card__heading">Teach primary computing</h2>
           <p class="govuk-body card__text">Our nationally recognised qualification will support you to demonstrate your commitment to developing your own practice and to computing as a school subject.</p>
           <p class="govuk-body govuk-!-margin-bottom-0"><strong><%= link_to 'Find out more', primary_path, class: 'ncce-link' %></strong></p>

--- a/app/views/landing_pages/secondary-teachers.html.erb
+++ b/app/views/landing_pages/secondary-teachers.html.erb
@@ -79,6 +79,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <div class="card card--cs-accelerator card--bottom-glyph">
+            <%= render 'pages/certification/programme-enrolment-status', programme: @programme %>
             <h2 class="govuk-heading-m card__heading">Teach GCSE computer science</h2>
             <p class="govuk-body card__text">The Computer Science Accelerator
               Programme is a certified professional development programme

--- a/app/views/pages/certification/_hero.html.erb
+++ b/app/views/pages/certification/_hero.html.erb
@@ -1,16 +1,7 @@
 <div class="hero hero--<%= @programme.slug %> hero--bottom-glyph">
   <div class="govuk-width-container">
     <div class="govuk-main-wrapper hero__wrapper">
-      <% if current_user && @programme.user_enrolled?(current_user) %>
-        <% case  current_user.user_programme_enrolments.find_by(programme_id: @programme.id).current_state %>
-          <% when 'enrolled' %>
-            <span class="govuk-body-m hero__status">You are enrolled</span>
-          <% when 'pending' %>
-            <span class="govuk-body-m hero__status">Programme complete</span>
-          <% when 'complete' %>
-            <span class="govuk-body-m hero__status">Certificate awarded</span>
-          <% end %>
-      <% end %>
+      <%= render 'pages/certification/programme-enrolment-status', programme: @programme %>
       <div class="hero__heading-wrapper <%= 'hero__heading-wrapper--full-width' if local_assigns[:full_width] %>">
         <h1 class="govuk-heading-xl hero__heading"><%= @programme.title %></h1>
         <p class="govuk-body hero__text">Certificate awarded by BCS, The Chartered Institute for IT</p>

--- a/app/views/pages/certification/_programme-enrolment-status.html.erb
+++ b/app/views/pages/certification/_programme-enrolment-status.html.erb
@@ -1,0 +1,10 @@
+<% if current_user && programme.user_enrolled?(current_user) %>
+  <% case  current_user.user_programme_enrolments.find_by(programme_id: programme.id).current_state %>
+    <% when 'enrolled' %>
+      <span class="govuk-body-m status-block">You are enrolled</span>
+    <% when 'pending' %>
+      <span class="govuk-body-m status-block">Programme complete</span>
+    <% when 'complete' %>
+      <span class="govuk-body-m status-block">Certificate awarded</span>
+    <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
   resources :courses, path: '/courses', only: [:index]
 
   get 'dashboard', action: :show, controller: 'dashboard'
-  
+
   get '/resources', action: :index, controller: 'resources'
   get '/resources/*redirect_url', action: :show, controller: 'resources', as: 'resources_redirect', format: false
 
@@ -56,8 +56,8 @@ Rails.application.routes.draw do
   get '/privacy', to: 'pages#page', as: :privacy, defaults: { page_slug: 'privacy' }
   get '/secondary-certificate', to: 'pages#static_programme_page', as: :secondary, defaults: { page_slug: 'secondary-certificate' },
     constraints: ->(_request) { Programme.secondary_certificate.enrollable? }
-    get '/secondary-teachers', to: 'pages#page', as: :secondary_teachers, defaults: { page_slug: 'secondary-teachers' }
-    get '/primary-teachers', to: 'pages#page', as: :primary_teachers, defaults: { page_slug: 'primary-teachers' }
+    get '/secondary-teachers', to: 'landing_pages#secondary_teachers', as: :secondary_teachers, defaults: { slug: 'cs-accelerator' }
+    get '/primary-teachers', to: 'landing_pages#primary_teachers', as: :primary_teachers, defaults: { slug: 'primary-certificate' }
     get '/signup-confirmation', to: 'pages#page', as: :signup_confirmation, defaults: { page_slug: 'signup-confirmation' }
   get '/terms-conditions', to: 'pages#page', as: :terms_conditions, defaults: { page_slug: 'terms-conditions' }
 

--- a/spec/requests/landing_pages/teacher_pages_spec.rb
+++ b/spec/requests/landing_pages/teacher_pages_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe LandingPagesController do
+  let(:cs_accelerator) { create(:programme, slug: 'cs-accelerator') }
+  let(:primary_certificate) { create(:programme, slug: 'primary-certificate') }
+
+  describe '#primary_teachers' do
+    before do
+      primary_certificate
+      get primary_teachers_path
+    end
+
+    it 'renders the correct template' do
+      expect(response).to render_template('landing_pages/primary-teachers')
+    end
+  end
+
+  describe '#secondary_teachers' do
+    before do
+      cs_accelerator
+      get secondary_teachers_path
+    end
+
+    it 'renders the correct template' do
+      expect(response).to render_template('landing_pages/secondary-teachers')
+    end
+  end
+end

--- a/spec/views/dashboard/programmes/_hero.html_spec.rb
+++ b/spec/views/dashboard/programmes/_hero.html_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe('dashboard/programmes/_hero', type: :view) do
     end
 
     it 'shows the completed text' do
-      expect(rendered).to have_css('.card__status', text: 'Programme complete')
+      expect(rendered).to have_css('.status-block', text: 'Programme complete')
     end
   end
 
@@ -65,7 +65,7 @@ RSpec.describe('dashboard/programmes/_hero', type: :view) do
     end
 
     it 'shows the completed text' do
-      expect(rendered).to have_css('.card__status', text: 'Certificate awarded')
+      expect(rendered).to have_css('.status-block', text: 'Certificate awarded')
     end
   end
 end

--- a/spec/views/landing_pages/primary-teachers_html_spec.rb
+++ b/spec/views/landing_pages/primary-teachers_html_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe('pages/primary-teachers', type: :view) do
+RSpec.describe('landing_pages/primary-teachers', type: :view) do
   let(:programme) { create(:primary_certificate ) }
 
   before do

--- a/spec/views/landing_pages/secondary-teachers_html_spec.rb
+++ b/spec/views/landing_pages/secondary-teachers_html_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe('pages/secondary-teachers', type: :view) do
+RSpec.describe('landing_pages/secondary-teachers', type: :view) do
   let(:programme) { create(:cs_accelerator ) }
 
   before do

--- a/spec/views/pages/certification/_hero.html_spec.rb
+++ b/spec/views/pages/certification/_hero.html_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe('pages/certification/_hero', type: :view) do
 
 
   it 'doesn\'t show the enrolled tag' do
-    expect(rendered).not_to have_css('.hero__status', text: 'You are enrolled')
+    expect(rendered).not_to have_css('.status-block', text: 'You are enrolled')
   end
 
   context 'when the user logged in but not enrolled' do
@@ -30,7 +30,7 @@ RSpec.describe('pages/certification/_hero', type: :view) do
     end
 
     it 'doesn\'t show the enrolled tag' do
-      expect(rendered).not_to have_css('.hero__status', text: 'You are enrolled')
+      expect(rendered).not_to have_css('.status-block', text: 'You are enrolled')
     end
   end
 
@@ -42,7 +42,7 @@ RSpec.describe('pages/certification/_hero', type: :view) do
     end
 
     it 'shows the enrolled tag' do
-      expect(rendered).to have_css('.hero__status', text: 'You are enrolled')
+      expect(rendered).to have_css('.status-block', text: 'You are enrolled')
     end
   end
 end

--- a/spec/views/programmes/cs-accelerator/complete.html_spec.rb
+++ b/spec/views/programmes/cs-accelerator/complete.html_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe('programmes/cs-accelerator/complete', type: :view) do
   end
 
   it 'has a status' do
-    expect(rendered).to have_css('.hero__status', text: 'Certificate awarded')
+    expect(rendered).to have_css('.status-block', text: 'Certificate awarded')
   end
 
   it 'has the programme title' do

--- a/spec/views/programmes/primary-certificate/complete.html_spec.rb
+++ b/spec/views/programmes/primary-certificate/complete.html_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe('programmes/primary-certificate/complete', type: :view) do
   end
 
   it 'has a status' do
-    expect(rendered).to have_css('.hero__status', text: 'Certificate awarded')
+    expect(rendered).to have_css('.status-block', text: 'Certificate awarded')
   end
 
   it 'has the programme title' do

--- a/spec/views/programmes/secondary-certificate/complete.html_spec.rb
+++ b/spec/views/programmes/secondary-certificate/complete.html_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe('programmes/secondary-certificate/complete', type: :view) do
   end
 
   it 'has a status' do
-    expect(rendered).to have_css('.hero__status', text: 'Certificate awarded')
+    expect(rendered).to have_css('.status-block', text: 'Certificate awarded')
   end
 
   it 'has the programme title' do


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-568.herokuapp.com/
* Closes [822](https://github.com/NCCE/teachcomputing.org-issues/issues/822)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Move the landing pages to their own controller and set the @programme variable
- Refactor the 'status' block for cards to a re-useable template
- Share CSS for the status-block between hero and card
- Fix spec's and add simple ones for landing pages

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*