### PR TITLE
Edit title to use h3 tag instead

### DIFF
--- a/app/views/curriculum/units/_lessons.html.erb
+++ b/app/views/curriculum/units/_lessons.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
 	<div class="govuk-grid-column-full">
-		<h3 class="govuk-body-l">Lessons</h3>
+		<h3 class="govuk-heading-m">Lessons</h3>
 			<ul class="govuk-list govuk-body govuk-!-padding-bottom-7">
         <% lessons.each do |lesson| %>
             <li class="curriculum__list--item <%= key_stage_list_color(key_stage.level) %>"><%= link_to lesson_title_wording(lesson), curriculum_key_stage_unit_lesson_path(key_stage_slug: key_stage.slug, unit_slug: unit.slug, lesson_slug: lesson.slug), class: 'govuk-link ncce-link' %></li>

--- a/app/views/curriculum/units/_lessons.html.erb
+++ b/app/views/curriculum/units/_lessons.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
 	<div class="govuk-grid-column-full">
-		<p class="govuk-body-l">Lessons</p>
+		<h3 class="govuk-body-l">Lessons</h3>
 			<ul class="govuk-list govuk-body govuk-!-padding-bottom-7">
         <% lessons.each do |lesson| %>
             <li class="curriculum__list--item <%= key_stage_list_color(key_stage.level) %>"><%= link_to lesson_title_wording(lesson), curriculum_key_stage_unit_lesson_path(key_stage_slug: key_stage.slug, unit_slug: unit.slug, lesson_slug: lesson.slug), class: 'govuk-link ncce-link' %></li>

--- a/spec/views/curriculum/units/_lessons_spec.rb
+++ b/spec/views/curriculum/units/_lessons_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe('curriculum/units/_lessons', type: :view) do
   end
 
   it 'has a title' do
-    expect(rendered).to have_css('.govuk-body-l', text: 'Lessons')
+    expect(rendered).to have_css('.govuk-body-m', text: 'Lessons')
   end
 
   it 'has list of lessons' do

--- a/spec/views/curriculum/units/_lessons_spec.rb
+++ b/spec/views/curriculum/units/_lessons_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe('curriculum/units/_lessons', type: :view) do
   end
 
   it 'has a title' do
-    expect(rendered).to have_css('.govuk-body-m', text: 'Lessons')
+    expect(rendered).to have_css('.govuk-heading-m', text: 'Lessons')
   end
 
   it 'has list of lessons' do


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2239

## What's changed?

*Switches to us h3 instead of just a p tag*
<img width="1328" alt="Screenshot 2022-12-14 at 13 54 31" src="https://user-images.githubusercontent.com/14819641/207614475-3174872e-752b-47f7-a37a-e83a03cbd6ac.png">

