### PR TITLE
Hide download link and rating partial if no zipped contents

### DIFF
--- a/app/views/curriculum/lessons/show.html.erb
+++ b/app/views/curriculum/lessons/show.html.erb
@@ -34,8 +34,10 @@
 						<li>Activities</li>
 					</ul>
           <% if current_user %>
-            <%= link_to 'Download all lesson files', generate_download_url(@lesson.zipped_contents), class: 'govuk-button button button--aside govuk-!-margin-bottom-7' %>
-					  <%= render partial: 'curriculum/rating', locals: { path: :create_curriculum_lesson_rating_path, comment_path: :update_curriculum_lesson_rating, id: @lesson.id, user_id: current_user.id } %>
+            <% if @lesson.zipped_contents.present? %>
+              <%= link_to 'Download all lesson files', generate_download_url(@lesson.zipped_contents), class: 'govuk-button button button--aside govuk-!-margin-bottom-7' %>
+              <%= render partial: 'curriculum/rating', locals: { path: :create_curriculum_lesson_rating_path, comment_path: :update_curriculum_lesson_rating, id: @lesson.id, user_id: current_user.id } %>
+            <% end %>
           <% else %>
             <%= link_to 'Log in to download', "#{auth_url}?source_uri=#{URI.escape(request.original_url)}", method: :post, :class => 'govuk-button button button--aside govuk-!-margin-bottom-7' %>
             <p class="govuk-body-s ncce-aside__text">Not registered yet?</p>


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Related to https://github.com/NCCE/teachcomputing.org-issues/issues/1560

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* If zipped_contents is not present don't try to show the link as generating the url will error
* Also hide the rating partial as it seems odd to ask to rate something that you can't download

This should only happen if a user requests a lesson page while the zipped_contents are being changed. Once new zipped_contents are uploaded the page will function as normal.

