### PR TITLE
2291: Remove gbic cta

### DIFF
--- a/app/views/pages/gender-balance.html.erb
+++ b/app/views/pages/gender-balance.html.erb
@@ -42,14 +42,6 @@
 					<%= link_to 'Discover our research articles', 'https://blog.teachcomputing.org/tag/gbic-article/', class: 'govuk-button button govuk-!-margin-bottom-3', data: tracking_data('research articles') %>
 				</div>
       </div>
-      <div class="govuk-grid-column-one-third">
-        <div class="ncce-aside">
-          <p class="govuk-body"><strong>Get updates about our programme<strong>
-          </p>
-          <p class="govuk-body">Want the latest news and updates about our research?</p>
-      		<%= link_to 'Sign up for our newsletter', 'https://raspberrypi.us9.list-manage.com/subscribe?u=54fbc2c9ac9d9dd634725107a&id=400611fc51', class: 'govuk-button button button--aside', data: tracking_data('newsletter') %>
-        </div>
-      </div>
     </div>
   </div>
 </div>

--- a/spec/views/pages/gender-balance.html_spec.rb
+++ b/spec/views/pages/gender-balance.html_spec.rb
@@ -21,14 +21,6 @@ RSpec.describe('pages/gender-balance', type: :view) do
     expect(rendered).to have_css('.padded-box', count: 2)
   end
 
-  it 'has an aside section' do
-    expect(rendered).to have_css('.ncce-aside', text: 'Sign up for our newsletter')
-  end
-
-  it 'has a newsletter button' do
-    expect(rendered).to have_link('Sign up for our newsletter', href: 'https://raspberrypi.us9.list-manage.com/subscribe?u=54fbc2c9ac9d9dd634725107a&id=400611fc51')
-  end
-
   it 'has a learn more button' do
     expect(rendered).to have_link('Discover our research articles', href: 'https://blog.teachcomputing.org/tag/gbic-article/')
   end


### PR DESCRIPTION
## Status

* Current Status: WIP / Ready for review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2291

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Removes newsletter call to action from gbic page

## Steps to perform after deploying to production

* N/A
