### PR TITLE
Seed new course CP278

### DIFF
--- a/db/seeds/activities/stem_learning.rb
+++ b/db/seeds/activities/stem_learning.rb
@@ -1611,11 +1611,10 @@ end
 
 a.programmes << cs_accelerator unless a.programmes.include?(cs_accelerator)
 
-# TODO: Why is this new course titled the same as the one above?
 a = Activity.find_or_create_by(stem_course_template_no: '16aa21f9-9d53-ed11-9562-0022481b5a27') do |activity|
   activity.title = 'Supporting GCSE computer science students at grades 1 to 3'
   activity.credit = 10
-  activity.slug = 'supporting-gcse-computer-science-students-at-grades-1-to-3'
+  activity.slug = 'supporting-gcse-computer-science-students-at-grades-1-to-3-face-to-face'
   activity.stem_course_template_no = '16aa21f9-9d53-ed11-9562-0022481b5a27'
   activity.category = 'face-to-face'
   activity.provider = 'stem-learning'


### PR DESCRIPTION
# Description

Please can we seed the following new course as per Dig support request from Liz:
- Course CP code: CP278
- Course name: Supporting GCSE computer science students at grades 1 to 3
- Format: Face to face
- Template ID: 16aa21f9-9d53-ed11-9562-0022481b5a27
- Certificate: CSA
- Hours/credits: 5 hrs so should count as 1 course in terms of credits 

# Related

- Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2213
- #1184 is an earlier example where @damienh seeded 12 new courses

# TODO

- [x] Find similar closed PR to understand what's needed
  - [x] e.g. ones [labelled certificate and courses](https://github.com/NCCE/teachcomputing.org-issues/issues?q=label%3Acertificate+is%3Aclosed+label%3Acourses)
- [x] Find how many credits a face-to-face CSA course is worth
  - From [Issue #2213](https://github.com/NCCE/teachcomputing.org-issues/issues/2213):
    > We said for this course format and duration it's 20 but pleases confirm to avoid confusion between credits for online courses that are 5 hours long, and face-to-face / remote ones which are 5 hours  long.
  - It should be 10 credits like other similar CSA courses
- [x] Work out why CP478 has the exact same title 
  - The old one is remote, the new one is face-to-face
- [x] Implements seeds
- [x] After approval merge and run `rails db:seed` on staging
  - [x] Check: https://staging.teachcomputing.org/courses/CP278/supporting-gcse-computer-science-students-at-grades-1-to-3-face-to-face
    - That 404s, but that's OK
  - [x] Check database: `Activity.find_by(stem_course_template_no: '16aa21f9-9d53-ed11-9562-0022481b5a27')` 
- [x] promote to prod and run `rails db:seed` on prod
    - [x] Check database: `Activity.find_by(stem_course_template_no: '16aa21f9-9d53-ed11-9562-0022481b5a27')` 
- [x] Once completed pls let Liz know [via the slack thread](https://ncce-group.slack.com/archives/CFG0FU3PD/p1666618282828799) that she can make the course live in dynamics
