### PR TITLE
Seed preprod QA courses

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -52,6 +52,8 @@ CREDLY_ORGANISATION_ID=id
 
 SIMPLECOV_MIN_COVERAGE=90
 
+PREPROD_ACHIEVER_COURSES=off
+
 # Use local templates to bypass stem api
 ACHIEVER_USE_LOCAL_TEMPLATES=true
 ACHIEVER_LOCAL_TEMPLATE_PATH='spec/support/achiever/local_templates'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,10 @@ require_relative './seeds/activities/future_learn'
 require_relative './seeds/activities/assessment'
 require_relative './seeds/activities/community'
 
+if ENV['PREPROD_ACHIEVER_COURSES'] == 'on'
+  require_relative './seeds/activities/preprod_achiever_courses'
+end
+
 require_relative './seeds/programme_activity_groupings/primary_certificate'
 require_relative './seeds/programme_activity_groupings/secondary_certificate'
 

--- a/db/seeds/activities/preprod_achiever_courses.rb
+++ b/db/seeds/activities/preprod_achiever_courses.rb
@@ -32,3 +32,17 @@ a = Activity.find_or_create_by(stem_course_template_no: '616b340e-ffb1-ed11-83ff
 end
 
 a.programmes << secondary_certificate unless a.programmes.include?(secondary_certificate)
+
+########################################################################################################################
+
+a = Activity.find_or_create_by(stem_course_template_no: '94196e7f-47b8-ed11-b597-0022481b547a') do |activity|
+  activity.title = 'NCCE Online Course 3'
+  activity.credit = 20
+  activity.slug = 'ncce-online-course-3'
+  activity.category = 'online'
+  activity.provider = 'stem-learning'
+  activity.stem_activity_code = 'OCT'
+  activity.always_on = true
+end
+
+a.programmes << secondary_certificate unless a.programmes.include?(secondary_certificate)

--- a/db/seeds/activities/preprod_achiever_courses.rb
+++ b/db/seeds/activities/preprod_achiever_courses.rb
@@ -1,0 +1,34 @@
+# These courses exist on the preprod instance of Dynamics for testing: so they are visible on
+# the preprod Smart Connector (Achiever)
+
+cs_accelerator = Programme.cs_accelerator
+primary_certificate = Programme.primary_certificate
+secondary_certificate = Programme.secondary_certificate
+
+########################################################################################################################
+
+a = Activity.find_or_create_by(stem_course_template_no: 'f5fe2274-fdb1-ed11-83ff-0022481b547a') do |activity|
+  activity.title = 'NCCE Online Course 1'
+  activity.credit = 20
+  activity.slug = 'ncce-online-course-1'
+  activity.category = 'online'
+  activity.provider = 'stem-learning'
+  activity.stem_activity_code = 'OC123'
+  activity.always_on = true
+end
+
+a.programmes << cs_accelerator unless a.programmes.include?(cs_accelerator)
+
+########################################################################################################################
+
+a = Activity.find_or_create_by(stem_course_template_no: '616b340e-ffb1-ed11-83ff-0022481b547a') do |activity|
+  activity.title = 'NCCE Online Course 2'
+  activity.credit = 20
+  activity.slug = 'ncce-online-course-2'
+  activity.category = 'online'
+  activity.provider = 'stem-learning'
+  activity.stem_activity_code = 'OC2879'
+  activity.always_on = true
+end
+
+a.programmes << secondary_certificate unless a.programmes.include?(secondary_certificate)


### PR DESCRIPTION
## Status

* Current Status: WIP
* Review App link(s): https://qa.teachcomputing.org/courses
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2279

## Review progress:
- [x] Tech review completed

## What's changed?

3 new online courses seeded as activities, only when 
```
PREPROD_ACHIEVER_COURSES=on
```

We added this variable to terraform for QA: https://github.com/NCCE/terraform/pull/178

