### PR TITLE
Add padding to curriculum rating

### DIFF
--- a/app/webpacker/stylesheets/components/pages/_curriculum.scss
+++ b/app/webpacker/stylesheets/components/pages/_curriculum.scss
@@ -121,12 +121,13 @@
 }
 
 .curriculum__rating {
-  display: flex;
   align-items: center;
-  justify-content: space-between;
-  height: 100%;
-  min-height: 3rem;
   background-color: $foam;
+  display: flex;
+  height: 100%;
+  justify-content: space-between;
+  margin-bottom: 50px;
+  min-height: 3rem;
   padding: 1rem;
 
   textarea {


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1782

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Adds margin to match that around the unit/lesson description so if the rating box is taller than the description the margin will still be there.
