### PR TITLE
Add rake task for updating active badges and then creating new 2021-22

### DIFF
--- a/lib/tasks/add_new_academic_year_badges_and_update_enabled_badges.rake
+++ b/lib/tasks/add_new_academic_year_badges_and_update_enabled_badges.rake
@@ -7,7 +7,7 @@ task add_new_academic_year_badges_and_update_enabled_badges: :environment do
   latest_primary_badge.update_attribute(active: false)
   latest_csa_badge.update_attribute(active: false)
 
-  Badge.create(credly_badge_template_id: '', academic_year: '2021-22', active: true, programme_id: Programme.secondary_certificate.id)
-  Badge.create(credly_badge_template_id: '', academic_year: '2021-22', active: true, programme_id: Programme.primary_certificate.id)
-  Badge.create(credly_badge_template_id: '', academic_year: '2021-22', active: true, programme_id: Programme.cs_accelerator.id)
+  Badge.create(credly_badge_template_id: '3e58c413-e9e0-4bb2-a6b8-4f7f064d0273', academic_year: '2021-22', active: true, programme_id: Programme.secondary_certificate.id)
+  Badge.create(credly_badge_template_id: '217479bf-039b-45a8-a61f-34c317b7f672', academic_year: '2021-22', active: true, programme_id: Programme.primary_certificate.id)
+  Badge.create(credly_badge_template_id: 'dc86853e-0878-4346-9156-63d2162fb0e1', academic_year: '2021-22', active: true, programme_id: Programme.cs_accelerator.id)
 end


### PR DESCRIPTION
## Status

* Current Status: Ready
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1884

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Add rake task to update active badges and then create new ones ready for academic year 21-22.

This is currently blocked as we are awaiting the template ids for each new badge.


## Steps to perform after deploying to production

- Add scheduled job to run via advanced scheduler. This should happen on the 1st of September at 00:01 am. 
