### PR TITLE
1935: Add task to remove and re-add pathway activities

### DIFF
--- a/lib/tasks/fix_pathway_activities.rake
+++ b/lib/tasks/fix_pathway_activities.rake
@@ -1,0 +1,5 @@
+task fix_pathway_activities: :environment do
+  PathwayActivity.delete_all
+
+  require_relative '../../db/seeds/pathways/cs_accelerator'
+end


### PR DESCRIPTION


## Status

* Current Status: Ready for review
* Closes [#1935](https://github.com/NCCE/teachcomputing.org-issues/issues/1935)

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* It appears we ended up with duplicates after changing the ordering on the seeds. This adds a task to remove and re-add PathwayActivities from seeds

## Steps to perform after deploying to production

* Run `rake fix_pathway_activities`
