### PR TITLE
967: Change for_programme scope on Achievement to use programme_id field

### DIFF
--- a/app/models/achievement.rb
+++ b/app/models/achievement.rb
@@ -13,7 +13,7 @@ class Achievement < ApplicationRecord
   has_many :achievement_transitions, autosave: false, dependent: :destroy
 
   scope :for_programme, lambda { |programme|
-    where('activity_id IN (SELECT activity_id FROM programme_activities WHERE programme_id = ?)', programme.id)
+    where(programme_id: programme.id)
   }
 
   scope :with_category, lambda { |category|

--- a/spec/models/achievement_spec.rb
+++ b/spec/models/achievement_spec.rb
@@ -2,16 +2,17 @@ require 'rails_helper'
 
 RSpec.describe Achievement, type: :model do
   let(:user) { create(:user) }
-  let(:achievement) { create(:achievement) }
+  let(:activity) { create(:activity) }
+  let(:programme) { create(:programme) }
+  let(:programme_activity) { create(:programme_activity, programme_id: programme.id, activity_id: activity.id) }
+
+  let(:achievement) { create(:achievement, activity_id: activity.id) }
   let(:achievement2) { create(:achievement) }
   let(:completed_achievement) { create(:completed_achievement) }
   let(:diagnostic_activity) { create(:activity, :cs_accelerator_diagnostic_tool) }
   let(:diagnostic_achievement) { create(:achievement, activity: diagnostic_activity) }
   let(:community_activity) { create(:activity, :community) }
   let(:community_achievement) { create(:achievement, activity: community_activity) }
-
-  let(:programme) { create(:programme) }
-  let(:programme_activity) { create(:programme_activity, programme_id: programme.id, activity_id: achievement.activity_id) }
 
   let(:cs_accelerator) { create(:cs_accelerator) }
   let(:achievement_with_passed_programme_id) {

--- a/spec/models/user_programme_achievements_spec.rb
+++ b/spec/models/user_programme_achievements_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe UserProgrammeAchievements do
     activities = [create(:activity, :future_learn, credit: 20), create(:activity, :future_learn, credit: 20)]
 
     activities.each do |activity|
-      create(:completed_achievement, user_id: user.id, activity_id: activity.id)
       create(:programme_activity, programme_id: programme.id, activity_id: activity.id)
+      create(:completed_achievement, user_id: user.id, activity_id: activity.id)
     end
   end
 

--- a/spec/models/user_programme_assessment_spec.rb
+++ b/spec/models/user_programme_assessment_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe UserProgrammeAssessment do
     activities = [create(:activity, :future_learn, credit: 20), create(:activity, :stem_learning, credit: 20)]
 
     activities.each do |activity|
-      create(:completed_achievement, user_id: user.id, activity_id: activity.id)
       create(:programme_activity, programme_id: programme.id, activity_id: activity.id)
+      create(:completed_achievement, user_id: user.id, activity_id: activity.id)
     end
   end
 


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [967](https://github.com/NCCE/teachcomputing.org-issues/issues/967)
* Related to [965](https://github.com/NCCE/teachcomputing.org-issues/issues/965) & [966](https://github.com/NCCE/teachcomputing.org-issues/issues/966)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Change Achievement.for_programme scope to use it's own programme_id field.
- Fix spec's to set programme on activity or programme_id of achievements before
- creating the actual achievement where we are calling for_programme


## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*