### PR TITLE
1147: Disable sending assessment eligibility email until we get a fix...

### DIFF
--- a/app/jobs/assessment_eligibility_job.rb
+++ b/app/jobs/assessment_eligibility_job.rb
@@ -11,6 +11,6 @@ class AssessmentEligibilityJob < ApplicationJob
 
     return unless programme.enough_activites_for_test?(user)
 
-    CsAcceleratorMailer.with(user: user).assessment_eligibility.deliver_now
+    # CsAcceleratorMailer.with(user: user).assessment_eligibility.deliver_now
   end
 end

--- a/spec/jobs/assessment_eligibility_job_spec.rb
+++ b/spec/jobs/assessment_eligibility_job_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe AssessmentEligibilityJob, type: :job do
     end
 
     it 'does calls CsAcceleratorMailer' do
+      pending("Pending fix for unique email per user")
       allow_any_instance_of(Programmes::CSAccelerator).to receive(:enough_activites_for_test?).with(user).and_return(true)
       expect { described_class.perform_now(user.id) }
       .to change { ActionMailer::Base.deliveries.count }.by(1)


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes *add issue numbers or delete*
* Related to [1147](https://github.com/NCCE/teachcomputing.org-issues/issues/1147)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Disable sending assessment eligibility email  - so that we don't keep sending emails to the same people everytime they get another achievement beyond those required to take the test.
Will be reverted when we have a way of ensuring the people only get the email once.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*