### PR TITLE
1848: amend to use 'schools' in nav, and add leaders pages

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,20 +1,20 @@
 module NavigationHelper
   def header_navigation
     [
-      { text: 'Primary teachers',
+      { text: 'Primary school',
         children: [
           { text: 'Primary teacher toolkit', link: primary_teachers_path, label: 'Primary teachers' },
-          { text: 'Primary certificate', link: primary_path, label: 'Primary certificate' }
+          { text: 'Primary certificate', link: primary_path, label: 'Primary certificate' },
+          { text: 'Primary senior leaders', link: '/primary-senior-leaders', label: 'Primary SLT' }
         ] },
-      { text: 'Secondary teachers', children:
-        [{ text: 'Secondary teacher toolkit',
-           link: secondary_teachers_path, label: 'Secondary teachers' },
-         { text: 'Subject knowledge certificate',
-           link: cs_accelerator_path, label: 'Subject knowledge certificate' },
-         { text: 'Secondary certificate',
-           link: secondary_path, label: 'Secondary certificate' },
-         { text: 'A level computer science',
-           link: a_level_computer_science_path, label: 'A level computer science' }] },
+      { text: 'Secondary school',
+        children: [
+          { text: 'Secondary teacher toolkit', link: secondary_teachers_path, label: 'Secondary teachers' },
+          { text: 'Subject knowledge certificate', link: cs_accelerator_path, label: 'Subject knowledge certificate' },
+          { text: 'Secondary certificate', link: secondary_path, label: 'Secondary certificate' },
+          { text: 'A level computer science', link: a_level_computer_science_path, label: 'A level computer science' },
+          { text: 'Secondary senior leaders', link: '/secondary-senior-leaders', label: 'Secondary SLT' }
+        ] },
       { text: 'Training and support',
         children: [
           { text: 'Courses', link: courses_path, label: 'Courses' },


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Closes [#1848](https://github.com/NCCE/teachcomputing.org-issues/issues/1848)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Amends primary and secondary teachers pages to say schools in nav
* Adds leaders pages to nav

## Steps to perform after deploying to production

* N/A