### PR TITLE
Skip basic auth no admin api endpoints

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,5 +1,6 @@
 class AdminController < ApplicationController
   protect_from_forgery unless: -> { request.format.json? }
+  skip_before_action :authenticate
   before_action :authenticate_api
 
   def authenticate_api

--- a/spec/services/certificate_generator_spec.rb
+++ b/spec/services/certificate_generator_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe CertificateGenerator do
 
   let(:transition) do
     user_programme_enrolment.transition_to(:complete, certificate_number: 20)
-    user_programme_enrolment.reload.last_transition
+    transition = user_programme_enrolment.reload.last_transition
+    transition.update_attribute(:created_at, Date.new(2020, 10, 1))
+    transition
   end
 
   let(:generator) do
@@ -45,7 +47,7 @@ RSpec.describe CertificateGenerator do
       expect(generator.generate_pdf)
         .to eq(
           {
-            filename: 'gcse-computer-science-subject-knowledge-certificate-202009-020.pdf',
+            filename: 'gcse-computer-science-subject-knowledge-certificate-202010-020.pdf',
             path: 'tmp/test_generated_certificate.pdf'
           }
         )


### PR DESCRIPTION
Fix test that has dependency on date.

## Status

* Current Status: Ready for review
* Review App: *populate this once the PR has been created*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1435


## What's changed?

* Skip basic auth for admin api endpoints. A bearer token is required for these endpoints to secure them, and having the bearer token and basic auth in place means making requests from rest clients like Postman or Insomnia doesn't work.
* Fixed a failing test that had a dependency on the date a record is created