### PR TITLE
Add stem_achiever_organisation_no

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   validates :email, presence: true
   validates :email, uniqueness: true
   validates :teacher_reference_number, uniqueness: true,
-    if: Proc.new { |u| u.teacher_reference_number.present? }
+                                       if: proc { |u| u.teacher_reference_number.present? }
 
   attr_encrypted :stem_credentials_access_token, key: ENV.fetch('STEM_CREDENTIALS_ACCESS_TOKEN_KEY')
   attr_encrypted :stem_credentials_refresh_token, key: ENV.fetch('STEM_CREDENTIALS_REFRESH_TOKEN_KEY')
@@ -19,7 +19,7 @@ class User < ApplicationRecord
   has_many :activities, through: :achievements
   has_many :assessment_attempts, dependent: :destroy
   has_many :user_programme_enrolments, dependent: :restrict_with_exception
-  has_many :programmes, through: :user_programme_enrolments 
+  has_many :programmes, through: :user_programme_enrolments
   has_many :resource_users
 
   after_commit :set_registered_with_ncce_achievement, on: :create
@@ -31,6 +31,7 @@ class User < ApplicationRecord
       user.last_name = info.last_name
       user.email = info.email.downcase
       user.stem_achiever_contact_no = info.achiever_contact_no
+      user.stem_achiever_organisation_no = info.achiever_organisation_no
       user.stem_credentials_access_token = credentials.token
       user.stem_credentials_refresh_token = credentials.refresh_token
       user.stem_credentials_expires_at = Time.zone.at(credentials.expires_at)
@@ -41,7 +42,7 @@ class User < ApplicationRecord
 
   def set_registered_with_ncce_achievement
     achievement = Achievement.create(user_id: id,
-                       activity_id: Activity.registered_with_the_national_centre.id)
+                                     activity_id: Activity.registered_with_the_national_centre.id)
     achievement.set_to_complete
   end
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -14,7 +14,8 @@ module OmniAuth::Strategies
         first_name: user_info['attributes']['firstName'][0],
         last_name: user_info['attributes']['lastName'][0],
         email: user_info['attributes']['mail'][0],
-        achiever_contact_no: user_info['attributes']['achieverContactNo'][0]
+        achiever_contact_no: user_info['attributes']['achieverContactNo'][0],
+        achiever_organisation_no: user_info['attributes']['achieverOrganisationNo'][0]
       }
     end
 
@@ -60,6 +61,7 @@ if ActiveModel::Type::Boolean.new.cast(ENV.fetch('BYPASS_OAUTH', false))
     },
     info: {
       achiever_contact_no: '94c52a7c-5001-45e3-82bd-949a882f5fb6',
+      achiever_organisation_no: 'dd748e4f-7c9a-4548-ba4e-8dd4a577f817',
       first_name: 'Web',
       last_name: 'Raspberry Pi',
       email: 'web@raspberrypi.org'

--- a/db/migrate/20200122145117_add_stem_achiever_organisation_no_to_user_model.rb
+++ b/db/migrate/20200122145117_add_stem_achiever_organisation_no_to_user_model.rb
@@ -1,0 +1,5 @@
+class AddStemAchieverOrganisationNoToUserModel < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :stem_achiever_organisation_no, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_10_120403) do
+ActiveRecord::Schema.define(version: 2020_01_22_145117) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
@@ -168,6 +169,7 @@ ActiveRecord::Schema.define(version: 2020_01_10_120403) do
     t.string "encrypted_stem_credentials_refresh_token"
     t.string "encrypted_stem_credentials_refresh_token_iv"
     t.string "teacher_reference_number"
+    t.string "stem_achiever_organisation_no"
     t.index ["stem_user_id"], name: "index_users_on_stem_user_id", unique: true
     t.index ["teacher_reference_number"], name: "index_users_on_teacher_reference_number", unique: true
   end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     last_name { 'Doe' }
     sequence(:email, 1000) { |n| "user#{n}@example.com" }
     sequence(:stem_achiever_contact_no, 1000) { |n| "achiever-#{n}" }
+    sequence(:stem_achiever_organisation_no, 1000) { |n| "organisation-#{n}" }
     sequence(:stem_user_id, 1000) { |n| "id-#{n}" }
     stem_credentials_access_token { 'CD355FC7DCCD9C7BB7E2C29F4BE3F' }
     stem_credentials_refresh_token { '7BF7E7C2EB515FBC5BA4D2F7B3E8B' }

--- a/spec/requests/auth/callback_spec.rb
+++ b/spec/requests/auth/callback_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe AuthController do
         },
         info: {
           achiever_contact_no: 'b44cb53f-c690-4535-bd79-89e893337ec6',
+          achiever_organisation_no: 'dd748e4f-7c9a-4548-ba4e-8dd4a577f817',
           first_name: 'Jane',
           last_name: 'Doe',
           email: 'user@example.com'
@@ -63,6 +64,7 @@ RSpec.describe AuthController do
           },
           info: {
             achiever_contact_no: 'b44cb53f-c690-4535-bd79-89e893337ec6',
+            achiever_organisation_no: 'dd748e4f-7c9a-4548-ba4e-8dd4a577f817',
             first_name: 'Jane',
             last_name: 'Doe',
             email: 'user@example.com'

--- a/spec/requests/auth/logout_spec.rb
+++ b/spec/requests/auth/logout_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe AuthController do
         },
         info: {
           achiever_contact_no: 'b44cb53f-c690-4535-bd79-89e893337ec6',
+          achiever_organisation_no: 'dd748e4f-7c9a-4548-ba4e-8dd4a577f817',
           first_name: 'Jane',
           last_name: 'Doe',
           email: 'user@example.com'


### PR DESCRIPTION
## Status

* Current Status: Ready
* Review App: *populate this once the PR has been created*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/889 

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Add stem_achiever_organisation_no to the user model which is grabbed during the OAuth exchange. We do not require this field so if it is `nil` the user can still register.

## Steps to perform after deploying to production