### PR TITLE
Correct path for non logged in users on secondary landing page

### DIFF
--- a/app/views/landing_pages/secondary_teachers.html.erb
+++ b/app/views/landing_pages/secondary_teachers.html.erb
@@ -147,7 +147,7 @@
 
             <% unless current_user && @secondary_certificate.user_enrolled?(current_user) %>
               <p class="govuk-body govuk-!-margin-bottom-0">
-                <strong><%= link_to 'Find out more', secondary_certificate_path, class: 'ncce-link' %></strong>
+                <strong><%= link_to 'Find out more', secondary_path, class: 'ncce-link' %></strong>
               </p>
             <% end %>
           </div>


### PR DESCRIPTION
## Status

* Current Status: Ready
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1648
## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Update path for non logged in users.
