### PR TITLE
Fix auto enrolment when course on multiple programmes

### DIFF
--- a/app/models/achievement.rb
+++ b/app/models/achievement.rb
@@ -143,7 +143,7 @@ class Achievement < ApplicationRecord
     end
 
     def queue_auto_enrolment
-      return unless activity.programmes.any?(&:cs_accelerator?)
+      return unless programme&.cs_accelerator?
       return unless user.csa_auto_enrollable?
 
       CSAccelerator::AutoEnrolJob.perform_later(achievement_id: id)

--- a/lib/tasks/achievements.rake
+++ b/lib/tasks/achievements.rake
@@ -1,7 +1,7 @@
 namespace :achievements do
   desc 'Set progress on achievements where it is currently 0, takes value from transition meatadata where it exists'
   task set_progress: :environment do
-    achievements = Achievement.where(progress: 0)
+    achievements = Achievement.includes(:activity).where(progress: 0, activity: { provider: 'future-learn' })
     puts "Updating #{achievements.length} achievements"
 
     achievements.each do |achievement|


### PR DESCRIPTION
## Status

* Current Status: Ready for review


## What's changed?

* Only attempt to set progress on future-learn related achievements.
* Ensure auto enrolment only fires for csa achievements
