### PR TITLE
Only show link if stem_activity_code is present

### DIFF
--- a/app/views/certificates/cs_accelerator/v2/_achievements.html.erb
+++ b/app/views/certificates/cs_accelerator/v2/_achievements.html.erb
@@ -45,7 +45,11 @@
   <% non_compulsory_achievements.each do |achievement| %>
     <div class="ncce-pathway-courses__course">
       <p>
-        <%= link_to achievement.title, course_path(id: achievement.stem_activity_code, name: achievement.slug), class: 'ncce-link' %>
+        <% if achievement.stem_activity_code.present? %>
+          <%= link_to achievement.title, course_path(id: achievement.stem_activity_code, name: achievement.slug), class: 'ncce-link' %>
+        <% else %>
+          <%= achievement.title %>
+        <% end %>
       </p>
 
 

--- a/spec/views/certificates/cs_accelerator/v2/_achievements.html.erb_spec.rb
+++ b/spec/views/certificates/cs_accelerator/v2/_achievements.html.erb_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe('certificates/_achievements', type: :view) do
+  let(:stem_id_activity) { create(:activity, stem_activity_code: 'CP123') }
+  let(:stem_id_achievement) { create(:achievement, activity: stem_id_activity) }
+
+  let(:no_stem_id_activity) { create(:activity, stem_activity_code: nil) }
+  let(:no_stem_id_achievement) { create(:achievement, activity: no_stem_id_activity) }
+
+  it 'links to activity if it has stem_activity_code' do
+    render partial: 'certificates/cs_accelerator/v2/achievements',
+           locals: {
+             non_compulsory_achievements: [stem_id_achievement],
+             compulsory_achievement: nil,
+             user_completed_non_compulsory_achievement: false
+           }
+    expect(rendered).to have_link(stem_id_achievement.title)
+  end
+
+  it 'does not error if achievement has no stem id' do
+    render partial: 'certificates/cs_accelerator/v2/achievements',
+           locals: {
+             non_compulsory_achievements: [no_stem_id_achievement],
+             compulsory_achievement: nil,
+             user_completed_non_compulsory_achievement: false
+           }
+    expect(rendered).to include(no_stem_id_achievement.title)
+  end
+end


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App link(s): *populate this with links to the relevant parts of the review app*

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Check stem_activity_code is present before trying to create link to it.
* Just display title if not present

