### PR TITLE
1840: Remove unused route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,8 +124,6 @@ Rails.application.routes.draw do
   get '/cs-accelerator', to: 'pages#static_programme_page', as: :cs_accelerator,
                          defaults: { page_slug: 'cs-accelerator' }
   get '/external/assets/ncce.css', to: 'asset_endpoint#css_endpoint', as: :css_endpoint
-  get '/images/:id', to: 'asset_endpoint#stem_image_endpoint', as: :stem_image_endpoint,
-                     constraints: { id: /[A-Za-z0-9-]+\.png/ }
   get '/fl-trailers', to: 'pages#page', as: :trailers, defaults: { page_slug: 'fl-trailers' }
   get '/gender-balance', to: 'pages#page', as: :gender_balance, defaults: { page_slug: 'gender-balance' }
   get '/get-involved', to: 'pages#page', as: :get_involved, defaults: { page_slug: 'get-involved' }


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Closes [#1840](https://github.com/NCCE/teachcomputing.org-issues/issues/1840)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Removes the unused `stem_image_endpoint`

## Steps to perform after deploying to production

* N/A
