### PR TITLE
use steps_completed_ratio instead of count

### DIFF
--- a/app/jobs/future_learn/update_user_activity_job.rb
+++ b/app/jobs/future_learn/update_user_activity_job.rb
@@ -14,7 +14,7 @@ module FutureLearn
       return if achievement.complete?
 
       achievement.update_state_for_online_activity(
-        enrolment[:steps_completed_count].to_f,
+        enrolment[:steps_completed_ratio].to_f * 100,
         enrolment[:deactivated_at]
       )
 

--- a/spec/jobs/future_learn/update_user_activity_job_spec.rb
+++ b/spec/jobs/future_learn/update_user_activity_job_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe FutureLearn::UpdateUserActivityJob, type: :job do
         run_job
         expect(mock_instance)
           .to have_received(:update_state_for_online_activity)
-          .with(enrolment[:steps_completed_count].to_f,
+          .with(enrolment[:steps_completed_ratio].to_f * 100,
                 enrolment[:deactivated_at])
       end
     end
@@ -53,7 +53,7 @@ RSpec.describe FutureLearn::UpdateUserActivityJob, type: :job do
         run_job
         expect(mock_instance)
           .to have_received(:update_state_for_online_activity)
-          .with(enrolment[:steps_completed_count].to_f,
+          .with(enrolment[:steps_completed_ratio].to_f * 100,
                 enrolment[:deactivated_at])
       end
     end
@@ -71,7 +71,7 @@ RSpec.describe FutureLearn::UpdateUserActivityJob, type: :job do
           build(:fl_enrolment,
                 run_uuid: run_uuid,
                 membership_uuid: membership_id,
-                steps_completed_count: 90)
+                steps_completed_ratio: 0.9)
         end
 
         it 'queues CertificatePendingTransitionJob' do
@@ -96,7 +96,7 @@ RSpec.describe FutureLearn::UpdateUserActivityJob, type: :job do
           build(:fl_enrolment,
                 run_uuid: run_uuid,
                 membership_uuid: membership_id,
-                steps_completed_count: 90)
+                steps_completed_ratio: 0.9)
         end
 
         it 'queues AssessmentEligibilityJob' do
@@ -121,7 +121,7 @@ RSpec.describe FutureLearn::UpdateUserActivityJob, type: :job do
           build(:fl_enrolment,
                 run_uuid: run_uuid,
                 membership_uuid: membership_id,
-                steps_completed_count: 77)
+                steps_completed_ratio: 0.77)
         end
 
         it 'queues CertificatePendingTransitionJob' do


### PR DESCRIPTION
## Status

* Current Status: 

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Use steps completed ratio instead of count as it differs from CSV

## Steps to perform after deploying to production

- Run the import 
