### PR TITLE
Turn off FutureLearn update jobs on a specified date

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -41,9 +41,6 @@ NCCE2_START_DATE='2023-04-02'
 
 MYLEARNING_DASHBOARD_URL=https://mylearning.stem.org.uk/my/
 
-FLAG_NCCE2_TEST=off
-FLAG_NCCE2_LIVE=off
-
 GOOGLE_TAG_MANAGER_KEY=key
 PROXY_URL=http://host.docker.internal:8888 # without docker, use http://localhost:8888
 REDIS_URL=redis://redis:6379

--- a/.env.defaults
+++ b/.env.defaults
@@ -36,7 +36,13 @@ FL_PARTNERS_CONSUMER_SECRET=secret
 FL_PARTNERS_URL=https://lticourses-api.sandbox.futurelearn.com # The sandbox is currently disabled
 FL_PARTNERS_IGNORED_COURSE_UUIDS=
 
+FLAG_NCCE2=on
+NCCE2_START_DATE='2023-04-02'
+
 MYLEARNING_DASHBOARD_URL=https://mylearning.stem.org.uk/my/
+
+FLAG_NCCE2_TEST=off
+FLAG_NCCE2_LIVE=off
 
 GOOGLE_TAG_MANAGER_KEY=key
 PROXY_URL=http://host.docker.internal:8888 # without docker, use http://localhost:8888

--- a/.env.test
+++ b/.env.test
@@ -27,6 +27,9 @@ CURRICULUM_APP_URL=https://staging-curriculum.teachcomputing.org
 FL_PARTNERS_CONSUMER_KEY=ncce.test
 FL_PARTNERS_URL=https://lticourses-api.sandbox.futurelearn.com
 
+FLAG_NCCE2=on
+NCCE2_START_DATE='2023-01-01'
+
 MYLEARNING_DASHBOARD_URL=https://moodle.example.com/my/
 
 SIMPLECOV_MIN_COVERAGE=90

--- a/Gemfile
+++ b/Gemfile
@@ -110,6 +110,7 @@ group :test do
   gem 'shoulda-callback-matchers'
   gem 'shoulda-matchers', '~> 3.1'
   gem 'simplecov'
+  gem 'timecop', '~> 0.9.6'
   gem 'vcr'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -591,6 +591,7 @@ GEM
     thor (1.2.1)
     thread_safe (0.3.6)
     tilt (2.0.11)
+    timecop (0.9.6)
     timeout (0.3.0)
     ttfunk (1.7.0)
     turbolinks (5.2.1)
@@ -730,6 +731,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   statesman (~> 10.0.0)
+  timecop (~> 0.9.6)
   turbolinks (~> 5)
   uglifier (>= 4.2)
   vcr

--- a/app/services/feature_flag_service.rb
+++ b/app/services/feature_flag_service.rb
@@ -26,7 +26,7 @@ class FeatureFlagService
   #
   # TODO: rm this method when remove ncce2 flag
   #
-  # note: set NCCE2_START_DATE to 2nd April "2023-04-02T00:00:00+00:00" to allow the jobs to run a final time on 1st April and
+  # note: set NCCE2_START_DATE to 2nd April "2023-04-02" to allow the jobs to run a final time on 1st April and
   # pick up the last end of the month course completions.
   def ncce2_live
     start_date_string = ENV['NCCE2_START_DATE']

--- a/app/services/feature_flag_service.rb
+++ b/app/services/feature_flag_service.rb
@@ -1,5 +1,13 @@
+# a list of flags that are each enabled by setting them to 'on' in the environment
+#
+# access with FeatureFlagService.new.flags[:flag_key]
+#
+# use extra flags added locally at run time with FeatureFlagService.new(flags: {new_flag1: 'FLAG_NEW_FLAG1'}).flags[:new_flag1]
+#
 class FeatureFlagService
-  FLAGS = {}.freeze
+  FLAGS = {
+    ncce2: 'FLAG_NCCE2'
+  }.freeze
 
   def initialize(dependencies = {})
     @flags_to_define = dependencies.fetch(:flags) do
@@ -13,11 +21,23 @@ class FeatureFlagService
     end
   end
 
+  # only true when ncce2 flag set, and NCCE2_START_DATE has past; this is a one-off flag that turns on automatically on a date
+  # determined by the environment variable
+  #
+  # TODO: rm this method when remove ncce2 flag
+  #
+  # note: set NCCE2_START_DATE to 2nd April "2023-04-02T00:00:00+00:00" to allow the jobs to run a final time on 1st April and
+  # pick up the last end of the month course completions.
+  def ncce2_live
+    start_date_string = ENV['NCCE2_START_DATE']
+    return false unless start_date_string
+
+    flags[:ncce2] && (Date.today >= Date.parse(start_date_string))
+  end
+
   private
 
     def cast_boolean(string_value)
-      return false unless string_value.present?
-
-      ActiveModel::Type::Boolean.new.cast(string_value)
+      string_value == 'on'
     end
 end

--- a/lib/tasks/partners.rake
+++ b/lib/tasks/partners.rake
@@ -2,7 +2,7 @@ namespace :partners do
   desc "Checks organisation memberships for all course runs and attempts to add
   any membership ids we do not know about"
   task update_memberships: :environment do
-    return if FeatureFlagService.new.ncce2_live
+    next if FeatureFlagService.new.ncce2_live
 
     FutureLearn::UpdateOrganisationMembershipsJob.perform_now
   end
