### PR TITLE
957: Don't show empty aside if the user is enrolled on a course.

### DIFF
--- a/app/views/courses/_aside-section.html.erb
+++ b/app/views/courses/_aside-section.html.erb
@@ -1,7 +1,7 @@
-<div class="ncce-aside">
-  <% if current_user %>
-    <% case user_achievement_state(current_user, @activity) %>
-    <% when :not_enrolled %>
+<% if current_user %>
+  <% case user_achievement_state(current_user, @activity) %>
+  <% when :not_enrolled %>
+    <div class="ncce-aside">
       <h2 class="govuk-heading-m ncce-aside__title"><%= @course.online_cpd ? 'Join this course' : 'Book this course' %></h2>
       <p class="govuk-body-s ncce-aside__text"><%= @course.online_cpd ? 'The course is delivered by Future Learn' : 'The course is delivered by STEM Learning' %></p>
       <p class="govuk-body">
@@ -11,13 +11,15 @@
           end
         %>
       </p>
-    <% end %>
-  <% else %>
-    <h2 class="govuk-heading-m ncce-aside__title"><%= @course.online_cpd ? 'Join this course' : 'Book this course' %></h2>
-    <p class="govuk-body-s ncce-aside__text"> You need to be logged in to start the course.</p>
-    <p class="govuk-body"><%= link_to @course.online_cpd ? 'Join this course' : 'Book this course', auth_url, class: 'govuk-button button--aside', draggable: 'false' %></p>
-    <p class="govuk-body-s ncce-aside__text"> Not got a STEM Learning account?
-      <br>
-      <%= link_to 'Create an account', create_account_url, class: 'ncce-link', draggable: 'false' %></p>
+    </div>
   <% end %>
-</div>
+<% else %>
+  <div class="ncce-aside">
+    <h2 class="govuk-heading-m ncce-aside__title"><%= @course.online_cpd ? 'Join this course' : 'Book this course' %></h2>
+      <p class="govuk-body-s ncce-aside__text"> You need to be logged in to start the course.</p>
+      <p class="govuk-body"><%= link_to @course.online_cpd ? 'Join this course' : 'Book this course', auth_url, class: 'govuk-button button--aside', draggable: 'false' %></p>
+      <p class="govuk-body-s ncce-aside__text"> Not got a STEM Learning account?
+        <br>
+        <%= link_to 'Create an account', create_account_url, class: 'ncce-link', draggable: 'false' %></p>
+  </div>
+<% end %>


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [957](https://github.com/NCCE/teachcomputing.org-issues/issues/957)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Move the aside `<div>` inside the conditionals so we don't get the blue
top-border.


## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*