### PR TITLE
Bump Rails v to match curriculum

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.7.2'
 
 gem 'activestorage-validator'
-gem 'administrate'
+gem 'administrate', '~> 0.16.0'
 gem 'attr_encrypted', '~> 3.1.0'
 gem 'awesome_print'
 gem 'aws-sdk-s3', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -604,7 +604,7 @@ PLATFORMS
 
 DEPENDENCIES
   activestorage-validator
-  administrate
+  administrate (~> 0.16.0)
   attr_encrypted (~> 3.1.0)
   awesome_print
   aws-sdk-s3

--- a/app/views/admin/application/_navigation.html.erb
+++ b/app/views/admin/application/_navigation.html.erb
@@ -8,7 +8,7 @@ as defined by the routes in the `admin/` namespace
 %>
 
 <nav class="navigation" role="navigation">
-  <%= link_to(t("administrate.navigation.back_to_app"), root_url, class: "button button--alt") if defined?(root_url) %>
+  <%= link_to(t("administrate.navigation.back_to_app"), root_url, class: "button button--alt button--nav") if defined?(root_url) %>
 
   <% Administrate::Namespace.new(namespace).resources_with_index_route.each do |resource| %>
     <%= link_to(


### PR DESCRIPTION
## Status

* Current Status: Ready
* Related to https://github.com/NCCE/curriculum.teachcomputing.org/pull/148

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Address actionpack issue and ensure Rails version matches curriculum
