### PR TITLE
965: Add programme_id to the Achievement model.

### DIFF
--- a/app/models/achievement.rb
+++ b/app/models/achievement.rb
@@ -3,6 +3,7 @@ class Achievement < ApplicationRecord
 
   belongs_to :activity
   belongs_to :user
+  belongs_to :programme, optional: true
 
   validates :user_id, uniqueness: { scope: [:activity_id] }
 

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -5,6 +5,7 @@ class Programme < ApplicationRecord
   has_many :users, through: :user_programme_enrolments
   has_one  :assessment, dependent: :destroy
   has_one  :programme_complete_counter, dependent: :destroy
+  has_many :achievements, dependent: :nullify
 
   validates :title, :description, :slug, presence: true
 

--- a/db/migrate/20200226150022_add_programme_id_to_achievement.rb
+++ b/db/migrate/20200226150022_add_programme_id_to_achievement.rb
@@ -1,0 +1,7 @@
+class AddProgrammeIdToAchievement < ActiveRecord::Migration[5.2]
+  def change
+    add_column :achievements, :programme_id, :uuid, null: true
+    add_index :achievements, [:programme_id, :user_id], unique: false
+    add_index :achievements, [:activity_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_11_124610) do
+ActiveRecord::Schema.define(version: 2020_02_26_150022) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
@@ -33,6 +34,9 @@ ActiveRecord::Schema.define(version: 2020_02_11_124610) do
     t.uuid "activity_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "programme_id"
+    t.index ["activity_id", "user_id"], name: "index_achievements_on_activity_id_and_user_id", unique: true
+    t.index ["programme_id", "user_id"], name: "index_achievements_on_programme_id_and_user_id"
   end
 
   create_table "activities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/achievement_spec.rb
+++ b/spec/models/achievement_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe Achievement, type: :model do
     it 'belongs to user' do
       expect(achievement).to belong_to(:user)
     end
+
+    it 'belongs to programme' do
+      expect(achievement).to belong_to(:programme)
+    end
   end
 
   describe 'validations' do


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [965](https://github.com/NCCE/teachcomputing.org-issues/issues/965)
* Related to [966](https://github.com/NCCE/teachcomputing.org-issues/issues/966)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Add migration
- Add associations to model - optional for Achievement to have a programme.
- Add spec

## Steps to perform before deploying to production

A user has a duplicate Achievement for the Diagnostic Activity - looks like a 'double-tap' as the dates are the same.  We would need to remove one of these before we promote because the migration adds a unique index to user & activity on Achievement

user_id: db0e2bd4-bd62-4c9e-8049-4191af09e32c
activity_id: 17776939-fe88-465d-b9ca-403548103ffd (diagnostic)

```
u = User.find('db0e2bd4-bd62-4c9e-8049-4191af09e32c')
Activity.find('17776939-fe88-465d-b9ca-403548103ffd')
u.achievements.where(activity_id: '17776939-fe88-465d-b9ca-403548103ffd').count

u.achievements.where(activity_id: '17776939-fe88-465d-b9ca-403548103ffd').first.destroy
```
