### PR TITLE
Fix pathway activity seed for an online course

### DIFF
--- a/db/seeds/pathways/cs_accelerator.rb
+++ b/db/seeds/pathways/cs_accelerator.rb
@@ -176,6 +176,10 @@ if activity
   end
 end
 
+# CO206/how-computers-work-demystifying-computation
+activity = Activity.find_by(stem_course_template_no: '249f1bc2-a5b6-ed11-b597-0022481b59ce')
+pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity
+
 activity = Activity.find_by(stem_course_template_no: '9187d975-a6b6-ed11-b597-0022481b59ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity
 


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review

## Review progress:

- [ ] Tech review completed

## What's changed?

add CO206 to new-to-computing cs accelerator pathway (as seen by a logged in user enrolled on the pathway https://teachcomputing.org/certificate/cs-accelerator )

(this is in the [March 2023 PDF](https://static.teachcomputing.org/pathways/01_New_to_computing.pdf) but I missed it from my earlier commit)

<img width="1391" alt="Screenshot 2023-03-07 at 12 12 34" src="https://user-images.githubusercontent.com/2813357/223419099-04eed103-921e-4744-8a01-ec152ed40f94.png">


## Steps to perform after deploying to production

run

    heroku run bin/rails fix_pathway_activities --app=teachcomputing-production

