### PR TITLE
Add GCSE specifications map pdf links

### DIFF
--- a/app/views/pages/cs-accelerator.html.erb
+++ b/app/views/pages/cs-accelerator.html.erb
@@ -13,6 +13,9 @@
           </li>
           <li>Access a network of on and offline support to guide you through your professional development journey</li>
           <li>Obtain a professionally-recognised training certificate, awarded by BCS, The Chartered Institute for IT</li>
+          <li>
+            Map your professional development to the <%= link_to ' GCSE computer science specifications (September 2020)', 'https://static.teachcomputing.org/GCSE_specifications_to_CSA_course_map.pdf', class: 'ncce-link' %> from AQA, OCR, and Pearson Edexcel.
+          </li>
         </ul>
         <%= render 'pages/certification/pathway' %>
 				<h2 class="govuk-heading-s">Funding your programme</h2>

--- a/app/views/programmes/cs-accelerator/_aside.html.erb
+++ b/app/views/programmes/cs-accelerator/_aside.html.erb
@@ -2,7 +2,9 @@
   <h2 class="govuk-heading-s ncce-aside__title">Support</h2>
   <p class='govuk-body-s'>We are happy to support you along the way. Call 020 0234 5678 or email <%= mail_to 'info@teachcomputing.org', 'info@teachcomputing.org', class: 'ncce-link' %>.</p>
   <p class="govuk-body-s">Have a question about your activities on this page?  Check out our <%= link_to 'Frequently Asked Questions', faq_courses_path, class: 'ncce-link' %></p>
-  <p class="govuk-body-s">Need to catch up on your learning? <%= link_to 'Download our Handbook', 'https://static.teachcomputing.org/CS_Accelerator_handbook.pdf', class: 'ncce-link' %></p>
+  <p class="govuk-body-s">Need to catch up on your learning?</p>
+  <p class="govuk-body-s"><%= link_to 'Download our Handbook', 'https://static.teachcomputing.org/CS_Accelerator_handbook.pdf', class: 'ncce-link' %></p>
+  <p class="govuk-body-s"><%= link_to 'Download our GCSE Specification Map', 'https://static.teachcomputing.org/GCSE_specifications_to_CSA_course_map.pdf', class: 'ncce-link' %></p>
 	<h2 class="govuk-heading-s ncce-aside__title">Learning pathways for teachers</h2>
 	<p class="govuk-body-s">Are you an aspiring computing teacher or are you unsure about your level of experience? Our learning pathways will help you to get started and offer a structured route through the programme:</p>
 	<p class="govuk-body-s govuk-!-margin-bottom-2"><%= link_to 'Advanced GCSE computer science', 'https://static.teachcomputing.org/pathways/05_Teaching_advanced_GCSE_computer_science.pdf', class: 'ncce-link' %>

--- a/spec/views/programmes/cs-accelerator/_aside.html_spec.rb
+++ b/spec/views/programmes/cs-accelerator/_aside.html_spec.rb
@@ -15,8 +15,13 @@ RSpec.describe('programmes/cs-accelerator/_aside', type: :view) do
     expect(rendered).to have_link('Frequently Asked Questions', href: '/faq/courses')
   end
 
-  it 'renders a link to  the handbook' do
+  it 'renders a link to the handbook' do
     render
     expect(rendered).to have_link('Download our Handbook', href: 'https://static.teachcomputing.org/CS_Accelerator_handbook.pdf')
+  end
+
+  it 'renders a link to the GCSE specification map' do
+    render
+    expect(rendered).to have_link('Download our GCSE Specification Map', href: 'https://static.teachcomputing.org/GCSE_specifications_to_CSA_course_map.pdf')
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App: https://teachcomputing-staging-pr-936.herokuapp.com/cs-accelerator (logged out page)
* Closes tc#1414
* Related to *add issue numbers or delete*

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Add link to GCSE specifications map pdf from cs-accelerator pages.
