### PR TITLE
882: Add resource unit to Year 4

### DIFF
--- a/app/mailers/resources_feedback_mailer.rb
+++ b/app/mailers/resources_feedback_mailer.rb
@@ -4,14 +4,14 @@ class ResourcesFeedbackMailer < ApplicationMailer
     year = params[:year].to_s
 
     @feedback_links = { '1' => 'http://ncce.io/year1capture',
-                        '2' => 'http:////ncce.io/year2capture',
-                        '3' => 'http:////ncce.io/year3capture',
-                        '4' => 'http:////ncce.io/year4capture',
-                        '5' => 'http:////ncce.io/year5capture',
-                        '6' => 'http:////ncce.io/year6capture',
-                        '7' => 'http:////ncce.io/year7capture',
-                        '8' => 'http:////ncce.io/year8capture',
-                        '9' => 'http:////ncce.io/year9capture',
+                        '2' => 'http://ncce.io/year2capture',
+                        '3' => 'http://ncce.io/year3capture',
+                        '4' => 'http://ncce.io/year4capture',
+                        '5' => 'http://ncce.io/year5capture',
+                        '6' => 'http://ncce.io/year6capture',
+                        '7' => 'http://ncce.io/year7capture',
+                        '8' => 'http://ncce.io/year8capture',
+                        '9' => 'http://ncce.io/year9capture',
                         'KS4' => 'http://ncce.io/ks4capture' }
 
     @feedback_url = @feedback_links[year]

--- a/app/views/resources/_year-4.html.erb
+++ b/app/views/resources/_year-4.html.erb
@@ -1,0 +1,18 @@
+<div class="resources-year">
+  <h3 id="year-4" class="govuk-heading-m resources-year__heading">Year 4</h3>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column">
+      <div class="govuk-grid-column-two-thirds">
+        <ul class="govuk-list resources-year__lesson-list" aria-role="list">
+          <li>
+            <h4 class="govuk-heading-s resources-year__title">Creating media – Photo editing</h4>
+            <p class="govuk-body">In this unit, learners will develop their understanding of how digital images can be changed and edited, and how they can then be resaved and reused. They will consider the impact that editing images can have, and evaluate the effectiveness of their choices.</p>
+          </li>
+        </ul>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <%= render 'aside', year: 4, resource_url: 'https://ncce.io/Year4', live: true %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/resources/index.html.erb
+++ b/app/views/resources/index.html.erb
@@ -23,6 +23,7 @@
 <div class="govuk-width-container">
   <div class="govuk-main-wrapper">
     <%= render 'year-3' %>
+    <%= render 'year-4' %>
   </div>
 </div>
 <%= render 'key-stage-header', key_stage: 3, guide_url: '#' %>

--- a/spec/views/resources/index.html_spec.rb
+++ b/spec/views/resources/index.html_spec.rb
@@ -15,17 +15,17 @@ RSpec.describe('resources/index', type: :view) do
 
   it 'has year headings' do
     render
-    expect(rendered).to have_css('.resources-year__heading', count: 6)
+    expect(rendered).to have_css('.resources-year__heading', count: 7)
   end
 
   it 'has resource lists for each year' do
     render
-    expect(rendered).to have_css('.resources-year__lesson-list', count: 6)
+    expect(rendered).to have_css('.resources-year__lesson-list', count: 7)
   end
 
   it 'has asides for each year' do
     render
-    expect(rendered).to have_css('.resources-aside', count: 6)
+    expect(rendered).to have_css('.resources-aside', count: 7)
   end
 
   context 'when a user is not signed in' do


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-583.herokuapp.com/resources#year-4
* Closes [882](https://github.com/NCCE/teachcomputing.org-issues/issues/882)
## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Add template for year and one unit of work to this.
- Fix specs
- Also fix the extra slashes in the 'capture' URLs for resources feedback mailer
- Add ncce.io/Year4 url in short.cm

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*