### PR TITLE
Adds curriculum pages banner

### DIFF
--- a/app/views/curriculum/_notice.html.erb
+++ b/app/views/curriculum/_notice.html.erb
@@ -1,0 +1,12 @@
+<div class="light-grey-bg">
+  <div class="govuk-width-container">
+		 <div class="govuk-main-wrapper ncce-notice_wrapper">
+				<div class="ncce-notice__container">
+					<span class="govuk-tag ncce-courses__tag ncce-notice__tag">ANNOUNCEMENT</span>
+					<div class="ncce-notice__copy">
+						<p class="govuk-body">Tried one of our resources? Please take 10 minutes <a href='http://ncce.io/tccsurvey' class="ncce-link">to complete our survey</a>. Most of the questions are multiple choice and we would love to hear your opinions.</p>
+					</div>
+    		</div>
+		</div>
+  </div>
+</div>

--- a/app/views/curriculum/key_stages/index.html.erb
+++ b/app/views/curriculum/key_stages/index.html.erb
@@ -2,6 +2,7 @@
 <% meta_tag :description, 'Curriculum resources contain everything you need to teach computing at key stages 1 to 4. Content is free to access, and has been created by subject experts.' %>
 <% meta_tag :image, asset_pack_path('media/images/curriculum/curriculum.png') %>
 <% meta_tag :url, request.original_url %>
+<%= render 'curriculum/notice' %>
 <%= render HeroMediaComponent.new(
   title: t('.hero.title'),
   text: t('.hero.text'),

--- a/app/views/curriculum/key_stages/show.html.erb
+++ b/app/views/curriculum/key_stages/show.html.erb
@@ -1,6 +1,7 @@
 <% meta_tag :title, @key_stage.title %>
 <% meta_tag :description, @key_stage.description %>
 <% meta_tag :image, asset_pack_path('media/images/curriculum/curriculum.png') %>
+<%= render 'curriculum/notice' %>
 <div class="hero hero--resources <%= ['1', '2'].include?(@key_stage.level) ? 'hero--orange' : 'hero--purple' %> hero--bottom-glyph">
   <div class="govuk-width-container">
     <div class="govuk-main-wrapper hero__wrapper">

--- a/spec/views/curriculum/_notice.html_spec.rb
+++ b/spec/views/curriculum/_notice.html_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe('curriculum/_notice', type: :view) do
+  before do
+    render
+  end
+
+  it 'has a tag' do
+    expect(rendered).to have_css('.ncce-courses__tag', text: 'ANNOUNCEMENT')
+  end
+
+  it 'has some words' do
+    expect(rendered).to have_text('Tried one of our resources?')
+  end
+end


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2131

## What's changed?

*Adds banner to curriculum pages*

<img width="1418" alt="Screenshot 2022-06-29 at 14 12 08" src="https://user-images.githubusercontent.com/14819641/176444997-0b73975f-a7e4-4f09-940b-a1aa943cde74.png">

============================================================================================

<img width="1402" alt="Screenshot 2022-06-29 at 14 12 24" src="https://user-images.githubusercontent.com/14819641/176445051-e7a73b11-4716-459e-9d5f-4b9ec3fa42be.png">

