### PR TITLE
Add class to handle user programme enrolment

### DIFF
--- a/app/controllers/user_programme_enrolments_controller.rb
+++ b/app/controllers/user_programme_enrolments_controller.rb
@@ -3,10 +3,10 @@ class UserProgrammeEnrolmentsController < ApplicationController
   before_action :user_has_existing_enrolment?, only: [:create]
 
   def create
-    enrolment = UserProgrammeEnrolment.new(user_programme_enrolment_params)
+    enroller = Programmes::UserEnroller.new(user_programme_enrolment_params)
     programme = Programme.find_by!(id: params[:user_programme_enrolment][:programme_id])
 
-    if enrolment.save
+    if enroller.call
       case programme.slug
       when 'primary-certificate'
         redirect_to diagnostic_primary_certificate_path(:question_1)

--- a/app/services/programmes/user_enroller.rb
+++ b/app/services/programmes/user_enroller.rb
@@ -1,0 +1,30 @@
+module Programmes
+  class UserEnroller
+    def initialize(params)
+      @enrolment_params = params
+      @user_id = params[:user_id]
+      @programme_id = params[:programme_id]
+    end
+
+    def call
+      enrolment = UserProgrammeEnrolment.new(@enrolment_params)
+      return false unless enrolment.save
+
+      KickOffEmailsJob.perform_later(enrolment.id)
+      Achiever::ScheduleCertificateSyncJob.perform_later(enrolment.id)
+
+      QuestionnaireResponse.create(user_id: @user_id, questionnaire: Questionnaire.cs_accelerator) if enrolment.programme.cs_accelerator?
+      set_eligible_achievements_for_programme
+      true
+    end
+    private
+
+    def set_eligible_achievements_for_programme
+      user_achievements = Achievement.where(user_id: @user_id, programme_id: nil)
+      user_achievements.each do |achievement|
+        programme_activity = ProgrammeActivity.find_by(activity_id: achievement.activity_id, programme_id: @programme_id)
+        achievement.update(programme_id: @programme_id) if programme_activity
+      end
+    end
+  end
+end

--- a/spec/models/user_programme_enrolment_spec.rb
+++ b/spec/models/user_programme_enrolment_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe UserProgrammeEnrolment, type: :model do
   let(:user) { create(:user) }
-  let(:achievements) { create_list(:achievement, 5, user: user) }
   let(:cs_accelerator) { create(:cs_accelerator) }
   let(:cs_accelerator_enrolment) { create(:user_programme_enrolment, user: user, programme: cs_accelerator) }
   let(:questionnaire_response) { create(:cs_accelerator_enrolment_score_1) }
@@ -39,49 +38,12 @@ RSpec.describe UserProgrammeEnrolment, type: :model do
     end
   end
 
-  describe '#set_eligible_achievements_for_programme' do
-    before do
-      cs_accelerator
-      achievements
-      Activity.all.each do |activity|
-        create(:programme_activity, programme: cs_accelerator, activity: activity)
-      end
-    end
-
-    it 'sets the programme_id for the achievements relating to the programe ' do
-      create(:user_programme_enrolment, user: user, programme: cs_accelerator)
-      expect(user.achievements.pluck(:programme_id).uniq).to include cs_accelerator.id
-    end
-  end
-
   describe '#set_pathway' do
     it 'sets the pathway id' do
       cs_accelerator
       upe = create(:user_programme_enrolment, user: user, programme: cs_accelerator)
       upe.assign_recommended_pathway(questionnaire_response)
       expect(upe.pathway_id).to eq(new_to_computing_pathway.id)
-    end
-  end
-
-  describe '#after_commit callbacks' do
-    it 'queues KickOffEmailsJob job' do
-      expect do
-        create(:user_programme_enrolment)
-      end.to have_enqueued_job(KickOffEmailsJob)
-    end
-
-    it 'queues ScheduleCertificateSyncJob job' do
-      expect do
-        create(:user_programme_enrolment)
-      end.to have_enqueued_job(Achiever::ScheduleCertificateSyncJob)
-    end
-
-    context 'when Programme is CSA' do
-      it 'creates questionnaire response' do
-        create(:csa_enrolment_questionnaire)
-        expect { create(:user_programme_enrolment, programme: cs_accelerator) }
-          .to change(QuestionnaireResponse, :count).by(1)
-      end
     end
   end
 

--- a/spec/requests/certificates/cs_accelerator/show_spec.rb
+++ b/spec/requests/certificates/cs_accelerator/show_spec.rb
@@ -58,13 +58,14 @@ RSpec.describe Certificates::CSAcceleratorController do
 
         context 'when the user has not completed the diagnostic' do
           it 'redirects to the diagnostic path' do
