### PR TITLE
Fix button spacing issues on dashboards

### DIFF
--- a/app/components/completed_dash_badge_component.rb
+++ b/app/components/completed_dash_badge_component.rb
@@ -9,6 +9,7 @@ class CompletedDashBadgeComponent < ViewComponent::Base
 
   def render?
     return false unless FeatureFlagService.new.flags[:badges_enabled]
+    return false unless @badge.present?
 
     true
   end

--- a/app/views/certificates/cs_accelerator/complete.html.erb
+++ b/app/views/certificates/cs_accelerator/complete.html.erb
@@ -13,7 +13,9 @@
 				<h2 class="govuk-heading-m govuk-!-margin-top-6">Your recommended next steps</h2>
 				<h3 class="govuk-heading-s">Improve your teaching confidence</h3>
         <p class="govuk-body">Take your professional development to the next level and start our new <%= link_to 'Teach secondary computing certificate', secondary_certificate_path, class: 'govuk-link ncce-link' %>. This qualification will help you to build on your subject knowledge and give you the practical skills for the classroom. It also supports your progress to chartered status.</p>
-        <%= link_to 'Enrol on Teach secondary computing', Programme.secondary_certificate.enrol_path(user_programme_enrolment: { user_id: current_user.id, programme_id: Programme.secondary_certificate.id }), method: :post, class: 'govuk-button button', role: 'button', draggable: 'false' %>
+        <p class="govuk-body">
+          <%= link_to 'Enrol on Teach secondary computing', Programme.secondary_certificate.enrol_path(user_programme_enrolment: { user_id: current_user.id, programme_id: Programme.secondary_certificate.id }), method: :post, class: 'govuk-button button', role: 'button', draggable: 'false' %>
+        </p>
         <h3 class="govuk-heading-s">Continue learning</h3>
         <p class="govuk-body">As a graduate of the Computer Science Accelerator, you can participate in any of our huge range of professional development courses for free, if you work in secondary state education. Just use the code “CSAGraduate” when booking your next course. The courses you take can also contribute towards your Teach secondary computing certificate.</p>
         <p class="govuk-body"><em>Note</em>, this code can only be used on bookings for teachers working in secondary state education. We reserve the right to charge the full course fee if the code is used by anyone who does not fall into this criteria. Teachers from independent schools will continue to pay a fee of £220 per course for any of our face-to-face or remote courses.</p>

--- a/app/views/certificates/secondary_certificate/complete.html.erb
+++ b/app/views/certificates/secondary_certificate/complete.html.erb
@@ -18,7 +18,9 @@
         </p>
         <p class="govuk-body-l">Continue learning</p>
         <p class="govuk-body">Enhance your learning by participating in courses from our growing programme of CPD. Plus, if you work in a state-funded secondary school or college, you can access any of these courses for free.</p>
-        <%= link_to 'Browse all courses', courses_path, class: 'govuk-button button' %>
+        <p class="govuk-body">
+          <%= link_to 'Browse all courses', courses_path, class: 'govuk-button button' %>
+        </p>
         <p class="govuk-body-l">Share your experience at a CAS Community meeting</p>
         <p class="govuk-body">CAS communities offer a supportive environment to reflect on your professional learning and encourage others. Think about attending one of your local meetings to share your experiences with other teachers.</p>
         <%= link_to 'Find out more', 'https://community.computingatschool.org.uk/events', class: 'govuk-button button' %>

--- a/spec/components/completed_dash_badge_component_spec.rb
+++ b/spec/components/completed_dash_badge_component_spec.rb
@@ -18,12 +18,23 @@ RSpec.describe CompletedDashBadgeComponent, type: :component do
 
   context 'when the badging feature is enabled' do
     before do
-      stub_issued_badges(user.id)
       stub_feature_flags({ badges_enabled: true })
+    end
+
+    context 'when badge is not present' do
+      before do
+        stub_issued_badges_empty(user.id)
+        render_inline(completed_dash_badge_component)
+      end
+
+      it 'does not render' do
+        expect(rendered_component).to eq ''
+      end
     end
 
     context 'when the achievement is complete' do
       before do
+        stub_issued_badges(user.id)
         render_inline(completed_dash_badge_component)
       end
 


### PR DESCRIPTION

## Status

* Current Status: Ready for review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1801

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Fix spacing after `Enrol on Teach secondary computing` button on csa dash:
   https://teachcomputing-staging-pr-1292.herokuapp.com/certificate/cs-accelerator/complete
* Fix spacing after `Browse all courses` button on completed secondary dash:
   https://teachcomputing-staging-pr-1292.herokuapp.com/certificate/secondary-certificate/complete
* Ensure completed_dash_badge_component does not try and render if no badge issued (this was breaking the page locally and would cause an error if it happened live)

