### PR TITLE
1842: Update email domain, and protect against extremely rare test failure

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,20 +84,22 @@ class User < ApplicationRecord
 
       self[name] = case name.to_sym
                    when :email
-                     "#{id}@forgotten.com"
+                     "#{id}@devnull-ncce.slcs.ac.uk"
                    when :stem_credentials_expires_at
                      DateTime.now
                    when :future_learn_organisation_memberships
                      []
                    when :forgotten
                      true
+                   when :last_sign_in_at
+                     nil
                    else
                      id
                    end
     end
 
-    self.stem_credentials_access_token = id
-    self.stem_credentials_refresh_token = id
+    self.stem_credentials_access_token = SecureRandom.hex(8)
+    self.stem_credentials_refresh_token = SecureRandom.hex(8)
 
     achievements_with_attachments = achievements.with_attachments
     achievements_with_attachments.each do |achievement|

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Api::UsersController do
       end
 
       it 'updates the email address' do
-        expect(JSON.parse(response.body)['email']).to eq "#{user.id}@forgotten.com"
+        expect(JSON.parse(response.body)['email']).to eq "#{user.id}@devnull-ncce.slcs.ac.uk"
       end
 
       it 'removes the future_learn_organisation_memberships' do
@@ -87,6 +87,10 @@ RSpec.describe Api::UsersController do
 
           expect(value).to eq(user.id)
         end
+      end
+
+      it 'sets last_sign_in_at to nil' do
+        expect(JSON.parse(response.body)['last_sign_in_at']).to be_nil
       end
 
       it 'does not break the relationships' do


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Closes [#1842](https://github.com/NCCE/teachcomputing.org-issues/issues/1842)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Update email domain when forgetting a user
* Protect against an extremely rare test failure by scrubbing some values more carefully

## Steps to perform after deploying to production

* N/A
