### PR TITLE
Ensure it returns if an enrolment does exist

### DIFF
--- a/app/jobs/assessment_eligibility_job.rb
+++ b/app/jobs/assessment_eligibility_job.rb
@@ -9,7 +9,7 @@ class AssessmentEligibilityJob < ApplicationJob
 
     enrolment = user.user_programme_enrolments.find_by(programme_id: programme.id)
 
-    return if enrolment.current_state == :complete.to_s
+    return if enrolment.nil? || enrolment.current_state == :complete.to_s
 
     # CsAcceleratorMailer.with(user: user).assesment_eligibility.deliver_now
   end

--- a/spec/jobs/assessment_eligibility_job_spec.rb
+++ b/spec/jobs/assessment_eligibility_job_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe AssessmentEligibilityJob, type: :job do
       .to change { ActionMailer::Base.deliveries.count }.by(0)
     end
 
+    it 'does not call CsAcceleratorMailer when the user does not have an enrolment' do
+      allow_any_instance_of(Programmes::CSAccelerator).to receive(:enough_activites_for_test?).with(user).and_return(true)
+      cs_accelerator_enrolment.destroy
+      expect { described_class.perform_now(user.id) }
+      .to change { ActionMailer::Base.deliveries.count }.by(0)
+    end
+
     # it 'does calls CsAcceleratorMailer' do
     # allow_any_instance_of(Programmes::CSAccelerator).to receive(:enough_activites_for_test?).with(user).and_return(true)
     #   expect { described_class.perform_now(user.id) }


### PR DESCRIPTION
## Status

* Current Status: Ready
* Review App: *populate this once the PR has been created*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1052
* Related to https://sentry.io/organizations/stem-learning/issues/1593900795/?project=1370995&referrer=github_integration

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Returns If an enrolment doesn't exist for a user 

## Steps to perform after deploying to production

Resolve the above Sentry alert. 