### PR TITLE
992: Update CSP to allow YouTube and Blog

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -5,9 +5,9 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
 Rails.application.config.content_security_policy do |policy|
-  policy.default_src :self, :https
+  policy.default_src :self, :https, 'youtube.com', 'www.youtube.com'
   policy.font_src    :self, :https, :data, 'fonts.gstatic.com'
-  policy.img_src     :self, :https, :data, 'view.vzaar.com'
+  policy.img_src     :self, :https, :data, 'view.vzaar.com', 'blog.teachcomputing.org'
   policy.media_src   :self, :https, :data, 'view.vzaar.com', 'download.vzaar.com'
   policy.object_src  :none
   policy.script_src  :self, :https, 'www.google-analytics.com', 'www.googletagmanager.com', 'tagmanager.google.com'


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [992](https://github.com/NCCE/teachcomputing.org-issues/issues/992)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Fix CSP to:

- Allow blog.teachcomputing.org images on website - some browsers enforcing img-src
- Allow www.youtube.com as a default-src because we embed the video on home page

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*