### PR TITLE
Reinstates IBM logo in supporters page

### DIFF
--- a/app/views/pages/supporting-partners.html.erb
+++ b/app/views/pages/supporting-partners.html.erb
@@ -102,6 +102,23 @@
         </div>
 
         <div class="shadow_card dark_card govuk-!-padding-top-0">
+          <%= link_to 'https://www.ibm.org/', class: 'ncce-link' do %>
+            <%= image_pack_tag 'media/images/partners/ibm.svg', class: 'dark_card--image dark_image--supporting-partners', alt: 'IBM logo' %>
+          <% end %>
+          <h2 class="govuk-heading-m dark_card--title govuk-!-padding-top-0">
+            <%= link_to 'IBM', 'https://www.ibm.org/', class: 'ncce-link ncce-link--heading' %>
+          </h2>
+          <p class="govuk-body govuk-!-margin-bottom-0">
+            IBM supports a more inclusive society by partnering with key organisations in
+            the public and non-profit sectors, providing expertise. technology, and a
+            commitment to help young people build the skills required to succeed.
+            Their free online learning platform, <%= link_to 'Open P-TECH', 'https://www.ptech.org/open-p-tech/', class: 'ncce-link'%>, introduces students (13-18 years)
+            and teachers to the technical and professional skills of the future. IBM also offers
+            <%= link_to 'SkillsBuild', 'https://skillsbuild.org/', class: 'ncce-link' %>, a free learning platform for adults looking to upskill and reskill.
+          </p>
+        </div>
+
+        <div class="shadow_card dark_card govuk-!-padding-top-0">
           <%= link_to 'https://www.nationwide-jobs.co.uk/', class: 'ncce-link' do %>
             <%= image_pack_tag 'media/images/partners/nationwide.svg', class: 'dark_card--image dark_image--supporting-partners', alt: 'Nationwide logo' %>
           <% end %>

--- a/spec/views/pages/supporting-partners.hmtl_spec.rb
+++ b/spec/views/pages/supporting-partners.hmtl_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe('pages/supporting-partners', type: :view) do
     end
 
     it 'has supporting partner cards showing' do
-      expect(rendered).to have_css('.shadow_card', count: 5)
+      expect(rendered).to have_css('.shadow_card', count: 6)
     end
 
     it 'has external links for each of the supporting_partner cards' do


### PR DESCRIPTION

## What's changed?

*Puts IBM logo back.*

<img width="1401" alt="Screenshot 2021-06-10 at 16 35 30" src="https://user-images.githubusercontent.com/14819641/121554236-e4f96c80-ca09-11eb-9e88-fb23212f521d.png">
