### PR TITLE
Ensure ratings endpoints are authenticated

### DIFF
--- a/app/controllers/concerns/curriculum/rateable.rb
+++ b/app/controllers/concerns/curriculum/rateable.rb
@@ -2,6 +2,10 @@ module Curriculum
   module Rateable
     extend ActiveSupport::Concern
 
+    included do
+      before_action :authenticate_user!, only: [:rate, :comment]
+    end
+
     def rate
       raise NoMethodError unless respond_to?(:client, true)
 

--- a/app/views/curriculum/_rating.html.erb
+++ b/app/views/curriculum/_rating.html.erb
@@ -13,6 +13,7 @@
           alt: "thumb up",
           class: "curriculum__rating--thumb-up",
           remote: true, 'aria-label': 'Thumbs up',
+          method: :post,
           data: { disable_with: true, action: 'ajax:success->rating#onRatingSuccess' }
         ) %>
         <%= link_to(
@@ -22,6 +23,7 @@
           class: "curriculum__rating--thumb-down",
           'aria-label': 'Thumbs down',
           remote: true,
+          method: :post,
           data: { disable_with: true, action: 'ajax:success->rating#onRatingSuccess' }
         ) %>
       </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,10 +88,9 @@ Rails.application.routes.draw do
   get '/curriculum/:key_stage_slug/:unit_slug', to: 'curriculum/units#show', as: :curriculum_key_stage_unit
   get '/curriculum/:key_stage_slug/:unit_slug/:lesson_slug', to: 'curriculum/lessons#show',
                                                              as: :curriculum_key_stage_unit_lesson
-  get '/curriculum/rating/units/:polarity/:id/:user_id', to: 'curriculum/units#rate', as: :create_curriculum_unit_rating
+  post '/curriculum/rating/units/:polarity/:id/:user_id', to: 'curriculum/units#rate', as: :create_curriculum_unit_rating
   post '/curriculum/rating/comment', to: 'curriculum/units#comment', as: :update_curriculum_unit_rating
-  get '/curriculum/rating/lessons/:polarity/:id/:user_id', to: 'curriculum/lessons#rate',
-                                                           as: :create_curriculum_lesson_rating
+  post '/curriculum/rating/lessons/:polarity/:id/:user_id', to: 'curriculum/lessons#rate', as: :create_curriculum_lesson_rating
   post '/curriculum/rating/comment', to: 'curriculum/lessons#comment', as: :update_curriculum_lesson_rating
 
   get 'dashboard', action: :show, controller: 'dashboard'

--- a/spec/support/shared_examples/curriculum/rateable_examples.rb
+++ b/spec/support/shared_examples/curriculum/rateable_examples.rb
@@ -3,20 +3,20 @@ require 'spec_helper'
 RSpec.shared_examples_for 'rateable' do |path, comment_path, _context, id, rating_id|
   let(:user) { create(:user, stem_achiever_contact_no: 'achieverid') }
 
-  describe 'GET #rate' do
+  describe 'POST #rate' do
     before do
       allow_any_instance_of(AuthenticationHelper)
         .to receive(:current_user).and_return(user)
     end
 
     it 'errors for an invalid polarity' do
-      expect { get send(path, polarity: :bad, id: :an_id, user_id: user.id) }
+      expect { post send(path, polarity: :bad, id: :an_id, user_id: user.id) }
         .to raise_error(ArgumentError, 'Unexpected polarity: bad')
     end
 
     it 'adds a rating and returns the id' do
       stub_a_rating_request(rating_id)
-      get send(path, polarity: :negative, id: id, user_id: '94c52a7c-5001-45e3-82bd-949a882f5fb6')
+      post send(path, polarity: :negative, id: id, user_id: '94c52a7c-5001-45e3-82bd-949a882f5fb6')
       body = JSON.parse(response.body, object_class: OpenStruct)
       expect(response).to have_http_status(:ok)
       expect(body.origin).to eq('rate')
@@ -26,8 +26,8 @@ RSpec.shared_examples_for 'rateable' do |path, comment_path, _context, id, ratin
     it 'creates cookies with the expected ids' do
       stub_a_valid_request
 
-      get send(path, polarity: :negative, id: :an_id, user_id: user.id)
-      get send(path, polarity: :negative, id: :another_id, user_id: user.id)
+      post send(path, polarity: :negative, id: :an_id, user_id: user.id)
+      post send(path, polarity: :negative, id: :another_id, user_id: user.id)
 
       cookie_jar = ActionDispatch::Cookies::CookieJar.build(request, cookies.to_hash)
       expect(cookie_jar.encrypted[:ratings]).to eq(%i[an_id another_id].to_json)
@@ -36,8 +36,8 @@ RSpec.shared_examples_for 'rateable' do |path, comment_path, _context, id, ratin
     it 'prevents re-rating' do
       stub_a_valid_request
 
-      get send(path, polarity: :negative, id: :an_id, user_id: user.id) # First request
-      get send(path, polarity: :negative, id: :an_id, user_id: user.id) # Second request
+      post send(path, polarity: :negative, id: :an_id, user_id: user.id) # First request
+      post send(path, polarity: :negative, id: :an_id, user_id: user.id) # Second request
       body = JSON.parse(response.body)
       expect(response).to have_http_status(:conflict)
       expect(body['data']).to eq(nil)
@@ -45,6 +45,11 @@ RSpec.shared_examples_for 'rateable' do |path, comment_path, _context, id, ratin
   end
 
   describe 'GET #comment' do
+    before do
+      allow_any_instance_of(AuthenticationHelper)
+        .to receive(:current_user).and_return(user)
+    end
+
     it 'adds a comment to a rating' do
       stub_a_valid_request
       post send(comment_path, rating_id: rating_id, comment: 'This is a test')


### PR DESCRIPTION
Make ratings via POST requests to add no-follow to link

## Status

* Current Status: WIP
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1814

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Add authentication to rate and comment endpoints
* Make ratings via POST instead of GET, rails will add the `rel="nofollow"` attribute to the links.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
