### PR TITLE
corrects padding affecting desktop views

### DIFF
--- a/app/webpacker/stylesheets/components/_header.scss
+++ b/app/webpacker/stylesheets/components/_header.scss
@@ -167,7 +167,7 @@
   padding: 15px 0;
   display: flex;
 
-  @include govuk-media-query($from: desktop) {
+  @include govuk-media-query($from: tablet) {
     padding: 0;
   }
 }


### PR DESCRIPTION
corrects desktop nav padding that was getting out of hand 

<img width="1055" alt="Screenshot 2021-06-03 at 12 37 29" src="https://user-images.githubusercontent.com/14819641/120638815-8a3f9e00-c468-11eb-9924-ccdf4c233874.png">
