### PR TITLE
1069: Fix redirect in the TRN form.

### DIFF
--- a/app/views/programmes/cs-accelerator/10_hours/_exam.erb
+++ b/app/views/programmes/cs-accelerator/10_hours/_exam.erb
@@ -29,7 +29,7 @@
                   class: 'govuk-input ncce-input activity-list__item-trn-input',
                   'aria-label': 'Enter your teacher reference number'
               %>
-              <%= hidden_field_tag 'redirect_path', programme_path(@programme.slug) %>
+              <%= hidden_field_tag 'redirect_path', request.original_url %>
 							<%= f.submit 'Add', class: 'govuk-button button button--small' %>
             <% end %>
             <span class="">


### PR DESCRIPTION
Uses absolute URL in whitelist checking.

## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [1069](https://github.com/NCCE/teachcomputing.org-issues/issues/1069)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Change the redirect_param in form to full URL (temp fix as we will address this form correctly in [1023](https://github.com/NCCE/teachcomputing.org-issues/issues/1023)

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*