### PR TITLE
Fix date format on course details

### DIFF
--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -54,8 +54,8 @@ module CoursesHelper
   end
 
   def online_course_date(start_date)
-    date = Date.parse(start_date, '%-d %B')
-    return "Register now (Starts on #{date})" if date.future?
+    date = Date.parse(start_date)
+    return "Register now (Starts on #{date.strftime('%-d %B %Y')})" if date.future?
 
     'Join now'
   end

--- a/spec/helpers/courses_helper_spec.rb
+++ b/spec/helpers/courses_helper_spec.rb
@@ -104,12 +104,17 @@ describe CoursesHelper, type: :helper do
   end
 
   describe('#online_course_date') do
-    it 'returns Join Now when it is in the present' do
-      expect(helper.online_course_date(DateTime.now.change(year: 2021).to_s)).to include 'Register now'
+    context 'when the date is past' do
+      it 'returns Join Now' do
+        expect(helper.online_course_date(DateTime.now.to_s)).to eq 'Join now'
+      end
     end
 
-    it 'returns register when it is in the future' do
-      expect(helper.online_course_date(DateTime.now.to_s)).to eq 'Join now'
+    context 'when the date is in the future' do
+      it 'returns correctly' do
+        expect(helper.online_course_date(DateTime.new(3020, 10, 1).to_s))
+          .to eq('Register now (Starts on 1 October 3020)')
+      end
     end
   end
 


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App: *populate this once the PR has been created*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1444


## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Amend date format on course information page currently it is `2020-10-5` but it should be `5 October 2020` to be consistent with the rest of the site.
* Also the tests were the wrong way round

<img width="698" alt="Screenshot 2020-10-02 at 13 58 06" src="https://user-images.githubusercontent.com/6632347/94925590-5ebe7b00-04b7-11eb-8adf-c4ec3308fc12.png">
