### PR TITLE
Change the UpdateUsersDetailsFromAchieverJob to skip validation

### DIFF
--- a/app/jobs/update_users_details_from_achiever_job.rb
+++ b/app/jobs/update_users_details_from_achiever_job.rb
@@ -16,13 +16,12 @@ class UpdateUsersDetailsFromAchieverJob < ApplicationJob
     if details
       achiever_organisation_no = details.send('Contact.COMPANYNO')
       if achiever_organisation_no.blank?
-        Rails.logger.warn "UpdateUsersDetailsFromAchieverJob: No achiever_organisation_no for user: #{user.id}"
+        Rails.logger.warn "UpdateUsersDetailsFromAchieverJob - No achiever_organisation_no for user: #{user.id}"
       else
-        user.stem_achiever_organisation_no = achiever_organisation_no
-        user.save!
+        user.update_attribute(:stem_achiever_organisation_no, achiever_organisation_no)
       end
     else
-      Rails.logger.warn "UpdateUsersDetailsFromAchieverJob: missing user: #{user.id}"
+      Rails.logger.warn "UpdateUsersDetailsFromAchieverJob - missing user: #{user.id}"
     end
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Related to [890](https://github.com/NCCE/teachcomputing.org-issues/issues/890)
## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Because it is throwing an exception when trying to validate encrypted fields.
We've checked the org no is not blank, so that is adequate, we are not updating any other fields.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*