### PR TITLE
1531: Add routes for cms pages, only set 100% width on specific pages…

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -56,3 +56,7 @@
 // Blog styles
 
 @import 'components/blog/_ghost-news-feed.scss';
+
+// CMS styles
+
+@import 'components/cms/_shared.scss';

--- a/app/assets/stylesheets/components/_external-content.scss
+++ b/app/assets/stylesheets/components/_external-content.scss
@@ -62,12 +62,6 @@
     @extend .govuk-list--number;
   }
 
-  img,
-  video {
-    margin-bottom: 20px;
-    width: 100%;
-  }
-
   a {
     @extend .govuk-link;
     @extend .ncce-link;

--- a/app/assets/stylesheets/components/cms/_shared.scss
+++ b/app/assets/stylesheets/components/cms/_shared.scss
@@ -1,0 +1,13 @@
+.home-teaching, .pedagogy {
+  img,
+  video {
+    margin-bottom: 20px;
+    width: 100%;
+  }
+}
+
+.subject-practitioners {
+  table tr td {
+    border-bottom: none;
+  }
+}

--- a/app/controllers/cms_controller.rb
+++ b/app/controllers/cms_controller.rb
@@ -3,7 +3,13 @@ class CmsController < ApplicationController
 
   def cms_page
     @page = Ghost.new.get_single_page(params[:page_slug])
+    @parent_slug = get_parent_slug
     render :cms_page
+  end
+
+  def get_parent_slug
+    route = request.env['PATH_INFO'].split('/').reject { |el| el.empty? }
+    parent = route[0] || ''
   end
 
   def clear_page_cache

--- a/app/views/cms/cms_page.html.erb
+++ b/app/views/cms/cms_page.html.erb
@@ -8,7 +8,7 @@
 <div class="govuk-width-container">
   <div class="govuk-main-wrapper govuk-main-wrapper--xl">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds external-content">
+      <div class="govuk-grid-column-two-thirds external-content <%= @parent_slug %>">
         <%= @page['html']&.html_safe %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,15 +86,14 @@ Rails.application.routes.draw do
   get '/auth/stem', to: redirect('/login')
   get '/auth/callback', to: 'auth#callback', as: 'callback'
   get '/bursary', to: 'cms#cms_page', as: :bursary, defaults: { page_slug: 'bursary' }
-  get '/bursary/refresh', to: 'cms#clear_page_cache', defaults: { page_slug: 'bursary' }
   get '/careers-week', to: 'pages#page', as: :careers_week, defaults: { page_slug: 'careers-week' }
   get '/cms/:page_slug', action: :cms_page, controller: :cms, as: :cms_page, defaults: { page_slug: 'hubs' }
-  get '/cms/:page_slug/refresh', action: :clear_page_cache, controller: :cms, as: :clear_page_cache, defaults: { page_slug: 'hubs' }
+  get '/:page_slug/refresh', action: :clear_page_cache, controller: :cms, as: :clear_page_cache_flat, defaults: { page_slug: 'hubs' }
+  get '/:page_slug/:page_slug/refresh', action: :clear_page_cache, controller: :cms, as: :clear_page_cache_flat_nested, defaults: { page_slug: 'hubs' }
   get '/competition-terms-and-conditions', to: 'pages#page', as: :competition_terms_and_conditions, defaults: { page_slug: 'competition-terms-and-conditions' }
   get '/cs-accelerator', to: 'pages#static_programme_page', as: :cs_accelerator, defaults: { page_slug: 'cs-accelerator' }
   get '/external/assets/ncce.css', to: 'asset_endpoint#css_endpoint', as: :css_endpoint
   get '/faq/courses/', to: 'cms#cms_page', as: :faq_courses, defaults: { page_slug: 'faq-courses' }
-  get '/faq/courses/refresh', to: 'cms#clear_page_cache', defaults: { page_slug: 'faq-courses' }
   get '/fl-trailers', to: 'pages#page', as: :trailers, defaults: { page_slug: 'fl-trailers' }
   get '/gender-balance', to: 'pages#page', as: :gender_balance, defaults: { page_slug: 'gender-balance' }
   get '/get-involved', to: 'pages#page', as: :get_involved, defaults: { page_slug: 'get-involved' }
@@ -102,14 +101,12 @@ Rails.application.routes.draw do
   get '/home-teaching', to: 'pages#page', as: :home_teaching, defaults: { page_slug: 'home-teaching' }
   get '/hero-demo', to: 'pages#page', as: :hero_demo, defaults: { page_slug: 'hero-demo' }
   get '/home-teaching/:page_slug', to: 'cms#cms_page', as: :cms_home_teaching_page, defaults: { page_slug: 'key-stage-1' }
-  get '/home-teaching/:page_slug/refresh', to: 'cms#clear_page_cache', as: :clear_home_teaching_page_cache, defaults: { page_slug: 'key-stage-1' }
   get '/hubs', to: 'cms#cms_page', as: :hubs, defaults: { page_slug: 'hubs' }
   get '/login', to: 'pages#login', as: :login
   get '/logout', to: 'auth#logout', as: :logout
   get '/maintenance', to: 'pages#page', as: :maintenance, defaults: { page_slug: 'maintenance' }
   get '/contributing-partners', to: 'pages#page', as: :contributing_partners, defaults: { page_slug: 'contributing-partners' }
   get '/pedagogy', to: 'cms#cms_page', as: :pedagogy, defaults: { page_slug: 'pedagogy' }
-  get '/pedagogy/refresh', to: 'cms#clear_page_cache', defaults: { page_slug: 'pedagogy' }
   get '/primary-certificate', to: 'pages#static_programme_page', as: :primary, defaults: { page_slug: 'primary-certificate' }
   get '/primary-senior-leaders', to: 'cms#cms_page', as: :primary_senior_leaders, defaults: { page_slug: 'primary-senior-leaders' }
   get '/primary-teachers', to: 'landing_pages#primary_teachers', as: :primary_teachers, defaults: { slug: 'primary-certificate' }
@@ -118,6 +115,11 @@ Rails.application.routes.draw do
                                 constraints: ->(_request) { Programme.secondary_certificate.enrollable? }
   get '/secondary-senior-leaders', to: 'pages#page', as: :secondary_senior_leaders, defaults: { page_slug: 'secondary-senior-leaders' }
   get '/secondary-teachers', to: 'landing_pages#secondary_teachers', as: :secondary_teachers
+  get '/subject-practitioners', to: 'cms#cms_page', as: :subject_practitioners, defaults: { page_slug: 'subject-practitioner-panels' }
+  get "/subject-practitioner-panels-(*level)" => redirect("/subject-practitioners/%{level}") # for the page links
+  get '/subject-practitioners/primary', to: 'cms#cms_page', as: :subject_practitioners_primary, defaults: { page_slug: 'subject-practitioner-panels-primary' }
+  get '/subject-practitioners/secondary', to: 'cms#cms_page', as: :subject_practitioners_secondary, defaults: { page_slug: 'subject-practitioner-panels-secondary' }
+  get '/subject-practitioners/a-level', to: 'cms#cms_page', as: :subject_practitioners_a_level, defaults: { page_slug: 'subject-practitioner-panels-a-level' }
   get '/support-for-ite-providers', to: 'cms#cms_page', as: :support_for_ite_providers, defaults: { page_slug: 'support-for-ite-providers' }
   get '/signup-confirmation', to: 'pages#page', as: :signup_confirmation, defaults: { page_slug: 'signup-confirmation' }
   get '/take-the-next-step-in-your-career', to: 'cms#cms_page', as: :take_the_next_step_in_your_career, defaults: { page_slug: 'take-the-next-step-in-your-career' }

--- a/spec/requests/cms/cms_page_spec.rb
+++ b/spec/requests/cms/cms_page_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CmsController do
     context 'with a valid page' do
       before do
         stub_cms_page
-        get '/cms/bursary'
+        get '/bursary'
       end
 
       it 'assigns @page' do
@@ -19,6 +19,10 @@ RSpec.describe CmsController do
       it 'renders the template' do
         expect(response).to render_template('cms_page')
       end
+
+      it 'has the expected class' do
+        expect(assigns(:parent_slug)).to eq('bursary')
+      end
     end
 
     context 'with a missing page' do
@@ -30,17 +34,28 @@ RSpec.describe CmsController do
         expect { get '/cms/bursary' }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
+
+    context 'with a nested page' do
+      before do
+        stub_nested_cms_page
+        get '/home-teaching/key-stage-1'
+      end
+
+      it 'has the expected class' do
+        expect(assigns(:parent_slug)).to eq('home-teaching')
+      end
+    end
   end
 
   describe 'GET #clear_page_cache' do
     context 'with a cms page' do
       before do
         stub_cms_page
-        get '/cms/bursary/refresh'
+        get '/bursary/refresh'
       end
 
       it 'assigns @page' do
-        expect(response).to redirect_to('/cms/bursary')
+        expect(response).to redirect_to('/bursary')
       end
     end
 

--- a/spec/routing/cms_page_spec.rb
+++ b/spec/routing/cms_page_spec.rb
@@ -5,10 +5,6 @@ describe 'CMS Page routes' do
     expect(get('/cms/hubs')).to route_to(controller: 'cms', action: 'cms_page', page_slug: 'hubs')
   end
 
-  it 'has a route for generic refresh' do
-    expect(get('/cms/hubs/refresh')).to route_to(controller: 'cms', action: 'clear_page_cache', page_slug: 'hubs')
-  end
-
   it 'has a route for bursary' do
     expect(get('/bursary')).to route_to(controller: 'cms', action: 'cms_page', page_slug: 'bursary')
   end

--- a/spec/support/ghost/ghost_stubs.rb
+++ b/spec/support/ghost/ghost_stubs.rb
@@ -19,6 +19,13 @@ module GhostStubs
       .to_return(body: raw_page_json)
   end
 
+  def stub_nested_cms_page
+    raw_page_json = File.new('spec/support/ghost/page.json')
+    stub_request(:get, "#{ENV['GHOST_API_ENDPOINT']}/content/pages/slug/key-stage-1/")
+      .with(query: hash_including({ 'key' => "#{ENV['GHOST_CONTENT_API_KEY']}" }))
+      .to_return(body: raw_page_json)
+  end
+
   def stub_missing_cms_page
     raw_missing_page_json = File.new('spec/support/ghost/missing_page.json')
     stub_request(:get, "#{ENV['GHOST_API_ENDPOINT']}/content/pages/slug/bursary/")


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Closes [#1531](https://github.com/NCCE/teachcomputing.org-issues/issues/1531)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Add subject practitioner page routes
* Only set width 100% (and table border bottom) on specific cms pages
* Flatten refresh route, i.e `/cms/bursary/refresh` to `/bursary/refresh`

## Steps to perform after deploying to production

* N/A
