### PR TITLE
Strict same site protection

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,8 @@ Bundler.require(*Rails.groups)
 
 module TeachComputing
   class Application < Rails::Application
+    config.action_dispatch.cookies_same_site_protection = :strict
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 


### PR DESCRIPTION
closes https://github.com/NCCE/teachcomputing.org-issues/issues/1817
## What's changed?

Adds a strict option to config to prevent cookies passed in from other sites from being recognised. 