### PR TITLE
Amend bypass auth details to use stem_user_id correctly

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -69,7 +69,7 @@ if ActiveModel::Type::Boolean.new.cast(ENV.fetch('BYPASS_OAUTH', false))
       token: '14849048797785647933'
     },
     info: {
-      achiever_contact_no: '94c52a7c-5001-45e3-82bd-949a882f5fb6',
+      achiever_contact_no: '89085e3f-d60e-eb11-a813-000d3a86f6ce',
       first_name: 'Web',
       last_name: 'Raspberry Pi',
       email: 'web@raspberrypi.org'


### PR DESCRIPTION
## Status

* Current Status: Ready for review

## What's changed?

* Amend the stem_user_id used when bypassing auth to match the web@raspberrypi.org users ID.

This will allow us to bypass auth on staging and log in as the correct user.

## After merge

Once you've restarted the docker containers locally you will need to amend the stem_user_id of the web@raspberrypi.org user in your local database. Or reset the database and then log in bypassing auth.