### PR TITLE
Adds alt blank quotes

### DIFF
--- a/app/views/pages/home/_confidence.html.erb
+++ b/app/views/pages/home/_confidence.html.erb
@@ -6,7 +6,7 @@
         <div class='ncce-confidence__panel'>
           <div class='ncce-confidence__panel-header'>
             <div class='ncce-confidence__icon-container'>
-              <%= image_pack_tag 'media/images/home/teacher_icon.svg', class: 'ncce-confidence__icon', alt: " " %>
+              <%= image_pack_tag 'media/images/home/teacher_icon.svg', class: 'ncce-confidence__icon', alt: "" %>
             </div>
             <h3 class='govuk-heading-m ncce-confidence__sub-heading'>Courses</h3>
           </div>
@@ -22,7 +22,7 @@
         <div class='ncce-confidence__panel'>
           <div class='ncce-confidence__panel-header'>
             <div class='ncce-confidence__icon-container'>
-              <%= image_pack_tag 'media/images/home/bursaries_icon_2.svg', class: 'ncce-confidence__icon', alt: " " %>
+              <%= image_pack_tag 'media/images/home/bursaries_icon_2.svg', class: 'ncce-confidence__icon', alt: "" %>
             </div>
             <h3 class='govuk-heading-m ncce-confidence__sub-heading'>Bursaries</h3>
           </div>
@@ -38,7 +38,7 @@
         <div class='ncce-confidence__panel'>
           <div class='ncce-confidence__panel-header'>
             <div class='ncce-confidence__icon-container'>
-                <%= image_pack_tag 'media/images/home/book_icon.svg', class: 'ncce-confidence__icon', alt: " " %>
+                <%= image_pack_tag 'media/images/home/book_icon.svg', class: 'ncce-confidence__icon', alt: "" %>
             </div>
             <h3 class='govuk-heading-m ncce-confidence__sub-heading'>Teaching resources</h3>
           </div>


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2108

## What's changed?

*Add blank quotes to the **alt** attributes of dashboard icons*

<img width="1379" alt="Screenshot 2022-05-13 at 12 37 58" src="https://user-images.githubusercontent.com/14819641/168275633-ca48f09e-fbe3-44e0-8a92-f61399310052.png">
