### PR TITLE
Fix for vars in .env not being picked up

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -67,3 +67,6 @@ BYPASS_OAUTH=true
 OAUTH_DEBUG=false
 
 DEFAULT_ADMIN_EMAIL=web@raspberrypi.org
+
+# This must exist in .env for docker-compose to detect it
+ENV_FILE=.env

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,14 +430,14 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-healthcheck (1.4.0)
-      actionpack
-      railties
     rails-erd (1.7.2)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
       choice (~> 0.2.0)
       ruby-graphviz (~> 1.2)
+    rails-healthcheck (1.4.0)
+      actionpack
+      railties
     rails-html-sanitizer (1.4.4)
       loofah (~> 2.19, >= 2.19.1)
     railties (6.1.4.7)
@@ -704,8 +704,8 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.3.1)
   rails (~> 6.1.4.1)
   rails-controller-testing
-  rails-healthcheck
   rails-erd
+  rails-healthcheck
   reek
   rest-client (~> 2.0.2)
   rspec-json_expectations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,8 +35,6 @@ services:
     depends_on:
       - redis
       - web
-    environment:
-      - ENV_FILE=.env
     env_file:
       - ${ENV_FILE:-.env.defaults}
     restart: unless-stopped
@@ -65,7 +63,6 @@ services:
       - PROXY_URL=http://host.docker.internal:8888
       - RAILS_DEV_DB_PASS=password
       - WEBPACKER_DEV_SERVER_HOST=webpack
-      - ENV_FILE=.env
     stdin_open: true
     tty: true # Allow interactive byebug sessions
     restart: unless-stopped


### PR DESCRIPTION
## Status

* Current Status: Ready for review

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Discovered a recent change to define the `ENV_FILE` var under `environment` in the `docker-compose.yml` caused the var not to be detected, when providing a fallback in `env_file`, perhaps they're not loaded early enough? this fixes that

## Steps to perform after deploying

* Ensure `ENV_FILE=.env` is defined in your `.env` if using one
