### PR TITLE
Log auth failures to sentry

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -26,6 +26,10 @@ class AuthController < ApplicationController
   end
 
   def failure
+    Sentry.capture_message(
+      'Auth failure',
+      extra: { error: request.env['omniauth.error'], error_type: request.env['omniauth.error.type'] }
+    )
     flash[:error] = 'Sorry, we were unable to log you in. Please try again or contact us for help.'
     redirect_to root_path
   end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -52,7 +52,7 @@ end
 # Wrap the code to avoid autoloading classes too early in the runtime, this will cause an error in
 # future Rails versions see https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots
 Rails.application.reloader.to_prepare do
-  OmniAuth.config.on_failure = AuthController.action(:failure)
+  OmniAuth.config.on_failure { |env| AuthController.action(:failure).call(env) }
 end
 
 OmniAuth.config.logger = Rails.logger if Rails.env.development?

--- a/spec/requests/auth/failure_spec.rb
+++ b/spec/requests/auth/failure_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe AuthController do
     context 'when an error is encountered' do
       before do
         OmniAuth.config.mock_auth[:stem] = :not_known
+        allow(Sentry).to receive(:capture_message)
       end
 
       it 'redirects to the root_path' do
@@ -21,6 +22,15 @@ RSpec.describe AuthController do
         get callback_path
         expect(flash[:error]).to be_present
         expect(flash[:error]).to match(/Sorry, we were unable to log you in. Please try again or contact us for help.*/)
+      end
+
+      it 'logs error to sentry' do
+        get callback_path
+        expect(Sentry)
+          .to have_received(:capture_message)
+          .once
+          .with('Auth failure',
+                extra: { error: nil, error_type: :not_known })
       end
     end
   end


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1784

## What's changed?

* Logs auth failures to sentry

