### PR TITLE
Remove rails-erd to solve dev issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,6 @@ end
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'listen', '>= 3.0.5', '< 3.2'
-  gem 'rails-erd'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console', '>= 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,6 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    choice (0.2.0)
     cloudflare-rails (0.4.0)
       httparty
       rails (~> 5.0)
@@ -316,11 +315,6 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-erd (1.6.0)
-      activerecord (>= 4.2)
-      activesupport (>= 4.2)
-      choice (~> 0.2.0)
-      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     railties (5.2.4.4)
@@ -404,8 +398,6 @@ GEM
       rubocop-ast (>= 1.1.0)
     ruby-debug-ide (0.7.2)
       rake (>= 0.8.1)
-    ruby-graphviz (1.2.5)
-      rexml
     ruby-progressbar (1.10.1)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.2)
@@ -563,7 +555,6 @@ DEPENDENCIES
   rack-cors
   rails (~> 5.2.4)
   rails-controller-testing
-  rails-erd
   redis-rails (~> 5.0.2)
   reek
   rest-client (~> 2.0.2)


### PR DESCRIPTION
## Status

* Current Status: Ready

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Resolves issue in dev due to graphviz not being available in the apline binary.

```
web_1      | Unable to find GraphViz's "dot" executable. Please visit https://voormedia.github.io/rails-erd/install.html for installation instructions.
web_1      | /usr/local/bundle/gems/rails-erd-1.6.0/lib/rails_erd/tasks.rake:11:in `block (2 levels) in <top (required)>'
web_1      | /usr/local/bundle/gems/rails-erd-1.6.0/lib/tasks/auto_generate_diagram.rake:18:in `update_model'
web_1      | /usr/local/bundle/gems/rails-erd-1.6.0/lib/tasks/auto_generate_diagram.rake:3:in `block (2 levels) in <top (required)>'
web_1      | /usr/local/bundle/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
web_1      | /usr/local/bin/bundle:30:in `block in <main>'
web_1      | /usr/local/bin/bundle:22:in `<main>'
web_1      | Tasks: TOP => erd => erd:generate => erd:check_dependencies
web_1      | (See full trace by running task with --trace)
web_1      | Faking OAuth login for review apps
```
## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
