### PR TITLE
Render pathways from database on certificate page

### DIFF
--- a/app/views/pages/certification/_pathway.html.erb
+++ b/app/views/pages/certification/_pathway.html.erb
@@ -1,27 +1,13 @@
 <div class="pathway-wrapper light-grey-bg">
   <h2 class="govuk-heading-s">Choose a pathway</h2>
-	<p class="govuk-body">Are you an aspiring computer science teacher, or are you unsure which courses support your development objectives? Our learning pathways are designed for teachers at different levels and provide a set of recommended courses to help you get started.</p>
+  <p class="govuk-body">Are you an aspiring computer science teacher, or are you unsure which courses support your development objectives? Our learning pathways are designed for teachers at different levels and provide a set of recommended courses to help you get started.</p>
   <ul class="govuk-list">
-		<li class="pathway__item">
-			<%= link_to 'New to computing', 'https://static.teachcomputing.org/pathways/01_New_to_computing.pdf', class: 'govuk-link ncce-link icon-resources' %>
-			<span class="pathway__item--pdf">PDF</span>
-		</li>
-		<li class="pathway__item">
-			<%= link_to 'New to algorithms & programming', 'https://static.teachcomputing.org/pathways/03_New_to_algorithms_and_programming.pdf', class: 'govuk-link ncce-link icon-resources' %>
-			<span class="pathway__item--pdf">PDF</span>
-		</li>
-		<li class="pathway__item">
-			<%= link_to 'New to computer systems', 'https://static.teachcomputing.org/pathways/04_New_to_computer_systems.pdf', class: 'govuk-link ncce-link icon-resources' %>
-			<span class="pathway__item--pdf">PDF</span>
-		</li>
-		<li class="pathway__item">
-			<%= link_to 'Preparing to teach GCSE computer science', 'https://static.teachcomputing.org/pathways/02_Preparing_to_teach_GCSE_computer_science.pdf', class: 'govuk-link ncce-link icon-resources' %>
-			<span class="pathway__item--pdf">PDF</span>
-		</li>
-		<li class="pathway__item">
-			<%= link_to 'Advanced GCSE computer science', 'https://static.teachcomputing.org/pathways/05_Teaching_advanced_GCSE_computer_science.pdf', class: 'govuk-link ncce-link icon-resources' %>
-			<span class="pathway__item--pdf">PDF</span>
-		</li>
+    <% Pathway.ordered.each do |pathway| %>
+      <li class="pathway__item">
+        <%= link_to pathway.title, pathway.pdf_link, class: 'govuk-link ncce-link icon-resources' %>
+        <span class="pathway__item--pdf">PDF</span>
+      </li>
+    <% end %>
   </ul>
   <p class="govuk-body">You can also tailor your learning, selecting from our wide range of courses to increase your subject knowledge. </p>
   <p class="govuk-body">This may be a good option if you are self-motivated and already have a good understanding of computer science.</p>

--- a/spec/factories/pathways.rb
+++ b/spec/factories/pathways.rb
@@ -1,10 +1,11 @@
 FactoryBot.define do
   factory :pathway do
     range { 1..10 }
-    title { 'Pathway' }
+    sequence(:title) { |n| "Pathway #{n}" }
     description { 'Pathway description' }
-    pdf_link { 'https://example.com/pdf-link.pdf' }
+    sequence(:pdf_link) { |n| "https://example.com/pdf-#{n}-link.pdf" }
     sequence(:slug) { |n| "slug-#{n}" }
+    sequence(:order) { |n| n }
     programme
 
     trait :new_to_computing do

--- a/spec/views/pages/certification/_pathway.html_spec.rb
+++ b/spec/views/pages/certification/_pathway.html_spec.rb
@@ -1,23 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe('pages/certification/_pathway', type: :view) do
-	let(:programme) { create(:cs_accelerator) }
+  let(:programme) { create(:cs_accelerator) }
 
   before do
-		@programme = programme
-    render
+    @programme = programme
   end
 
   it 'has the title' do
+    render
     expect(rendered).to have_css('.govuk-heading-s', text: 'Choose a pathway')
   end
 
-  it 'has all items' do
-    expect(rendered).to have_css('.pathway__item', count: 5)
+  it 'renders pathways from database' do
+    pathway1 = create(:pathway)
+    pathway2 = create(:pathway)
+    render
+    expect(rendered).to have_css('.pathway__item', count: 2)
+    expect(rendered).to have_text(pathway1.title)
+    expect(rendered).to have_text(pathway2.title)
   end
 
   it 'has a courses button' do
+    render
     expect(rendered).to have_css('.button', text: 'Browse our courses')
   end
-
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App link(s): https://teachcomputing-staging-pr-1347.herokuapp.com/cs-accelerator
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1709

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Pull pathway data from database to render list on cs-accelerator page

