### PR TITLE
Remove secondary certificate flag

### DIFF
--- a/app.json
+++ b/app.json
@@ -108,9 +108,6 @@
       "required": true,
       "value": "secret"
     },
-    "SECONDARY_CERTIFICATE_ENABLED": {
-      "required": true
-    },
     "CERTIFICATION_SYNCING_ENABLED": {
       "required": true
     }

--- a/app/services/feature_flag_service.rb
+++ b/app/services/feature_flag_service.rb
@@ -1,7 +1,6 @@
 class FeatureFlagService
   FLAGS = {
     certification_sync_enabled: 'CERTIFICATION_SYNCING_ENABLED',
-    secondary_certificate_enabled: 'SECONDARY_CERTIFICATE_ENABLED',
     csa_questionnaire_enabled: 'CSA_QUESTIONNAIRE_ENABLED'
   }.freeze
 

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -13,11 +13,7 @@
         </p>
         <p class="govuk-body">
           Select individual courses, or make your learning go further, by enrolling on our national certification programmes in
-          <% if FeatureFlagService.new.flags[:secondary_certificate_enabled] %>
             <%= link_to 'primary computing', primary_path, class: 'ncce-link' %>, <%= link_to 'GCSE computer science subject knowledge', cs_accelerator_path, class: 'ncce-link' %> or <%= link_to 'secondary computing', secondary_path, class: 'ncce-link' %>.
-          <% else %>
-            <%= link_to 'primary computing', primary_path, class: 'ncce-link' %>, or <%= link_to 'GCSE computer science', cs_accelerator_path, class: 'ncce-link' %>.
-          <% end %>
         </p>
       </div>
     </div>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -15,10 +15,9 @@
 				<div class="certification__container">
 					<%= render 'dashboard/certificates/primary', programme: Programme.primary_certificate %>
 					<%= render 'dashboard/certificates/cs-accelerator', programme: Programme.cs_accelerator %>
-					<%= render 'dashboard/certificates/secondary', programme: Programme.secondary_certificate if FeatureFlagService.new.flags[:secondary_certificate_enabled] %>
+					<%= render 'dashboard/certificates/secondary', programme: Programme.secondary_certificate %>
 				</div>
 			<%= render 'dashboard/courses' %>
 		</div>
 	</div>
 </div>
-

--- a/app/views/landing_pages/secondary_teachers.html.erb
+++ b/app/views/landing_pages/secondary_teachers.html.erb
@@ -134,7 +134,6 @@
           </div>
         </div>
       </div>
-      <% if FeatureFlagService.new.flags[:secondary_certificate_enabled] %>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <div class="card card--cs-accelerator card--bottom-glyph">
@@ -161,7 +160,6 @@
           </div>
         </div>
       </div>
-    <% end %>
     </div>
   </div>
 </div>

--- a/app/views/pages/home/_certificates.html.erb
+++ b/app/views/pages/home/_certificates.html.erb
@@ -24,14 +24,12 @@
               </h3>
               <p class='govuk-body'>Develop subject knowledge of GCSE computer science</p>
             </div>
-            <% if FeatureFlagService.new.flags[:secondary_certificate_enabled] %>
-              <div class='ncce-certs__certificate ncce-certs__certificate--secondary'>
-                <h3 class='govuk-heading-m ncce-certs__heading'>
-                  <%= link_to 'Secondary certificate', secondary_path, class: 'ncce-link ncce-link--heading' %>
-                </h3>
-                <p class='govuk-body'>Further your knowledge and teach secondary computing effectively</p>
-              </div>
-            <% end %>
+            <div class='ncce-certs__certificate ncce-certs__certificate--secondary'>
+              <h3 class='govuk-heading-m ncce-certs__heading'>
+                <%= link_to 'Secondary certificate', secondary_path, class: 'ncce-link ncce-link--heading' %>
+              </h3>
+              <p class='govuk-body'>Further your knowledge and teach secondary computing effectively</p>
+            </div>
           </div>
         </div>
       </div>

--- a/spec/services/feature_flag_service_spec.rb
+++ b/spec/services/feature_flag_service_spec.rb
@@ -47,11 +47,7 @@ RSpec.describe FeatureFlagService do
 
   describe 'FLAGS' do
     it 'defines hash of flags correctly' do
-      expect(FeatureFlagService::FLAGS.count).to eq 3
-    end
-
-    it 'defines secondary_certificate_enabled flag' do
-      expect(FeatureFlagService::FLAGS.keys).to include(:secondary_certificate_enabled)
+      expect(FeatureFlagService::FLAGS.count).to eq 2
     end
 
     it 'sets the csa_questionnaire_enabled flag' do

--- a/spec/views/landing_pages/secondary_teachers.html.erb_spec.rb
+++ b/spec/views/landing_pages/secondary_teachers.html.erb_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe('landing_pages/secondary_teachers', type: :view) do
   let(:secondary_certificate) { create(:secondary_certificate) }
 
   before do
-    ENV['SECONDARY_CERTIFICATE_ENABLED'] = 'true'
     @cs_accelerator = cs_accelerator
     @secondary_certificate = secondary_certificate
     render
@@ -23,9 +22,7 @@ RSpec.describe('landing_pages/secondary_teachers', type: :view) do
     expect(rendered).to have_css('.card__heading', text: 'GCSE computer science subject knowledge')
   end
 
-  context 'when secondary certificate is enabled' do
-    it 'renders the secondary certificate card' do
-      expect(rendered).to have_css('.card__heading', text: 'Teach secondary computing')
-    end
+  it 'renders the secondary certificate card' do
+    expect(rendered).to have_css('.card__heading', text: 'Teach secondary computing')
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1603


## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Removes secondary certificate feature flag and enables all behaviour by default
