### PR TITLE
Switch to updated community version of ansi-html

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@rails/activestorage": "^6.1.3",
     "@rails/ujs": "^6.1.3",
     "@rails/webpacker": "^5.4.3",
+    "ansi-html-community": "0.0.8",
     "channels": "^0.0.4",
     "cookieconsent": "^3.1.0",
     "core-js": "^3.12.0",
@@ -72,5 +73,8 @@
       "git add"
     ]
   },
-  "pre-commit": "lint:staged"
+  "pre-commit": "lint:staged",
+  "resolutions": {
+    "ansi-html": "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1367,10 +1367,10 @@ ansi-escapes@^4.3.0:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-html@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
-  integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
+ansi-html-community@0.0.8, ansi-html@0.0.7, "ansi-html@https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
+  integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
 
 ansi-regex@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Related to https://github.com/NCCE/teachcomputing.org-issues/issues/1943
* Related to https://github.com/NCCE/teachcomputing.org/security/dependabot/yarn.lock/ansi-html/open

## What's changed?

- Switch to the ansi-html-community package as the ansi-html package is no longer maintained and the vulnerability in it will never be fixed.
