### PR TITLE
Set cookies_same_site_protection to lax

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,8 @@ Bundler.require(*Rails.groups)
 
 module TeachComputing
   class Application < Rails::Application
+    config.action_dispatch.cookies_same_site_protection = :lax
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 


### PR DESCRIPTION
## Status

* Current Status: Ready

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Set cookies_same_site_protection to `lax` to ensure allowing of cookie exchange if request resulted from a top-level navigation by the user.
