### PR TITLE
Fix margin below the 'status block' on card component

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -89,9 +89,9 @@
 .card > .status-block {
   @include status_block();
   display: inline-block;
-  margin-bottom: 20px;
+  margin-bottom: 10px;
   @include govuk-media-query($from: desktop) {
-    margin-bottom: 25px;
+    margin-bottom: 15px;
   }
 }
 


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Related to [822]()
## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Change the bottom margin on the status block to 15px (10px mobile)

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*