### PR TITLE
1023: Save TRN when trying to take the test.

### DIFF
--- a/app/controllers/assessment_attempts_controller.rb
+++ b/app/controllers/assessment_attempts_controller.rb
@@ -1,5 +1,7 @@
 class AssessmentAttemptsController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_assessment
+  before_action :teacher_reference_number, only: [:create]
 
   def create
     assessment_attempt = AssessmentAttempt.new(assessment_attempts_params)
@@ -27,5 +29,10 @@ class AssessmentAttemptsController < ApplicationController
 
     def assessment_url(user)
       "#{@assessment.link}&cm_e=#{user.email}&cm_user_id=#{user.id}"
+    end
+
+    def teacher_reference_number
+      trn = params.fetch(:user, {})[:teacher_reference_number]
+      current_user.update_attributes(teacher_reference_number: trn) if trn.present?
     end
 end

--- a/app/views/programmes/cs-accelerator/10_hours/_exam.erb
+++ b/app/views/programmes/cs-accelerator/10_hours/_exam.erb
@@ -15,34 +15,34 @@
           <li>You can’t skip a question</li>
         </ul>
         <p>You are allowed two initial attempts at the test before a 48 hour cool off period between each subsequent attempt. Good luck!</p>
-        <div class="activity-list__item-trn-box">
-          <% if current_user.teacher_reference_number.present? %>
-            <p>Teacher Reference Number: <%= current_user.teacher_reference_number %></p>
-          <% else %>
-            Teacher Reference Number <span class="govuk-body-s activity-list__item-trn-optional">(optional)</span><br>
-            <%= form_for(current_user, url: user_teacher_reference_number_path(current_user),
-                  html: {
-                    class: ''
-                  }
-                ) do |f| %>
-              <%= f.text_field :teacher_reference_number,
-                  class: 'govuk-input ncce-input activity-list__item-trn-input',
-                  'aria-label': 'Enter your teacher reference number'
-              %>
-              <%= hidden_field_tag 'redirect_path', request.original_url %>
-							<%= f.submit 'Add', class: 'govuk-button button button--small' %>
-            <% end %>
-            <span class="">
-              <%= link_to 'What is this?', 'https://www.gov.uk/guidance/individual-teacher-records-information-for-teachers#your-teacher-reference-number-trn', class: 'govuk-body-s ncce-link', target: '_blank' %>
-            </span>
-          <% end %>
-        </div>
+
         <% if @user_programme_assessment.currently_taking_test? %>
           <span>You are currently taking the test.  If you have recently failed, please come back in 2 hours.</span>
         <% elsif @user_programme_assessment.can_take_test_at != 0 %>
           <span>Your <%= to_word_ordinal(@user_programme_assessment.num_attempts + 1) %> attempt at the test can be done <strong>after <%= "#{(Time.zone.now + @user_programme_assessment.can_take_test_at).in_time_zone('London').strftime('%l%P on %A')}" %></strong>, please come back then!</span>
         <% else %>
-          <%= link_to 'Take the test', assessment_attempts_path(assessment_attempt: { assessment_id: @programme.assessment.id, user_id: current_user }), method: :post, class: 'govuk-button button govuk-!-margin-bottom-6' %>
+          <%= form_for(current_user, method: :post, url: assessment_attempts_path(assessment_attempt: { assessment_id: @programme.assessment.id, user_id: current_user }),
+              html: {
+                class: ''
+              }
+            ) do |f| %>
+            <div class="activity-list__item-trn-box">
+              <% if current_user.teacher_reference_number.present? %>
+                <p>Teacher Reference Number: <%= current_user.teacher_reference_number %></p>
+              <% else %>
+                Teacher Reference Number <span class="govuk-body-s activity-list__item-trn-optional">(optional)</span><br>
+                  <%= f.text_field :teacher_reference_number,
+                      class: 'govuk-input ncce-input activity-list__item-trn-input',
+                      'aria-label': 'Enter your teacher reference number'
+                  %>
+
+                <span class="">
+                  <%= link_to 'What is this?', 'https://www.gov.uk/guidance/individual-teacher-records-information-for-teachers#your-teacher-reference-number-trn', class: 'govuk-body-s ncce-link', target: '_blank' %>
+                </span>
+              <% end %>
+            </div>
+            <%= f.submit 'Take the test', class: 'govuk-button button govuk-!-margin-bottom-6' %>
+          <% end %>
         <% end %>
       </li>
     <% end %>

--- a/spec/requests/assessment_attempts/create_spec.rb
+++ b/spec/requests/assessment_attempts/create_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe AssessmentAttemptsController do
     before do
       user
       assessment
+      allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
     end
 
     context 'with valid params' do
@@ -27,7 +28,26 @@ RSpec.describe AssessmentAttemptsController do
           post assessment_attempts_path(assessment_attempt: { assessment_id: assessment.id, user_id: user.id })
         end.to have_enqueued_job(ExpireAssessmentAttemptJob)
       end
+
+      it 'doesn\'t store trn if not present' do
+        post assessment_attempts_path(assessment_attempt: { assessment_id: assessment.id, user_id: user.id })
+        expect(user.teacher_reference_number).to be(nil)
+      end
+
+      it 'stores the trn if it is present' do
+        path = assessment_attempts_path(assessment_attempt: {
+                                          assessment_id: assessment.id,
+                                          user_id: user.id
+                                        })
+        post path, params: {
+                      user: {
+                        teacher_reference_number: 'abc123'
+                      }
+                    }
+        expect(user.teacher_reference_number).to eq('abc123')
+      end
     end
+
     context 'with invalid params' do
       it 'raises ActiveRecord::RecordNotFound exception' do
         expect do


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [1023](https://github.com/NCCE/teachcomputing.org-issues/issues/1023)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Hide the AssessmentAttempt controller behind auth
Remove separate form for saving TRN - combine with 'Take the test'
Add before_action to AssessmentAttempt create to save the TRN
Add spec's to check.


## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*