### PR TITLE
Fix flickering test failures

### DIFF
--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Activity, type: :model do
       end
 
       it 'lists available online activities for a given user' do
-        expect(Activity.available_for(user)).to eq(online_courses)
+        expect(Activity.available_for(user)).to match_array(online_courses)
       end
 
       it 'does not include activities if a user already has an existing achievement' do
@@ -66,9 +66,7 @@ RSpec.describe Activity, type: :model do
       end
 
       it 'includes only online activities' do
-        online_courses.each do |online_course|
-          expect(Activity.online.to_a).to include(online_course)
-        end
+        expect(Activity.online).to match_array(online_courses)
       end
 
       it 'does not include actions' do
@@ -82,9 +80,7 @@ RSpec.describe Activity, type: :model do
       end
 
       it 'includes only face-to-face activities' do
-        face_to_face_courses.each do |face_to_face_course|
-          expect(Activity.face_to_face.to_a).to include(face_to_face_course)
-        end
+        expect(Activity.face_to_face).to match_array(face_to_face_courses)
       end
 
       it 'does not include actions' do
@@ -98,9 +94,7 @@ RSpec.describe Activity, type: :model do
       end
 
       it 'includes only future-learn activities' do
-        online_courses.each do |online_course|
-          expect(Activity.future_learn.to_a).to include(online_course)
-        end
+        expect(Activity.future_learn).to match_array(online_courses)
       end
 
       it 'does not include actions' do
@@ -114,9 +108,7 @@ RSpec.describe Activity, type: :model do
       end
 
       it 'includes only stem-learning activities' do
-        face_to_face_courses.each do |face_to_face_course|
-          expect(Activity.stem_learning.to_a).to include(face_to_face_course)
-        end
+        expect(Activity.stem_learning).to match_array(face_to_face_courses)
       end
 
       it 'does not include actions' do

--- a/spec/system/curriculum/lessons/show_spec.rb
+++ b/spec/system/curriculum/lessons/show_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe('Curriculum Ratings', type: :system) do
 
     describe 'when a positive rating is given' do
       before do
-        click_on class: 'curriculum__rating--thumb-down'
+        click_on class: 'curriculum__rating--thumb-up'
       end
 
       it 'does not show the thumbs buttons' do


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1752

## What's changed?

* Ensure correct link clicked on when testing positive review
* Use `match_array` instead of `eq` to prevent ordering of results affecting test
* Refactor some tests to use `match_array` instead of looping through the results and checking each is present.

