### PR TITLE
Bumps loglevel to debug

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  config.log_level = :info
+  config.log_level = :debug
 
   # Prepend all log lines with the following tags.
   config.log_tags = [


### PR DESCRIPTION
In order to attempt to decipher what's going on with these large (~7MB) responses from `stemraspberrypiapi.smartmembership.net:443`.

This will be reverted as soon as enough data has been captured (ideally within 24hrs).

We're not close to exceeding our Papertrail usage this month, so don't anticipate any issues there.