### PR TITLE
1906: Amend primary & secondary tag names

### DIFF
--- a/app/components/course_component.rb
+++ b/app/components/course_component.rb
@@ -11,4 +11,10 @@ class CourseComponent < ViewComponent::Base
     @course = course
     @course_filter = filter
   end
+
+  def get_course_tag(programme)
+    return "#{programme} certificate" if %w[Primary Secondary].include?(programme)
+
+    programme
+  end
 end

--- a/app/components/course_component/course_component.html.erb
+++ b/app/components/course_component/course_component.html.erb
@@ -33,7 +33,7 @@
           <% end %>
       <% end %>
       <% @course.programmes.each do |programme| %>
-        <strong class="govuk-tag ncce-courses__tag ncce-courses__tag ncce-courses__filter-tag--<%= programme.parameterize %>"><%= programme %></strong>
+        <strong class="govuk-tag ncce-courses__tag ncce-courses__tag ncce-courses__filter-tag--<%= programme.parameterize %>"><%= get_course_tag programme %></strong>
       <% end %>
   <% end %>
 </div>

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -3,21 +3,21 @@ module DashboardHelper
     if achievement&.cs_accelerator?
       'CS Accelerator'
     elsif achievement&.secondary_certificate?
-      'Secondary'
+      'Secondary certificate'
     elsif achievement&.primary_certificate?
-      'Primary'
+      'Primary certificate'
     end
   end
 
   def get_course_suffix(achievement)
-    get_course_tag(achievement)&.parameterize
+    get_course_tag(achievement)&.gsub(' certificate', '')&.parameterize
   end
 
   def get_date_string(achievement)
     if achievement.current_state == :complete.to_s
-      "Completed on #{achievement.created_at.strftime("%b %Y")}"
+      "Completed on #{achievement.created_at.strftime('%b %Y')}"
     else
-      "Enrolled on #{achievement.updated_at.strftime("%b %Y")}"
+      "Enrolled on #{achievement.updated_at.strftime('%b %Y')}"
     end
   end
 end

--- a/spec/components/course_component_spec.rb
+++ b/spec/components/course_component_spec.rb
@@ -1,13 +1,15 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe CourseComponent, type: :component do
   let(:course) { build(:achiever_course_template, activity_code: 'abc', title: 'test course') }
+  let(:course_primary) { build(:achiever_course_template, activity_code: 'abc', title: 'primary test course', programmes: ['Primary']) }
+  let(:course_secondary) { build(:achiever_course_template, activity_code: 'abc', title: 'secondary test course', programmes: ['Secondary']) }
   let(:filter) { instance_double(Achiever::CourseFilter) }
 
   before do
     allow(filter).to receive_messages(
-      subjects: { 'Algorithms' => 000000000, 'Other' => 222222222 },
-      age_groups: { 'Key stage 1' => 000000000, 'Key stage 2' => 222222222 }
+      subjects: { 'Algorithms' => 0o00000000, 'Other' => 222_222_222 },
+      age_groups: { 'Key stage 1' => 0o00000000, 'Key stage 2' => 222_222_222 }
     )
   end
 
@@ -26,9 +28,19 @@ RSpec.describe CourseComponent, type: :component do
     expect(rendered_component).to have_text('Algorithms')
   end
 
-  it 'shows programmes' do
+  it 'shows the expected tag for a CSA course' do
     render_inline(described_class.new(course: course, filter: filter))
     expect(rendered_component).to have_text('CS Accelerator')
+  end
+
+  it 'shows the expected tag for a Primary course' do
+    render_inline(described_class.new(course: course_primary, filter: filter))
+    expect(rendered_component).to have_text('Primary certificate')
+  end
+
+  it 'shows the expected tag for a Secondary course' do
+    render_inline(described_class.new(course: course_secondary, filter: filter))
+    expect(rendered_component).to have_text('Secondary certificate')
   end
 
   it 'shows age groups' do

--- a/spec/views/dashboard/show.html_spec.rb
+++ b/spec/views/dashboard/show.html_spec.rb
@@ -77,10 +77,10 @@ RSpec.describe('dashboard/show', type: :view) do
     end
 
     it 'shows the expected tag' do
-      expect(rendered).to have_css('.dashboard-tags--primary')
+      expect(rendered).to have_css('.dashboard-tags--primary', text: 'Primary certificate')
     end
 
-    it "does not render an empty list for complete achievements" do
+    it 'does not render an empty list for complete achievements' do
       expect(rendered).to have_css('.ncce-activity-list', count: 1)
     end
   end
@@ -104,10 +104,10 @@ RSpec.describe('dashboard/show', type: :view) do
     end
 
     it 'shows the expected tag' do
-      expect(rendered).to have_css('.dashboard-tags--secondary')
+      expect(rendered).to have_css('.dashboard-tags--secondary', text: 'Secondary certificate')
     end
 
-    it "does not render an empty list for incomplete achievements" do
+    it 'does not render an empty list for incomplete achievements' do
       expect(rendered).to have_css('.ncce-activity-list', count: 1)
     end
   end
@@ -128,7 +128,7 @@ RSpec.describe('dashboard/show', type: :view) do
     end
 
     it 'shows the expected tag' do
-      expect(rendered).to have_css('.dashboard-tags--cs-accelerator', count: 2)
+      expect(rendered).to have_css('.dashboard-tags--cs-accelerator', count: 2, text: 'CS Accelerator')
     end
   end
 


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1906

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Primary and secondary tags, now say 'Primary certificate' and 'Secondary certificate' on the overview dashboard and courses page 

## Steps to perform after deploying to production

* N/A
