### PR TITLE
1043: Only email the user for resources feedback once.

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -8,10 +8,10 @@ class ResourcesController < ApplicationController
 
   def show
     redirect_url = URI.decode_www_form_component(params[:redirect_url])
-    
+
     if helpers.whitelist_redirect_url(redirect_url)
-      track_resources!
-      ScheduleUserResourcesFeedbackJob.set(wait: 7.days).perform_later(current_user, params[:year])
+      resource_user = track_resources!
+      ScheduleUserResourcesFeedbackJob.set(wait: 7.days).perform_later(resource_user.user, params[:year]) if resource_user.counter == 1
       return redirect_to redirect_url
     else
       return redirect_to root_path
@@ -24,5 +24,6 @@ class ResourcesController < ApplicationController
       resource_user = ResourceUser.find_or_create_by!(user_id: current_user.id, resource_year: params[:year])
       resource_user.counter = resource_user.counter + 1
       resource_user.save
+      resource_user
     end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [1043](https://github.com/NCCE/teachcomputing.org-issues/issues/1043)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Check the number of times the user has downloaded the resource and only schedule feedback email if it's the first time.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*