### PR TITLE
Reduce production loglevel to 'info'

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [


### PR DESCRIPTION
## What's changed?

The log level was increased to `debug` temporarily in order to debug issues we were seeing in production with one of STEM's APIs.

This issue has now been resolved, so the loglevel can be returned to `info`.