### PR TITLE
add before action to ensure user for resources feedback job

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -1,5 +1,6 @@
 class ResourcesController < ApplicationController
   layout 'full-width'
+  before_action :authenticate_user!, only: [:show]
 
   def index
     render :index

--- a/spec/requests/resources/show_spec.rb
+++ b/spec/requests/resources/show_spec.rb
@@ -2,8 +2,15 @@ require 'rails_helper'
 
 RSpec.describe ResourcesController do
   let(:redirect_url) { URI.encode_www_form_component('https://ncce.io/Year1') }
+  let(:user) { create(:user) }
+
 
   describe '#show' do
+    before do
+      allow_any_instance_of(AuthenticationHelper)
+        .to receive(:current_user).and_return(user)
+    end
+
     it 'renders the index template' do
       get resources_redirect_path(redirect_url: redirect_url, year: 1)
       expect(response).to redirect_to('https://ncce.io/Year1')


### PR DESCRIPTION
## Status

* Current Status: Ready
* Review App: *populate this once the PR has been created*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/865

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

A few tasks for feedback have been scheduled where no user has been set. Initial assumption was that given you can only click the link to visit the resources when you're logged in that would suffice. Iv now added the before action to the resources controller itself as well to ensure we know its there if we cannot rely on the latter. 