### PR TITLE
1161: Re-instate the redirect back to the course page when logging in.

### DIFF
--- a/app/views/courses/_aside-section.html.erb
+++ b/app/views/courses/_aside-section.html.erb
@@ -17,7 +17,7 @@
   <div class="ncce-aside">
     <h2 class="govuk-heading-m ncce-aside__title"><%= @course.online_cpd ? 'Join this course' : 'Book this course' %></h2>
       <p class="govuk-body-s ncce-aside__text"> You need to be logged in to start the course.</p>
-      <p class="govuk-body"><%= link_to @course.online_cpd ? 'Join this course' : 'Book this course', auth_url, class: 'govuk-button button--aside', draggable: 'false' %></p>
+      <p class="govuk-body"><%= link_to @course.online_cpd ? 'Join this course' : 'Book this course', "#{auth_url}?source_uri=#{URI.escape(request.original_url)}", method: :post, class: 'govuk-button button--aside', draggable: 'false' %></p>
       <p class="govuk-body-s ncce-aside__text"> Not got a STEM Learning account?
         <br>
         <%= link_to 'Create an account', create_account_url, class: 'ncce-link', draggable: 'false' %></p>


### PR DESCRIPTION
## Status

* Current Status:/ Ready for (front-end / tech) review
* Review App: *populate this once the PR has been created*
* Closes [1161](https://github.com/NCCE/teachcomputing.org-issues/issues/1161)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

On course details page, when user is not logged in, add the source_uri to the button that initiates login so that the user ends up on the right page.
This seems to have dropped off when Course Details pages were added.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*