### PR TITLE
Search for user by id before email when processing future learn export

### DIFF
--- a/app/jobs/process_future_learn_csv_export_job.rb
+++ b/app/jobs/process_future_learn_csv_export_job.rb
@@ -7,7 +7,8 @@ class ProcessFutureLearnCsvExportJob < ApplicationJob
     @primary_certificate_user_ids = []
 
     CSV.parse(csv_contents, headers: true).each do |record|
-      user = User.find_by('email ILIKE ?', record['learner_identifier'])
+      user = User.find_by(id: record['learner_identifier'])
+      user ||= User.find_by('email ILIKE ?', record['learner_identifier'])
       next if user.nil?
 
       activity = fetch_activity(record)

--- a/spec/jobs/process_future_learn_csv_export_job_spec.rb
+++ b/spec/jobs/process_future_learn_csv_export_job_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe ProcessFutureLearnCsvExportJob, type: :job do
   let!(:user_four) { create(:user, email: 'user4@example.com') }
   let!(:user_five) { create(:user, email: 'user5@example.com') }
   let!(:user_six) { create(:user, email: 'user6@example.com') }
+  let!(:id_user) { create(:user, id: '83b9d231-ed72-47d1-87ad-d985f4182ff1') }
+
   let(:dropped_achievement) { create(:achievement, user_id: user_six.id, activity_id: activity_two.id) }
   let(:another_dropped_achievement) { create(:achievement, user_id: user_two.id, activity_id: activity_two.id) }
   let(:completed_achievement) { create(:achievement, user_id: user_four.id, activity_id: activity_two.id) }
@@ -126,8 +128,14 @@ RSpec.describe ProcessFutureLearnCsvExportJob, type: :job do
       end
     end
 
+    context 'when learner_identifier is user id' do
+      it 'creates an achievement' do
+        expect(id_user.achievements.where(activity_id: activity_one.id).exists?).to eq true
+      end
+    end
+
     it 'queues PrimaryCertificatePendingTransitionJob job for complete courses' do
-      expect(PrimaryCertificatePendingTransitionJob).to have_been_enqueued.exactly(:twice)
+      expect(PrimaryCertificatePendingTransitionJob).to have_been_enqueued.exactly(3).times
     end
 
     it 'queues AssessmentEligibilityJob once for cs-accelerator per user' do

--- a/spec/support/test_future_learn_export.csv
+++ b/spec/support/test_future_learn_export.csv
@@ -13,3 +13,4 @@ run_start_date,membership_id,learner_identifier,full_name,fl_profile_url,steps_c
 2019-01-07,2,user2@example.com,Name 2,https://www.futurelearn.com/profiles/2,45%,0,0%,,5678,
 2019-01-07,2,user2@example.com,Name 2,https://www.futurelearn.com/profiles/2,45%,0,0%,,2222,
 2019-01-07,2,user2@example.com,Name 2,https://www.futurelearn.com/profiles/2,45%,0,0%,,3333,
+2019-01-07,1,83b9d231-ed72-47d1-87ad-d985f4182ff1,Name 1,https://www.futurelearn.com/profiles/1,61%,1,0%,,1234,


### PR DESCRIPTION
When LTI launch comes into effect we will start to see users IDs being passed as their learner identifier

## Status

* Current Status: Ready for review
* Review App: *populate this once the PR has been created*
* Closes tc#1386

## Review progress:

- [ ] Tech review completed

## What's changed?

* Try to find user by id matching learner_identifier
* If no match try and match email to learner_identifier
