### PR TITLE
2181: Update cs champions aside

### DIFF
--- a/app/views/landing_pages/_champions-aside.html.erb
+++ b/app/views/landing_pages/_champions-aside.html.erb
@@ -1,12 +1,12 @@
 <div class="ncce-aside">
   <h2 class="govuk-heading-s">
-    CS Champions
+    Subject Expert support
   </h2>
   <p class="govuk-body-s ncce-bursary-aside__text">
-    Our team provide support and mentoring to help you complete the Computer Science Accelerator programme.
+    Our Computing Hubs provide support and mentoring to help you complete the Subject knowledge certificate
   </p>
   <p class="govuk-body-s ncce-bursary-aside__link">
-    <%= link_to 'Email our CS Champions', 'mailto:CSChampionSupport@stem.org.uk',
+    <%= link_to 'Contact your local hub', '/hubs',
         class: 'ncce-link ncce-link--contrast',
         data: { event_action: 'click',
                 event_category: @landing_page.event_tracking_category,


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2181

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Updates the copy to make references to cs champions point to hubs

## Steps to perform after deploying to production

* N/A
