### PR TITLE
1141: CSS rules for course page video / imagery from STEM API

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,7 +35,6 @@
 @import 'components/pages/_news.scss';
 @import 'components/pages/_resources.scss';
 @import 'components/pages/_secondary-teachers.scss';
-@import 'components/pages/_cms.scss';
 @import 'components/courses/_courses.scss';
 @import 'components/courses/_landing-page.scss';
 @import 'components/dashboard/_certification.scss';
@@ -48,3 +47,4 @@
 @import 'components/_table.scss';
 @import 'components/_confirmation.scss';
 @import 'components/welcome/_welcome.scss';
+@import 'components/_external-content.scss';

--- a/app/assets/stylesheets/components/_external-content.scss
+++ b/app/assets/stylesheets/components/_external-content.scss
@@ -1,4 +1,4 @@
-.cms-content {
+.external-content {
   font-family: $font-family-body;
 
   p {
@@ -57,7 +57,7 @@
 
   img,
   video {
-    width: 100%;
     margin-bottom: 20px;
+    width: 100%;
   }
 }

--- a/app/assets/stylesheets/components/courses/_landing-page.scss
+++ b/app/assets/stylesheets/components/courses/_landing-page.scss
@@ -33,21 +33,6 @@
 	padding: 1rem 1rem 0 1rem;
 }
 
-.course-summary {
-  @extend .govuk-body;
-  p {
-    @extend .govuk-body;
-  }
-
-  ul {
-    @extend .govuk-list, .govuk-list--bullet;
-  }
-
-	h2 {
-		@extend .govuk-heading-m;
-	}
-}
-
 .course-details__icons {
 	display: flex;
 	flex-direction: column;

--- a/app/views/cms/cms_page.html.erb
+++ b/app/views/cms/cms_page.html.erb
@@ -8,7 +8,7 @@
 <div class="govuk-width-container">
   <div class="govuk-main-wrapper govuk-main-wrapper--xl">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds cms-content">
+      <div class="govuk-grid-column-two-thirds external-content">
         <%= @page['html']&.html_safe %>
       </div>
     </div>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -10,7 +10,7 @@
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-body-m"><%= @course.meta_description %></h2>
         <%= render 'courses/courses-details' %>
-        <div class="course-summary govuk-!-margin-bottom-7">
+        <div class="external-content govuk-!-margin-bottom-7">
           <%= sanitize_stem_html @course.summary %>
           <%= sanitize_stem_html @course.outcomes %>
         </div>

--- a/spec/views/cms/cms_page.html_spec.rb
+++ b/spec/views/cms/cms_page.html_spec.rb
@@ -12,6 +12,6 @@ RSpec.describe('cms/cms_page', type: :view) do
   end
 
   it('renders the content') do
-    expect(rendered).to have_css('.cms-content', text: /This is a test page/)
+    expect(rendered).to have_css('.external-content', text: /This is a test page/)
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App: https://teachcomputing-staging-pr-783.herokuapp.com/courses/CO207/ && https://teachcomputing-staging-pr-783.herokuapp.com/bursary
* Closes [1141](https://github.com/NCCE/teachcomputing.org-issues/issues/1141)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Refactor:
Combine the CMS rules with those for external HTML from STEM into single
generic class wrapper.
Apply rules for video and images that may come from STEM.
Fix spec's for CMS pages.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*