### PR TITLE
Add full QA host

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -140,5 +140,6 @@ Rails.application.configure do
   config.hosts << /teachcomputing-staging-pr-[a-z0-9-]+\.herokuapp\.com/
   config.hosts << 'staging.teachcomputing.org'
   config.hosts << 'teachcomputing-staging.herokuapp.com'
+  config.hosts << 'qa.teachcomputing.org'
   config.hosts << 'teachcomputing-qa.herokuapp.com'
 end


### PR DESCRIPTION
## What's changed?

In order to use STEM's OAuth flow, we need to access the QA app via the qa.teachcomputing.org subdomain (which is preferable anyway, over the Heroku-generated domain)