### PR TITLE
Allow Sentry to be passed an environment ENV var

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,6 @@
 Sentry.init do |config|
   config.dsn = ENV.fetch('SENTRY_DSN')
+  config.environment = ENV.fetch('SENTRY_CURRENT_ENV', nil) || ENV.fetch('RAILS_ENV', nil)
   config.breadcrumbs_logger = %i[sentry_logger active_support_logger http_logger]
   config.traces_sample_rate = 0.25
   config.enabled_environments = %w[staging production]


### PR DESCRIPTION
Environments can then optionally set `SENTRY_CURRENT_ENV` to a value (eg. `review`, `staging`, `qa`, `production`) in order to more clearly delineate where error reports are coming from.