### PR TITLE
1968: Amend brochure

### DIFF
--- a/app/views/pages/cs-accelerator.html.erb
+++ b/app/views/pages/cs-accelerator.html.erb
@@ -42,7 +42,7 @@
         </div>
         <h2 class="govuk-heading-s ncce-aside__title">Useful documents</h2>
         <p class="govuk-body-s">
-          <%= link_to 'Computer Science Accelerator brochure', 'https://static.teachcomputing.org/CSA.brochure.pdf', class: 'ncce-link' %>
+          <%= link_to 'Computer Science Accelerator brochure', 'https://static.teachcomputing.org/CS_Accelerator_handbook.pdf', class: 'ncce-link' %>
         </p>
         <p class="govuk-body-s">
           <%= link_to 'GCSE specifications to Computer Science Accelerator course map', 'https://static.teachcomputing.org/GCSE_specifications_to_CSA_course_map.pdf', class: 'ncce-link' %> (September 2020)


### PR DESCRIPTION


## Status

* Current Status: Ready for review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1968

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Updates the the link to the brochure to match everywhere else

## Steps to perform after deploying to production

* Remove https://static.teachcomputing.org/CSA.brochure.pdf from S3
