### PR TITLE
Redirect sub home-teaching pages to home-teaching

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,6 +133,7 @@ Rails.application.routes.draw do
 
   # CMS ROUTES
   get '/home-teaching-resources' => redirect('/home-teaching')
+  get '/home-teaching/:page_slug' => redirect('/home-teaching')
   get '/:parent_slug/:page_slug/refresh', to: 'cms#clear_page_cache'
   get '/:page_slug/refresh', to: 'cms#clear_page_cache'
 


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App link(s):
* https://teachcomputing-staging-pr-1097.herokuapp.com/home-teaching/key-stage-3-mobile-app-development-lesson-1
 should redirect to https://teachcomputing-staging-pr-1097.herokuapp.com/home-teaching

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Redirect home-teaching sub pages to `/home-teaching`

Some users have bookmarked the sub pages as they were following lessons. The new home-teaching page has links to the lessons as the sub pages were just a temporary home.
