### PR TITLE
remove datadog buildpack

### DIFF
--- a/app.json
+++ b/app.json
@@ -123,9 +123,6 @@
   ],
   "buildpacks": [
     {
-      "url": "https://github.com/DataDog/heroku-buildpack-datadog"
-    },
-    {
       "url": "heroku/nodejs"
     },
     {


### PR DESCRIPTION
## Status

* Current Status: WIP / Ready for (front-end / tech) review
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Related to https://github.com/NCCE/teachcomputing.org-issues/issues/1616

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Remove datadog buildpack as we don't need it for heroku stats 