+            create(:questionnaire_response, user: user, questionnaire: questionnaire)
             get cs_accelerator_certificate_path
             expect(response)
               .to redirect_to(diagnostic_cs_accelerator_certificate_path(:question_1))
           end
 
           it 'redirects to last question completed' do
-            user_response = QuestionnaireResponse.find_by(user: user, questionnaire: questionnaire)
+            user_response = create(:questionnaire_response, user: user, questionnaire: questionnaire)
             user_response.update(current_question: 3)
 
             get cs_accelerator_certificate_path
@@ -78,7 +79,7 @@ RSpec.describe Certificates::CSAcceleratorController do
             create(:activity, :community_5)
             create_list(:activity, 3, :community)
             create_list(:activity, 4, :community_20)
-            questionnaire_response = QuestionnaireResponse.find_by(user: user, questionnaire: questionnaire)
+            questionnaire_response = create(:questionnaire_response, user: user, questionnaire: questionnaire)
             questionnaire_response.transition_to(:complete)
             get cs_accelerator_certificate_path
           end
@@ -102,8 +103,6 @@ RSpec.describe Certificates::CSAcceleratorController do
 
         context 'when the user does not have a diagnostic response' do
           it 'renders the correct template' do
-            QuestionnaireResponse.find_by(user: user, questionnaire: questionnaire).destroy
-
             get cs_accelerator_certificate_path
             expect(response).to render_template('show')
           end

--- a/spec/requests/diagnostics/cs_accelerator/show_spec.rb
+++ b/spec/requests/diagnostics/cs_accelerator/show_spec.rb
@@ -36,10 +36,7 @@ RSpec.describe Diagnostics::CSAcceleratorController do
     context 'when the user has completed the diagnostic' do
       before do
         user_programme_enrolment
-        answers = QuestionnaireResponse.find_by(
-          user: user,
-          questionnaire: cs_accelerator_questionnaire
-        )
+        answers = create(:questionnaire_response, user: user, questionnaire: cs_accelerator_questionnaire)
         answers.transition_to(:complete)
         get diagnostic_cs_accelerator_certificate_path(:question_1)
       end

--- a/spec/services/programmes/user_enroller_spec.rb
+++ b/spec/services/programmes/user_enroller_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Programmes::UserEnroller do
+  let(:user) { create(:user) }
+  let(:programme) { create(:primary_certificate) }
+  let(:enroller) { described_class.new({ user_id: user.id, programme_id: programme.id }) }
+
+  describe '#call' do
+    it 'creates the user programme enrolment' do
+      expect { enroller.call }.to change { user.user_programme_enrolments.count }.by(1)
+      expect(user.user_programme_enrolments.where(programme_id: programme.id).exists?).to eq true
+    end
+
+    it 'returns true' do
+      expect(enroller.call).to eq(true)
+    end
+
+    it 'schedules kick off emails' do
+      expect { enroller.call }.to have_enqueued_job(KickOffEmailsJob)
+    end
+
+    it 'schedules achiever sync' do
+      expect { enroller.call }.to have_enqueued_job(Achiever::ScheduleCertificateSyncJob)
+    end
+
+    it 'does not create questionnaire response for user' do
+      expect { enroller.call }.not_to change(QuestionnaireResponse, :count)
+    end
+
+    it 'sets eligible achievements for the programme' do
+      achievements = create_list(:achievement, 2, user: user)
+      Activity.all.each do |activity|
+        create(:programme_activity, programme: programme, activity: activity)
+      end
+
+      enroller.call
+      expect(user.achievements.pluck(:programme_id).uniq).to include programme.id
+    end
+
+    context 'when enrolling on cs_accelerator' do
+      let(:programme) { create(:cs_accelerator) }
+
+      it 'creates questionnaire response for user' do
+        create(:csa_enrolment_questionnaire)
+        expect { enroller.call }.to change(QuestionnaireResponse, :count).by(1)
+      end
+    end
+
+    context 'with invalid params' do
+      let(:enroller) { described_class.new({ user_id: nil, programme_id: nil }) }
+
+      it 'does not create an enrolment' do
+        expect { enroller.call }.not_to change(UserProgrammeEnrolment, :count)
+      end
+
+      it 'returns false' do
+        expect(enroller.call).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Moves callbacks out of enrolment class which should make some testing set up easier

## Status

* Current Status: Ready for review
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1708

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Adds service class to handle user programme enrolment
* Moves behaviour from callbacks on model into service class
* Removes callback behaviour from model

Having the callback behaviour required some non related objects needed to exist in the database when you created an enrolment in a test.
This refactor should remove that need.
