### PR TITLE
Show questionnaire text if flag enabled

### DIFF
--- a/app/views/pages/cs-accelerator.html.erb
+++ b/app/views/pages/cs-accelerator.html.erb
@@ -31,7 +31,11 @@
             <li>
               Enrol with the click of a button
             </li>
-            <li>Complete a quiz to assess your subject knowledge</li>
+            <% if FeatureFlagService.new.flags[:csa_questionnaire_enabled] %>
+              <li>Complete a questionnaire to assess your subject knowledge</li>
+            <% else %>
+              <li>Complete a quiz to assess your subject knowledge</li>
+            <% end %>
             <li>Participate in a mix of courses to suit your experience</li>
             <li>Pass a short test to receive your qualification</li>
           </ol>


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1615

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Changes text shown to say `questionnaire` instead of `quiz` once feature flag is toggled

