### PR TITLE
Add rake to update attempt assessment_ids

### DIFF
--- a/lib/tasks/update_assessment_attempts_ids.rake
+++ b/lib/tasks/update_assessment_attempts_ids.rake
@@ -1,0 +1,4 @@
+task update_assessment_attempts_ids: :environment do
+  assessment_id = Assessment.first.id
+  AssessmentAttempt.update_all(assessment_id: assessment_id)
+end


### PR DESCRIPTION
## Status

* Current Status: Ready
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2011

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Rake task to update assessment_id for all assessment attempts after creation of new record Friday.
