### PR TITLE
Set session to expire after 48hours.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -127,5 +127,6 @@ Rails.application.configure do
   config.session_store :cookie_store,
                        key: '_teach_computing_session',
                        secure: true,
-                       httponly: true
+                       httponly: true,
+                       expire_after: 48.hours
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -122,5 +122,6 @@ Rails.application.configure do
   config.session_store :cookie_store,
                        key: '_teach_computing_session',
                        secure: true,
-                       httponly: true
+                       httponly: true,
+                       expire_after: 48.hours
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1578


## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Set 48 hour expiry on session cookie.

Have tested this locally and changing the session expiry seems to update existing session cookies on next page load so we shouldn't need to do anything further with regards to expiring existing sessions.

