### PR TITLE
Amend wording around additional time on csa test

### DIFF
--- a/app/views/certificates/cs_accelerator/_csa-test.html.erb
+++ b/app/views/certificates/cs_accelerator/_csa-test.html.erb
@@ -41,9 +41,11 @@
     <% end %>
     <div class="ncce-csa-dash__sub-section">
       <p class="govuk-body-s">
-        You’ll have 30 minutes to answer 25 multiple-choice questions and you must complete it in one sitting.
-        The pass mark is 65%. You’re allowed two initial attempts at the test before a 48 hour cool off
-        period between each subsequent attempt. Good luck!
+        You’ll have 30 minutes to answer 25 multiple-choice questions and you must complete it in one sitting.  
+        If you have a disability we can extend the test time to 45 minutes. To request this, please
+        <%= mail_to 'certificationqueries@bcs.uk', 'email us' %>
+        and we'd be happy to help. 
+        The pass mark is 65%. You’re allowed two initial attempts at the test before a 48 hour cool off period between each subsequent attempt. Good luck!
       </p>
     </div>
   <% end %>


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1725

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Amends wording about extending time for CSA test.

