### PR TITLE
Fix access to Achiever Smart Connector from a docker container without a proxy

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -37,7 +37,7 @@ FL_PARTNERS_URL=https://lticourses-api.sandbox.futurelearn.com # The sandbox is 
 FL_PARTNERS_IGNORED_COURSE_UUIDS=
 
 GOOGLE_TAG_MANAGER_KEY=key
-PROXY_URL=http://localhost:8888
+PROXY_URL=http://host.docker.internal:8888 # without docker, use http://localhost:8888
 REDIS_URL=redis://redis:6379
 SENTRY_DSN=false
 STATIC_FILE_PATH=https://static.teachcomputing.org

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ ACHIEVER_V2_USERNAME=...
 ACHIEVER_V2_ENDPOINT=...
 ```
 
-You will need to ensure you have a proxy setup. You can do this [here](https://github.com/NCCE/private-documentation/blob/master/APIs/rpf-proxy.md)
+If your IP address is whitelisted, set `PROXY_URL=''` in `.env`. If not, you will need to ensure you have a proxy setup that tunnels to a whitelisted IP. You can do this [here](https://github.com/NCCE/private-documentation/blob/master/APIs/rpf-proxy.md)
 
 There are two commands `yarn start-tunnel` and `yarn stop-tunnel` that are wrappers to manage the proxy locally, `yarn start` (below) utilises this to create the tunnel when the stack is brought up. It is important to have this setup for testing, however please see the 'Offline Dynamics' section below for how to run this offline.
 

--- a/app/services/achiever/connection.rb
+++ b/app/services/achiever/connection.rb
@@ -5,7 +5,7 @@ class Achiever::Connection
     Faraday.new(url: ENV.fetch('ACHIEVER_V2_ENDPOINT')) do |conn|
       conn.adapter :net_http
       conn.request(:basic_auth, ENV.fetch('ACHIEVER_V2_USERNAME'), ENV.fetch('ACHIEVER_V2_PASSWORD'))
-      conn.proxy = ENV.fetch('PROXY_URL')
+      conn.proxy = ENV.fetch('PROXY_URL') # set PROXY_URL='' if you don't need a proxy
     end
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,6 @@ services:
       - docker-host
       - webpack
     environment:
-      - PROXY_URL=http://host.docker.internal:8888
       - RAILS_DEV_DB_PASS=password
       - WEBPACKER_DEV_SERVER_HOST=webpack
     stdin_open: true


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review

## Review progress:

~- [ ] Browser tested~
~- [ ] Front-end review completed~
- [x] Tested by RPF developer
- [x] Tech review completed

## What's changed?

Storm doesn't have a proxy tunnel, as we share a fixed IPv4 address, so I removed PROXY_URL from the compose file, to allow this setting in the local `.env` to override it

I moved this value to `.env.defaults` so that the proxy still works for the RPF devs that need it.

I tested by running an achiever rake task in the web container's console:
```
root@9ae610137ec9 /app - (fix/default-smart-connector-host) $ bin/rails achiever:get_course_info
false
false
false
false
false
Achiever currently has 170 courses with 1 F2F & 0 online occurrences
Time: 3.836331785 s.
root@9ae610137ec9 /app - (fix/default-smart-connector-host) $
```
