### PR TITLE
973: Add online_cpd accessor method to Achievers Course Delegate API model

### DIFF
--- a/app/services/achiever/course/delegate.rb
+++ b/app/services/achiever/course/delegate.rb
@@ -1,5 +1,5 @@
 class Achiever::Course::Delegate
-  attr_accessor :course_template_no, :is_fully_attended
+  attr_accessor :course_template_no, :is_fully_attended, :online_cpd
 
   RESOURCE_PATH = 'Get?cmd=CoursesForCurrentDelegateByProgramme'.freeze
   PROGRAMME_NAME = 'ncce'.freeze
@@ -19,5 +19,6 @@ class Achiever::Course::Delegate
   def initialize(delegate_course)
     @course_template_no = delegate_course.send('Activity.COURSETEMPLATENO')
     @is_fully_attended = ActiveRecord::Type::Boolean.new.deserialize(delegate_course.send('Delegate.Is_Fully_Attended').downcase)
+    @online_cpd = delegate_course.send('OnlineCPD')
   end
 end

--- a/spec/models/services/achiever/courses/delegate_spec.rb
+++ b/spec/models/services/achiever/courses/delegate_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Achiever::Course::Delegate do
     it 'provides the required accessor methods' do
       expect(delegate).to respond_to(:course_template_no)
       expect(delegate).to respond_to(:is_fully_attended)
+      expect(delegate).to respond_to(:online_cpd)
     end
   end
 
@@ -34,7 +35,7 @@ RSpec.describe Achiever::Course::Delegate do
 
       it 'contains instances of Achiever::Course::Delegate' do
         expect(described_class.find_by_achiever_contact_number('id-101').first).to be_an Achiever::Course::Delegate
-      end 
+      end
     end
   end
 end

--- a/spec/support/achiever/courses/delegate.json
+++ b/spec/support/achiever/courses/delegate.json
@@ -33,6 +33,7 @@
         "Delegate.Progress": "157420002",
         "Activity.ImportedToITK": false,
         "Activity.COURSEOCCURRENCENO": "cf8903f9-91a2-4d08-ba41-596ea05b498d",
+        "OnlineCPD": false,
         "Activity.COURSETEMPLATENO": "92f4f86e-0237-4ecc-a905-2f6c62d6b5ae"
       },
       {
@@ -59,6 +60,7 @@
         "Delegate.Progress": "157420002",
         "Activity.ImportedToITK": false,
         "Activity.COURSEOCCURRENCENO": "cf8903f9-91a2-4d08-ba41-596ea05b498c",
+        "OnlineCPD": true,
         "Activity.COURSETEMPLATENO": "92f4f86e-0237-4ecc-a905-2f6c62d6b5ax"
       },
       {
@@ -85,6 +87,7 @@
         "Delegate.Progress": "157420002",
         "Activity.ImportedToITK": false,
         "Activity.COURSEOCCURRENCENO": "cf8903f9-91a2-4d08-ba41-596ea05b498c",
+        "OnlineCPD": false,
         "Activity.COURSETEMPLATENO": "92f4f86e-0237-4ecc-a905-2f6c62d6b5aw"
       }
     ]


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [973](https://github.com/NCCE/teachcomputing.org-issues/issues/973)
## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Add accessor method
- Update JSON stub
- Add spec

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*