### PR TITLE
Add http_logger to sentry breadcrumbs

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,6 +1,6 @@
 Sentry.init do |config|
   config.dsn = Rails.application.credentials[ENV.fetch('SENTRY_DSN')]
-  config.breadcrumbs_logger = [:active_support_logger]
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
   config.traces_sample_rate = 0.25
   config.enabled_environments = %w[staging production]
 


### PR DESCRIPTION
## Status

* Current Status: Ready for review

## What's changed?

Adds http_logger to sentry. The courses index page is responding very slowly (~5s even with a warm cache) and most of that time appears to be in net/http. Hopefully this will give some more information on what exactly is happening.
