### PR TITLE
Add -moz-fit-content to fix error in firefox

### DIFF
--- a/app/assets/stylesheets/components/pages/_curriculum.scss
+++ b/app/assets/stylesheets/components/pages/_curriculum.scss
@@ -1,21 +1,21 @@
 .curriculum__title {
-	font-weight: 400;
-	line-height: 1.75rem;
+  font-weight: 400;
+  line-height: 1.75rem;
 }
 
 .curriculum__line {
-	border: 0.0625rem solid $concrete;
+  border: 0.0625rem solid $concrete;
   margin-bottom: 1.625rem;
 }
 
 .curriculum__list--item {
-	background-color: $concrete;
-	border-left-color: $jaffa;
-	border-left-style: solid;
- 	border-left-width: 0.5625rem;
-	font-weight: 500;
-	margin-bottom: 1rem !important;
-	padding: 1.3rem;
+  background-color: $concrete;
+  border-left-color: $jaffa;
+  border-left-style: solid;
+  border-left-width: 0.5625rem;
+  font-weight: 500;
+  margin-bottom: 1rem !important;
+  padding: 1.3rem;
 }
 
 .curriculum__list--item-purple {
@@ -27,154 +27,155 @@
 }
 
 .resources__wrapper {
-	padding-top: 3.125rem;
+  padding-top: 3.125rem;
 }
 
 .curriculum__tiles {
-	margin-top: 2.75rem;
-	padding-bottom: 1.375rem;
+  margin-top: 2.75rem;
+  padding-bottom: 1.375rem;
 
-	@include govuk-media-query($from: tablet) {
-		display: grid;
+  @include govuk-media-query($from: tablet) {
+    display: grid;
     grid-column-gap: 1rem;
     grid-row-gap: 1.5rem;
     grid-template-columns: 1fr 1fr;
     grid-template-rows: auto;
-	}
+  }
 
   @include govuk-media-query($from: desktop) {
     grid-template-columns: 1fr 1fr 1fr;
-		padding-bottom:  3.75rem;
+    padding-bottom: 3.75rem;
   }
 }
 
 .curriculum__tile {
-	background-image: image-url('unit.svg');
-	background-position: 1.25rem center;
-	background-repeat: no-repeat;
-	background-size: 2.2rem;
-	border: 0.125rem solid $aluminum;
-	border-radius: 0.5rem;
-	height: 1.6rem;
-	margin-bottom: 0.9375rem;
-	padding: 2.2rem 0;
-	padding-left: 5.5rem;
-	padding-right: 1.25rem;
+  background-image: image-url('unit.svg');
+  background-position: 1.25rem center;
+  background-repeat: no-repeat;
+  background-size: 2.2rem;
+  border: 0.125rem solid $aluminum;
+  border-radius: 0.5rem;
+  height: 1.6rem;
+  margin-bottom: 0.9375rem;
+  padding: 2.2rem 0;
+  padding-left: 5.5rem;
+  padding-right: 1.25rem;
 
-	@include govuk-media-query($from: tablet) {
-		align-items: center;
-  	display: flex;
-	}
+  @include govuk-media-query($from: tablet) {
+    align-items: center;
+    display: flex;
+  }
 
-	@include govuk-media-query($from: desktop) {
-		background-size: 3rem;
-		margin-bottom: 0;
-	}
+  @include govuk-media-query($from: desktop) {
+    background-size: 3rem;
+    margin-bottom: 0;
+  }
 }
 
 .curriculum__tile--heading {
-	font-weight: 500;;
-	margin-bottom: 0;
+  font-weight: 500;
+  margin-bottom: 0;
 }
 
 .curriculum__label {
-	background-color: $grey-dark-x;
-	color: $white;
-	font-weight: bold;
-	margin: 0;
-	padding: 0.3rem 0.675rem;
-	width: fit-content;
-	@include govuk-media-query($from: desktop) {
-		padding: 0.5rem 1rem;
-	}
+  background-color: $grey-dark-x;
+  color: $white;
+  font-weight: bold;
+  margin: 0;
+  padding: 0.3rem 0.675rem;
+  width: fit-content;
+  width: -moz-fit-content;
+  @include govuk-media-query($from: desktop) {
+    padding: 0.5rem 1rem;
+  }
 }
 
 .curriculum__rating {
-	align-items: center;
-	background-color: $foam;
-	display: flex;
-	height: 3.5rem;
-	justify-content: space-between;
-	padding: 1rem;
+  align-items: center;
+  background-color: $foam;
+  display: flex;
+  height: 3.5rem;
+  justify-content: space-between;
+  padding: 1rem;
 
-	img {
-		width: auto !important;
-	}
+  img {
+    width: auto !important;
+  }
 
-	@include govuk-media-query($from: tablet) {
-		display: block;
+  @include govuk-media-query($from: tablet) {
+    display: block;
     height: auto;
     text-align: center;
-	}
+  }
 
-	@include govuk-media-query($from: desktop) {
-		align-items: center;
-		display: flex;
-		height: 3.5rem;
-		justify-content: space-between;
-	}
+  @include govuk-media-query($from: desktop) {
+    align-items: center;
+    display: flex;
+    height: 3.5rem;
+    justify-content: space-between;
+  }
 }
 
 .curriculum__rating--submitted {
-	text-align: center;
+  text-align: center;
 }
 
 .curriculum__rating--text {
-	margin-bottom: 0 !important;
-	width: 55%;
+  margin-bottom: 0 !important;
+  width: 55%;
 
-	@include govuk-media-query($from: tablet) {
+  @include govuk-media-query($from: tablet) {
     padding-bottom: 1rem;
-  	width: 100%;
-	}
+    width: 100%;
+  }
 
-	@include govuk-media-query($from: desktop) {
-		padding-bottom: unset;
-		width: 55%;
-	}
+  @include govuk-media-query($from: desktop) {
+    padding-bottom: unset;
+    width: 55%;
+  }
 }
 
 .curriculum__rating--only-text {
-	margin-bottom: 0 !important;
+  margin-bottom: 0 !important;
   vertical-align: middle;
 }
 
 .curriculum__rating--thumb {
-	cursor: pointer;
-	height: 2.5rem;
-	transition: all .2s ease-in-out;
-	width: auto;
+  cursor: pointer;
+  height: 2.5rem;
+  transition: all 0.2s ease-in-out;
+  width: auto;
 }
 
 .curriculum__rating--thumb-up {
-	@include govuk-media-query($from: tablet) {
-		margin-right: 3rem;
-	}
-	@include govuk-media-query($from: desktop) {
-		margin-right: unset;
-	}
+  @include govuk-media-query($from: tablet) {
+    margin-right: 3rem;
+  }
+  @include govuk-media-query($from: desktop) {
+    margin-right: unset;
+  }
 }
 
