### PR TITLE
Displays learning objectives only when there are present on a lesson

### DIFF
--- a/spec/support/curriculum/views/lesson_alt.json
+++ b/spec/support/curriculum/views/lesson_alt.json
@@ -27,24 +27,6 @@
         }
       },
       "learning_objectives": [
-        {
-          "id": "90db7eb4-1a88-44ef-815d-873fca2351cc",
-          "description": "To identify technology",
-          "success_criteria": [
-            {
-              "id": "60eb3fab-dfc1-4290-a47f-64d39ffa7621",
-              "description": "I can explain technology as something that helps us"
-            },
-            {
-              "id": "67c253e7-f4a3-4c13-8171-10059f23b309",
-              "description": "I can locate examples of technology in the classroom"
-            },
-            {
-              "id": "0200cd71-3803-4dcd-a85c-99a81ccea2d9",
-              "description": "I can explain how these technology examples help us"
-            }
-          ]
-        }
       ]
     }
   }

--- a/spec/views/curriculum/lessons/_learning_objectives_spec.rb
+++ b/spec/views/curriculum/lessons/_learning_objectives_spec.rb
@@ -45,24 +45,6 @@ RSpec.describe('curriculum/lessons/_learning_objectives', type: :view) do
     end
   end
 
-  context 'when there are no objectives present' do
-    before do
-      json = { "objectives": [] }.to_json
-
-      data = JSON.parse(json, object_class: OpenStruct)
-
-      render partial: 'curriculum/lessons/learning_objectives',
-             locals: {
-               key_stage_level: '1',
-               objectives: data.objectives
-             }
-    end
-
-    it 'does not render the learning objectives partial' do
-      expect(rendered).not_to have_text('Learning objectives')
-    end
-  end
-
   context 'when the key stage 3 or 4' do
     before do
       json =

--- a/spec/views/curriculum/lessons/show_spec.rb
+++ b/spec/views/curriculum/lessons/show_spec.rb
@@ -109,4 +109,15 @@ RSpec.describe('curriculum/lessons/show', type: :view) do
       expect(rendered).to have_css('.curriculum__rating')
     end
   end
+
+  context 'when there are no objectives present' do
+      before do
+        setup_view_with_range
+        render
+      end
+
+    it 'does not render the learning objectives partial' do
+      expect(rendered).not_to have_text('Learning objectives')
+    end
+  end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for  review
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2151

## What's changed?

*Resolves learning objectives lesson rendering issue*
