### PR TITLE
Increase memcache key limit from 1MB to 10MB

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,6 +74,7 @@ Rails.application.configure do
                          socket_failure_delay: 0.2,
                          down_retry_delay: 60,
                          pool_size: 5,
+                         value_max_bytes: 10485760,
                          ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
 
   # Use a real queuing backend for Active Job (and separate queues per environment)


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Related to https://github.com/NCCE/teachcomputing.org-issues/issues/2039

## What's changed?

The responses from the following two STEM API endpoints are coming in at around 7MB:

* `FutureOnlineCoursesByProgrammeId`
* `CourseListingFutureByProgrammeId`

STEM will be deploying new endpoints on Tuesday 1st Feb (`FutureOnlineCoursesByProgrammeIdV2Concise`
and `CourseListingFutureByProgrammeIdV2Concise`) so in the meantime, but also for general future-proofing, the suggestion is to increase the current memcached key size limit from 1MB (the default) to 10MB.