### PR TITLE
1944: Reinstate contributing partners

### DIFF
--- a/app/views/landing_pages/_contributing-partners-slice.html.erb
+++ b/app/views/landing_pages/_contributing-partners-slice.html.erb
@@ -2,8 +2,17 @@
   <div class="govuk-main-wrapper">
      <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds bottom-margin">
-          <h2 class="govuk-heading-l"> Contributing partners </h2>
-          <p class="govuk-body-l"> Our educational <a href="/contributing-partners" label="Contributing partners">partners</a> offer complementary programmes that enrich and enhance the curriculum, bringing computing and computer science to life.</p>
+          <h2 class="govuk-heading-l">Contributing partners</h2>
+          <p class="govuk-body-l">
+            Our educational
+            <%= link_to 'partners', contributing_partners_path,
+              class: 'ncce-link axe-skip-a11y-test',
+              data: { event_action: 'click',
+                      event_category: @landing_page.event_tracking_category,
+                      event_label: 'Contributing partners' }
+            %>
+            offer complementary programmes that enrich and enhance the curriculum, bringing computing and computer science to life.
+          </p>
         </div>
         <div class="govuk-grid-column-full">
           <%= render NonBorderedCardsComponent.new(@landing_page.contributing_partners) %>

--- a/app/views/landing_pages/_resources.html.erb
+++ b/app/views/landing_pages/_resources.html.erb
@@ -42,6 +42,7 @@
         </div>
         <div class="govuk-grid-column-one-third">
           <%= render 'landing_pages/subject-knowledge-assessments-aside' if @landing_page.secondary?  %>
+          <%= render 'landing_pages/contributing-partners-aside' if @landing_page.secondary? %>
         </div>
       </div>
     </div>

--- a/app/views/landing_pages/show.html.erb
+++ b/app/views/landing_pages/show.html.erb
@@ -18,5 +18,5 @@
 <%= render partial: 'landing_pages/courses' %>
 <%= render partial: 'landing_pages/resources' %>
 <%= render IsaacCardComponent.new(tracking_category: @landing_page.event_tracking_category) if @landing_page.secondary? %>
-<%= render partial: 'landing_pages/contributing-partners-slice' if @landing_page.primary?%>
+<%= render partial: 'landing_pages/contributing-partners-slice' if @landing_page.primary? %>
 <%= render partial: 'landing_pages/support' %>

--- a/spec/views/landing_pages/show.html_spec.rb
+++ b/spec/views/landing_pages/show.html_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe('landing_pages/show', type: :view) do
       expect(rendered).to have_css('.govuk-heading-l', text: 'Resources')
     end
 
+    it 'renders a knowledge assessment aside' do
+      expect(rendered).to have_link('View assessments', href: 'https://eedi.com/projects/teach-computing')
+    end
+
+    it 'renders a contributing partners aside' do
+      expect(rendered).to have_link('Meet our contributing partners', href: '/contributing-partners')
+    end
+
     it 'renders support section' do
       expect(rendered).to have_css('.govuk-heading-l', text: "We're here to help")
     end


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App link(s): https://teachcomputing-staging-pr-1390.herokuapp.com/
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1944

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Adds contributing partners back to the secondary teachers page
* Fixes event tracking on partners link on primary teachers page

## Steps to perform after deploying to production

* N/A
