### PR TITLE
About us dropdown expansion shift

### DIFF
--- a/app/views/components/_header.html.erb
+++ b/app/views/components/_header.html.erb
@@ -43,21 +43,11 @@
                 <span class="ncce-header__certification-item--text"><%= nav_item[:text] %></span>
                 <span class="ncce-header__certification-item--icon"></span>
               </div>
-
-              <% if nav_item[:text] == 'About us' %>
-                <ul class="govuk-list govuk-body-s dropdown__expander-content last_dropdown__expander_section">
-                  <% nav_item[:children].each do  | item |%>
-                    <li class="dropdown__expander-content-item"><%= link_to item[:text], item[:link], data: { event_action: 'click', event_category: 'Header: Navigation', event_label: item[:label] } %></li>
-                  <% end %>
-                </ul>
-              <% else%>
-                <ul class="govuk-list govuk-body-s dropdown__expander-content">
-                  <% nav_item[:children].each do  | item |%>
-                    <li class="dropdown__expander-content-item"><%= link_to item[:text], item[:link], data: { event_action: 'click', event_category: 'Header: Navigation', event_label: item[:label] } %></li>
-                  <% end %>
-                </ul>
-              <% end %>
-
+							<ul class="govuk-list govuk-body-s dropdown__expander-content">
+							<% nav_item[:children].each do  | item |%>
+								<li class="dropdown__expander-content-item"><%= link_to item[:text], item[:link], data: { event_action: 'click', event_category: 'Header: Navigation', event_label: item[:label] } %></li>
+							<% end %>
+							</ul>
 						</li>
 					<% end %>
 				</ul>

--- a/app/webpacker/stylesheets/components/_dropdown-expander.scss
+++ b/app/webpacker/stylesheets/components/_dropdown-expander.scss
@@ -26,6 +26,12 @@
   }
 }
 
+.dropdown__expander:last-of-type > .dropdown__expander-content{
+  right: 0;
+  left:auto;
+  min-width: 175px;
+}
+
 .dropdown__expander-content-item {
   font-size: 1rem;
   padding-bottom: 1rem;

--- a/app/webpacker/stylesheets/components/_header.scss
+++ b/app/webpacker/stylesheets/components/_header.scss
@@ -162,6 +162,7 @@
     visibility: visible;
   }
 }
+
 .ncce-header__wrap {
   display: flex;
 }
@@ -363,11 +364,5 @@
   line-height: normal;
   vertical-align: middle;
   width: 1rem;
-}
-
-.last_dropdown__expander_section {
-  right: 0;
-  left:auto;
-  min-width: 175px;
 }
 


### PR DESCRIPTION
design: https://www.figma.com/file/UMTFWRbSrewj2RCOkXzcEv/Design%3A-Ready-to-build-%F0%9F%9B%A0?node-id=0%3A1
## What's changed?

About us - dropdown to open to the left side

<img width="1397" alt="Screenshot 2021-05-07 at 11 21 33" src="https://user-images.githubusercontent.com/14819641/117436033-6f8c0f00-af26-11eb-89f3-f5d08738c8e7.png">