@@ -10,7 +10,7 @@ namespace :partners do
   desc "Queues the job that will fetch course runs from the partners api and
   start the process of updating course progress for users"
   task update_progress: :environment do
-    return if FeatureFlagService.new.ncce2_live
+    next if FeatureFlagService.new.ncce2_live
 
     FutureLearn::CourseRunsJob.perform_now
   end

--- a/lib/tasks/partners.rake
+++ b/lib/tasks/partners.rake
@@ -2,12 +2,16 @@ namespace :partners do
   desc "Checks organisation memberships for all course runs and attempts to add
   any membership ids we do not know about"
   task update_memberships: :environment do
+    return if FeatureFlagService.new.ncce2_live
+
     FutureLearn::UpdateOrganisationMembershipsJob.perform_now
   end
 
   desc "Queues the job that will fetch course runs from the partners api and
   start the process of updating course progress for users"
   task update_progress: :environment do
+    return if FeatureFlagService.new.ncce2_live
+
     FutureLearn::CourseRunsJob.perform_now
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -94,3 +94,5 @@ RSpec.configure do |config|
     raise JavascriptError errors.join("\n\n") if errors.present? && ENV['RAISE_CONSOLE_ERRORS']
   end
 end
+
+Timecop.safe_mode = true

--- a/spec/services/feature_flag_service_spec.rb
+++ b/spec/services/feature_flag_service_spec.rb
@@ -1,26 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe FeatureFlagService do
-  describe '.flags' do
+  around do |example|
+    orig_test_flag_var = ENV['TEST_FLAG_VAR']
+    orig_flag_ncce2 = ENV['FLAG_NCCE2']
+    orig_flag_ncce2_start_date = ENV['NCCE2_START_DATE']
+    example.run
+  ensure
+    ENV['TEST_FLAG_VAR'] = orig_test_flag_var
+    ENV['FLAG_NCCE2'] = orig_flag_ncce2
+    ENV['NCCE2_START_DATE'] = orig_flag_ncce2_start_date
+  end
+
+  describe '#flags' do
     subject(:flags) { described_class.new(flags: { test_flag: 'TEST_FLAG_VAR' }).flags }
 
-    context('when env var is "true"') do
+    context('when env var is "on"') do
       before do
-        ENV['TEST_FLAG_VAR'] = 'true'
+        ENV['TEST_FLAG_VAR'] = 'on'
       end
 
       it 'sets flag correctly' do
-        expect(flags[:test_flag]).to eq(true)
+        expect(flags[:test_flag]).to be true
       end
     end
 
-    context('when env var is "false"') do
+    context('when env var is "off"') do
       before do
-        ENV['TEST_FLAG_VAR'] = 'false'
+        ENV['TEST_FLAG_VAR'] = 'off'
       end
 
       it 'sets flag correctly' do
-        expect(flags[:test_flag]).to eq(false)
+        expect(flags[:test_flag]).to be false
       end
     end
 
@@ -30,7 +41,7 @@ RSpec.describe FeatureFlagService do
       end
 
       it 'sets flag correctly' do
-        expect(flags[:test_flag]).to eq(false)
+        expect(flags[:test_flag]).to be false
       end
     end
 
@@ -40,14 +51,50 @@ RSpec.describe FeatureFlagService do
       end
 
       it 'sets flag correctly' do
-        expect(flags[:test_flag]).to eq(false)
+        expect(flags[:test_flag]).to be false
       end
     end
   end
 
   describe 'FLAGS' do
     it 'defines hash of flags correctly' do
-      expect(FeatureFlagService::FLAGS.count).to eq 0
+      expect(FeatureFlagService::FLAGS.count).to eq 1
+    end
+  end
+
+  describe '#ncce2_live' do
+    it 'is true when flag set on start date' do
+      ENV['NCCE2_START_DATE'] = '2023-04-02'
+      ENV['FLAG_NCCE2'] = 'on'
+      Timecop.freeze(2023, 4, 2) do
+        expect(described_class.new.ncce2_live).to be true
+      end
+    end
+
+    it 'is false when flag unset' do
+      ENV['FLAG_NCCE2'] = nil
+      expect(described_class.new.ncce2_live).to be false
+    end
+
+    it 'is false when flag set before start date' do
+      ENV['NCCE2_START_DATE'] = '2023-04-02'
+      ENV['FLAG_NCCE2'] = 'on'
+      Timecop.freeze(2023, 4, 1, 23, 59) do
+        expect(described_class.new.ncce2_live).to be false
+      end
+    end
+
+    it 'is false when flag unset on start date' do
+      ENV['NCCE2_START_DATE'] = '2023-04-02'
+      ENV['FLAG_NCCE2'] = nil
+      Timecop.freeze(2023, 4, 2) do
+        expect(described_class.new.ncce2_live).to be false
+      end
+    end
+
+    it 'is false when start date unset' do
+      ENV['NCCE2_START_DATE'] = nil
+      expect(described_class.new.ncce2_live).to be false
     end
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2282

* https://github.com/NCCE/terraform/pull/179 deploys the env vars

## Review progress:

- [x] Tech review completed

## What's changed?

When NCCE2 starts, turn off
- FutureLearn::CourseRunsJob
- FutureLearn::UpdateOrganisationMembershipsJob

## Steps to perform after deploying to production

Set
```
FLAG_NCCE2=on
NCCE2_START_DATE='2023-04-02'
```
in production when you are ready
