### PR TITLE
Add empty announcement component

### DIFF
--- a/app/views/components/_announcement.html.erb
+++ b/app/views/components/_announcement.html.erb
@@ -4,7 +4,7 @@
 				<div class="ncce-announcement__container">
 					<span class="govuk-tag ncce-courses__tag ncce-announcement__tag">ANNOUNCEMENT</span>
 					<div class="ncce-announcement__copy">
-						<p class="govuk-body govuk-!-margin-bottom-0">Make an ANNOUNCEMENT here! ideally one that spans multiple lines and gives a decent idea of how long text would actually look, hmm maybe long enough? ok, let's see!</p>
+						<p class="govuk-body govuk-!-margin-bottom-0"></p>
 					</div>
     		</div>
 		</div>

--- a/app/views/components/_announcement.html.erb
+++ b/app/views/components/_announcement.html.erb
@@ -1,0 +1,12 @@
+<div class="light-grey-bg">
+  <div class="govuk-width-container">
+		 <div class="govuk-main-wrapper ncce-announcement_wrapper">
+				<div class="ncce-announcement__container">
+					<span class="govuk-tag ncce-courses__tag ncce-announcement__tag">ANNOUNCEMENT</span>
+					<div class="ncce-announcement__copy">
+						<p class="govuk-body govuk-!-margin-bottom-0">Make an ANNOUNCEMENT here! ideally one that spans multiple lines and gives a decent idea of how long text would actually look, hmm maybe long enough? ok, let's see!</p>
+					</div>
+    		</div>
+		</div>
+  </div>
+</div>

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -64,6 +64,7 @@
   <% end %>
 
   <%= render 'components/header' %>
+  <%#= render 'components/announcement' %>
   <%= yield :content %>
 
   <%= render 'components/footer' %>

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -37,6 +37,7 @@
 @import 'components/_supplementary-courses.scss';
 @import 'components/_details.scss';
 @import 'components/_expander.scss';
+@import 'components/_announcement.scss';
 @import 'components/landing_pages/_certificates.scss';
 @import 'components/landing_pages/_courses.scss';
 @import 'components/landing_pages/_resources.scss';

--- a/app/webpacker/stylesheets/components/_announcement.scss
+++ b/app/webpacker/stylesheets/components/_announcement.scss
@@ -1,0 +1,26 @@
+.ncce-announcement__container {
+  @include govuk-media-query($from: tablet) {
+    align-items: start;
+    display: grid;
+    grid-gap: 20px;
+    grid-template-columns: 10rem auto;
+  }
+}
+
+.ncce-announcement_wrapper {
+  padding: 20px 0;
+
+  @include govuk-media-query($from: tablet) {
+    padding: 25px 0;
+  }
+}
+
+.ncce-announcement__tag {
+  background: transparent !important;
+  text-align: center;
+  margin-bottom: 0;
+
+  @include govuk-media-query($until: tablet) {
+    margin-bottom: 5px;
+  }
+}

--- a/spec/views/components/pending_announcement_spec.rb
+++ b/spec/views/components/pending_announcement_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe('components/_announcement') do
+  before do
+    render
+  end
+
+  it 'has a tag' do
+    expect(rendered).to have_css('.ncce-announcement__tag', text: 'ANNOUNCEMENT')
+  end
+
+  it 'has the text' do
+    expect(rendered).to have_css('.ncce-announcement__copy', text: '')
+  end
+end


### PR DESCRIPTION
## Status

* Current Status: Ready for review

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [x] Tech review completed

## What's changed?

* Adds an empty announcement container, but comments out the render

## Steps to perform after deploying to production

* N/A
