### PR TITLE
Adds padding to mobile nav

### DIFF
--- a/app/webpacker/stylesheets/components/_header.scss
+++ b/app/webpacker/stylesheets/components/_header.scss
@@ -163,6 +163,7 @@
   }
 }
 .ncce-header__wrap {
+  padding: 15px 0;
   display: flex;
 }
 .ncce-header__certification-item {


### PR DESCRIPTION
design: https://www.figma.com/proto/xiKaHUwHJaK1NyglqiuZYr/Homepage%2C-navigation-and-footer?node-id=1053%3A173&scaling=min-zoom&hide-ui=1
## What's changed?

Adds some extra padding/height to mobile nav items

<img width="482" alt="Screenshot 2021-05-07 at 17 05 24" src="https://user-images.githubusercontent.com/14819641/117477910-72065d00-af56-11eb-842b-2ce56bfc3884.png">


