### PR TITLE
Use endpoint methods defined in env

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,6 +1,16 @@
 ACHIEVER_V2_PASSWORD=
 ACHIEVER_V2_USERNAME=
 ACHIEVER_V2_ENDPOINT=https://stemapi.dev3.smartmembership.net/smartconnector.smartconnector.svc/JSON/
+
+# If using staging can use the concise endpoints.
+ACHIEVER_F2F_METHOD=CourseListingFutureByProgrammeIdV2Concise
+ACHIEVER_ONLINE_METHOD=FutureOnlineCoursesByProgrammeIdV2Concise
+
+# Concise endpoints not implemented on prod yet, so use old endpoints.
+# Expected prod will have concise endpoints available 1/2/2022
+# ACHIEVER_F2F_METHOD=CourseListingFutureByProgrammeId
+# ACHIEVER_ONLINE_METHOD=FutureOnlineCoursesByProgrammeId
+
 AWS_ACCESS_KEY_ID=changeme
 AWS_SECRET_ACCESS_KEY=changeme
 AWS_S3_ACTIVE_STORAGE_BUCKET=changeme

--- a/app/services/achiever/course/occurrence.rb
+++ b/app/services/achiever/course/occurrence.rb
@@ -21,8 +21,9 @@ class Achiever::Course::Occurrence
                 :coordinates,
                 :distance
 
-  FACE_TO_FACE_RESOURCE_PATH = 'Get?cmd=CourseListingFutureByProgrammeId'.freeze
-  ONLINE_RESOURCE_PATH = 'Get?cmd=FutureOnlineCoursesByProgrammeId'.freeze
+  FACE_TO_FACE_RESOURCE_PATH = "Get?cmd=#{ENV['ACHIEVER_F2F_METHOD']}".freeze
+  ONLINE_RESOURCE_PATH = "Get?cmd=#{ENV['ACHIEVER_ONLINE_METHOD']}".freeze
+
   QUERY_STRINGS = { Page: '1',
                     RecordCount: '1000',
                     EndDate: Time.zone.today.strftime('%F'),

--- a/spec/support/achiever/achiever_stubs.rb
+++ b/spec/support/achiever/achiever_stubs.rb
@@ -39,13 +39,13 @@ module AchieverStubs
 
   def stub_face_to_face_occurrences
     json_response = File.new('spec/support/achiever/courses/face_to_face_occurrences.json')
-    uri_template = Addressable::Template.new 'https://stemapi.dev3.smartmembership.net/smartconnector.smartconnector.svc/JSON/Get?Date={date}&EndDate={end_date}&Page=1&ProgrammeName=ncce&RecordCount=1000&cmd=CourseListingFutureByProgrammeId'
+    uri_template = Addressable::Template.new "https://stemapi.dev3.smartmembership.net/smartconnector.smartconnector.svc/JSON/Get?Date={date}&EndDate={end_date}&Page=1&ProgrammeName=ncce&RecordCount=1000&cmd=#{ENV['ACHIEVER_F2F_METHOD']}"
     stub_request(:get, uri_template).to_return(body: json_response)
   end
 
   def stub_online_occurrences
     json_response = File.new('spec/support/achiever/courses/online_occurrences.json')
-    uri_template = Addressable::Template.new 'https://stemapi.dev3.smartmembership.net/smartconnector.smartconnector.svc/JSON/Get?EndDate={end_date}&Page=1&ProgrammeName=ncce&RecordCount=1000&cmd=FutureOnlineCoursesByProgrammeId'
+    uri_template = Addressable::Template.new "https://stemapi.dev3.smartmembership.net/smartconnector.smartconnector.svc/JSON/Get?EndDate={end_date}&Page=1&ProgrammeName=ncce&RecordCount=1000&cmd=#{ENV['ACHIEVER_ONLINE_METHOD']}"
     stub_request(:get, uri_template).to_return(body: json_response)
   end
 


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Related to https://github.com/NCCE/teachcomputing.org-issues/issues/2039

## What's changed?

* Use endpoint methods defined in environment vars to retrieve course occurrences
This will allow us to switch to the new concise endpoints on production without making any code changes once they are implemented
The env vars have already been [set via terraform](https://github.com/NCCE/terraform/pull/157)