-
-
 .curriculum__rating--thumb:hover {
-		transform: scale(1.2);
+  transform: scale(1.2);
 }
 
 .curriculum__rating--thumb-up:hover {
-	filter: invert(58%) sepia(96%) saturate(435%) hue-rotate(45deg) brightness(93%) contrast(107%);
+  filter: invert(58%) sepia(96%) saturate(435%) hue-rotate(45deg)
+    brightness(93%) contrast(107%);
 }
 
 .curriculum__rating--thumb-down:hover {
-	filter: invert(25%) sepia(64%) saturate(5006%) hue-rotate(1deg) brightness(99%) contrast(84%);
+  filter: invert(25%) sepia(64%) saturate(5006%) hue-rotate(1deg)
+    brightness(99%) contrast(84%);
 }
 
 @media screen and (prefers-reduced-motion: reduce) {
-	.curriculum__rating--thumb {
-		transform: none;
-	}
+  .curriculum__rating--thumb {
+    transform: none;
+  }
 
-	.curriculum__rating--thumb:hover {
-		transform: none;
-	}
+  .curriculum__rating--thumb:hover {
+    transform: none;
+  }
 }


### PR DESCRIPTION
## Status

* Current Status: Ready fo front-end review
* Review App: *populate this once the PR has been created*
* Closes tc#1343

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Currently Titles in firefox display with a full background bar as `width: fit-content` is invalid in firefox:
![Screenshot 2020-08-06 at 14 02 46](https://user-images.githubusercontent.com/6632347/89535035-c032d800-d7ed-11ea-9513-431c92a3a2e9.png)

Add the `width: -moz-fit-content` property so it displays as expected:
![Screenshot 2020-08-06 at 14 02 57](https://user-images.githubusercontent.com/6632347/89535064-ce80f400-d7ed-11ea-9c60-db1901b56f53.png)

Also converts a load of tabs to spaces :/