### PR TITLE
Ensure partial isn't rendered if @programmes is empty array

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -14,7 +14,7 @@
           <%= sanitize_stem_html @course.summary %>
           <%= sanitize_stem_html @course.outcomes %>
         </div>
-        <%= render 'courses/certificates-card' unless @programmes.nil? %>
+        <%= render 'courses/certificates-card' if @programmes.present? %>
       </div>
       <div class="govuk-grid-column-one-third">
         <%= render 'courses/aside-section' %>


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App link(s): https://teachcomputing-staging-pr-1177.herokuapp.com/courses/CP308/computing-as-a-second-subject-for-non-specialist-teachers
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1659

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Blue box was appearing because `@programmes` is an empty array which returns `false` for `.nil?`
* Check for `if .. .present?` which will ignore empty arrays. 
