### PR TITLE
Ensure completion email for secondary is queued

### DIFF
--- a/app/jobs/complete_certificate_email_job.rb
+++ b/app/jobs/complete_certificate_email_job.rb
@@ -7,6 +7,8 @@ class CompleteCertificateEmailJob < ApplicationJob
       CSAcceleratorMailer.with(user: user).completed.deliver_now
     when 'primary-certificate'
       PrimaryMailer.with(user: user).completed.deliver_now
+    when 'secondary-certificate'
+      SecondaryMailer.with(user: user).completed.deliver_now
     end
   end
 end

--- a/spec/jobs/complete_certificate_email_job_spec.rb
+++ b/spec/jobs/complete_certificate_email_job_spec.rb
@@ -3,8 +3,10 @@ require 'rails_helper'
 RSpec.describe CompleteCertificateEmailJob, type: :job do
   let(:cs_accelerator) { create(:cs_accelerator) }
   let(:primary) { create(:primary_certificate) }
+  let(:secondary) { create(:secondary_certificate) }
   let(:cs_accelerator_enrolment) { create(:user_programme_enrolment, programme_id: cs_accelerator.id) }
   let(:primary_enrolment) { create(:user_programme_enrolment, programme_id: primary.id) }
+  let(:secondary_enrolment) { create(:user_programme_enrolment, programme_id: secondary.id) }
 
   describe '#perform' do
     context 'when the programme is cs accelerator' do
@@ -17,6 +19,13 @@ RSpec.describe CompleteCertificateEmailJob, type: :job do
     context 'when the programme is primary' do
       it 'sends an email' do
         expect { described_class.perform_now(primary_enrolment.user, primary_enrolment.programme) }
+          .to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
+    end
+
+    context 'when the programme is secondary' do
+      it 'sends an email' do
+        expect { described_class.perform_now(secondary_enrolment.user, secondary_enrolment.programme) }
           .to change { ActionMailer::Base.deliveries.count }.by(1)
       end
     end


### PR DESCRIPTION
## Status

* Current Status: Ready
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1769

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Ensure secondary completion email is queued when completed 

