### PR TITLE
Fix padding issues on curriculum feedback box

### DIFF
--- a/app/views/curriculum/_feedback.html.erb
+++ b/app/views/curriculum/_feedback.html.erb
@@ -1,5 +1,5 @@
 <div class="light-blue-bg padded-box padded-box--resources">
 	<h2 class="govuk-heading-m padded-box__title">Help us make these resources better</h2>
-	<%= link_to 'Provide your feedback', 'https://forms.gle/qT2XqoCecYjLLohC6', class: 'govuk-button button button--inline' %>
-	<p class="govuk-body govuk-!-margin-top-5">Or email us at <%= link_to 'resourcesfeedback@raspberrypi.org', 'mailto:resourcesfeedback@raspberrypi.org', class: 'govuk-link ncce-link' %></p>
+	<%= link_to 'Provide your feedback', 'https://forms.gle/qT2XqoCecYjLLohC6', class: 'govuk-button button padded-box--button' %>
+	<p class="govuk-body">Or email us at <%= link_to 'resourcesfeedback@raspberrypi.org', 'mailto:resourcesfeedback@raspberrypi.org', class: 'govuk-link ncce-link' %></p>
 </div>

--- a/app/webpacker/stylesheets/components/pages/_padded-box.scss
+++ b/app/webpacker/stylesheets/components/pages/_padded-box.scss
@@ -12,20 +12,24 @@
 }
 
 .padded-box__title {
-	font-weight: 500;
-	line-height: 1.5625rem;
-	margin-bottom: 1.8rem !important;
+  font-weight: 500;
+  line-height: 1.5625rem;
+  margin-bottom: 1.2rem !important;
 
-	@include govuk-media-query($from: desktop) {
-		margin-bottom: 2.5rem !important;
-	}
+  @include govuk-media-query($from: desktop) {
+    margin-bottom: 1.5rem !important;
+  }
 }
 
 .padded-box--resources {
-		padding: 3rem 1rem 1rem 2rem;
+  padding: 1.5rem 1rem 1rem 2rem;
 
   @include govuk-media-query($from: tablet) {
-		margin-top: 2.2rem;
-		padding: 2rem 2rem 1rem 4rem;
-	}
+    margin-top: 2.2rem;
+    padding: 2rem 2rem 1rem 4rem;
+  }
+}
+
+.padded-box--button {
+  margin-bottom: 10px;
 }


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App link(s): https://teachcomputing-staging-pr-1293.herokuapp.com/curriculum
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1803


## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Amend top padding on blue feedback box and tweak padding between elements at different resolutions 

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
