### PR TITLE
Cache graphql query responses for 12 hours

### DIFF
--- a/app/services/achiever/request.rb
+++ b/app/services/achiever/request.rb
@@ -3,7 +3,12 @@ class Achiever::Request
     def option_sets(resource_path, query = {})
       query_string = query_strings(query)
 
-      response = Rails.cache.fetch(resource_path, expires_in: 1.day) do
+      response = Rails.cache.fetch(
+        resource_path,
+        expires_in: 1.day,
+        race_condition_ttl: 20.seconds,
+        namespace: 'achiever'
+      ) do
         api.get("#{resource_path}&#{query_string}")
       end
 

--- a/app/services/curriculum_client/request.rb
+++ b/app/services/curriculum_client/request.rb
@@ -12,7 +12,12 @@ module CurriculumClient
       begin
         return client.execute(query, params).data unless query.definition_node.operation_type == 'query'
 
-        Rails.cache.fetch(params.to_s, expires_in: 12.hours) do
+        Rails.cache.fetch(
+          params.to_s,
+          expires_in: 12.hours,
+          race_condition_ttl: 20.seconds,
+          namespace: 'curriculum'
+        ) do
           json_response = client.execute(query, params)
                                 .data
                                 .to_h


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App: https://teachcomputing-staging-pr-927.herokuapp.com/curriculum
* Related to tc#1314

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Caches responses to query requests sent to the curriculum graphql api.

The actual response comes back as an anonymous class, which can't be cached. So the response is converted to a hash, the hash keys converted to snake_case and then then converted to json. The json is then parsed into an OpenStruct to make its properties available as methods. Converting to json before parsing to a struct preserves nested values and allows chaining method calls.
Converting the data this way and then creating an OpenStruct means the final object responds to all the same methods that the graphql response class did. So there are no changes to any of the views or helpers needed.

* Mutations are not cached 
* Cache duration set for 12 hours
