### PR TITLE
Fix Ghost image size

### DIFF
--- a/app/webpacker/stylesheets/components/cms/_shared.scss
+++ b/app/webpacker/stylesheets/components/cms/_shared.scss
@@ -11,3 +11,9 @@
     border-bottom: none;
   }
 }
+
+// fixes for Ghost CMS image sizes
+.kg-image-card img {
+  width: 100%;
+  height: auto;
+}


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2053

## What's changed?

Ghost's latest release has introduced some new classes and styles that result in incorrect image sizing when rendered in the Teach Computing application:

<img width="1426" alt="Screenshot 2022-02-08 at 09 29 06" src="https://user-images.githubusercontent.com/91799/152958187-55695299-45f9-4ba5-95c3-8a62e0cc4cd5.png">

This fix restores the correct size / constraints:

<img width="751" alt="Screenshot 2022-02-08 at 09 28 54" src="https://user-images.githubusercontent.com/91799/152958230-1b707963-d6ff-45ae-9cf9-53e1f53c50a3.png">

