### PR TITLE
Add rake task to trigger historic secondary badges

### DIFF
--- a/lib/tasks/issue_historic_secondary_badges.rake
+++ b/lib/tasks/issue_historic_secondary_badges.rake
@@ -1,0 +1,9 @@
+task issue_historic_secondary_badges: :environment do
+  programme = Programme.secondary_certificate
+  enrolments = programme.user_programme_enrolments
+
+  enrolments.each do |enrolment|
+    has_first_stem_achievement = enrolment.user.achievements.in_state(:complete).with_provider('stem-learning').for_programme(programme).count >= 1
+    Credly::IssueBadgeJob.perform_later(enrolment.user.id, programme.id) if has_first_stem_achievement
+  end
+end


### PR DESCRIPTION
## Status

* Current Status: Ready
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1885

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Rake task to issue secondary badges for historic users

