### PR TITLE
Update CSA pathways with March/April 2023 courses

### DIFF
--- a/app/dashboards/activity_dashboard.rb
+++ b/app/dashboards/activity_dashboard.rb
@@ -34,6 +34,7 @@ class ActivityDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
+    stem_activity_code
     title
     description
   ].freeze

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -3,8 +3,8 @@ class Activity < ApplicationRecord
   ASSESSMENT_CATEGORY = 'assessment'.freeze
   COMMUNITY_CATEGORY = 'community'.freeze
   DIAGNOSTIC_CATEGORY = 'diagnostic'.freeze
-  FACE_TO_FACE_CATEGORY = 'face-to-face'.freeze
-  ONLINE_CATEGORY = 'online'.freeze
+  FACE_TO_FACE_CATEGORY = 'face-to-face'.freeze # includes live remote courses
+  ONLINE_CATEGORY = 'online'.freeze # self-paced
 
   has_many :achievements, dependent: :restrict_with_exception
   has_many :users, through: :achievements

--- a/db/seeds/activities/future_learn.rb
+++ b/db/seeds/activities/future_learn.rb
@@ -140,7 +140,7 @@ a = Activity.find_or_create_by(future_learn_course_uuid: '4ec560a3-6435-46bc-90b
   activity.stem_course_template_no = '497f57fd-bfaa-4b32-99b9-04f83805eb4c'
   activity.future_learn_course_uuid = '4ec560a3-6435-46bc-90b7-75cfdcf7e72d'
   activity.provider = 'future-learn'
-  activity.stem_activity_code = 'CO210R'
+  activity.stem_activity_code = 'CO010R'
   activity.always_on = true
 end
 

--- a/db/seeds/activities/mylearning.rb
+++ b/db/seeds/activities/mylearning.rb
@@ -104,7 +104,6 @@ end
 
 a.programmes << cs_accelerator unless a.programmes.include?(cs_accelerator)
 
-
 ########################################################################################################################
 
 a = Activity.find_or_create_by(stem_course_template_no: '63c44113-a4b6-ed11-b597-0022481b59ce') do |activity|

--- a/db/seeds/activities/stem_learning.rb
+++ b/db/seeds/activities/stem_learning.rb
@@ -1,4 +1,4 @@
-# This file contains seeds for Activities faciliated by STEM Learning
+# This file contains seeds for live (F2F and remote) Activities facilitated by STEM Learning
 
 cs_accelerator = Programme.cs_accelerator
 primary_certificate = Programme.primary_certificate

--- a/db/seeds/pathways/cs_accelerator.rb
+++ b/db/seeds/pathways/cs_accelerator.rb
@@ -26,6 +26,10 @@ pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activi
 activity = Activity.find_by(stem_course_template_no: '7ffcf8be-a6b6-ed11-b597-0022481b59ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity
 
+# CP478/supporting-gcse-computer-science-students-at-grades-1-3
+activity = Activity.find_by(stem_course_template_no: 'c53a5ed2-3c6e-ec11-8943-000d3a874094')
+pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity
+
 # alternative remote
 
 activity = Activity.find_by(stem_course_template_no: '67a21143-4886-ea11-a811-000d3a86d545')
@@ -39,12 +43,15 @@ pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplemen
 
 # alternative online
 
+# CO221/introduction-to-web-development
 activity = Activity.find_by(stem_course_template_no: '0bccfb49-a6b6-ed11-b597-0022481b59ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity
 
+# CO210/object-oriented-programming-in-python-create-your-own-adventure-game
 activity = Activity.find_by(stem_course_template_no: 'a46bc181-a4b6-ed11-b597-0022481b59ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity
 
+# CO225/introduction-to-databases-and-sql
 activity = Activity.find_by(stem_course_template_no: 'ed5a3948-a4b6-ed11-b597-0022481b59ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity
 
@@ -77,15 +84,21 @@ pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activi
 activity = Activity.find_by(stem_course_template_no: '9187d975-a6b6-ed11-b597-0022481b59ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity
 
-# alternative remote
+# CP439/higher-attainment-in-computer-science-meeting-the-challenges-of-the-exams-remote
+activity = Activity.find_by(stem_course_template_no: '03fb0a52-a712-eb11-a813-000d3a86d545')
+pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity
 
-activity = Activity.find_by(stem_course_template_no: '65fe83ad-b188-ea11-a811-000d3a86d545')
-pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity
+
+# alternative remote
 
 activity = Activity.find_by(stem_course_template_no: '67a21143-4886-ea11-a811-000d3a86d545')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity
 
 activity = Activity.find_by(stem_course_template_no: 'ce24e77f-d312-eb11-a813-000d3a86f6ce')
+pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity
+
+# CP478/supporting-gcse-computer-science-students-at-grades-1-3
+activity = Activity.find_by(stem_course_template_no: 'c53a5ed2-3c6e-ec11-8943-000d3a874094')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity
 
 # alternative online
@@ -122,18 +135,24 @@ pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activi
 activity = Activity.find_by(stem_course_template_no: 'ac3bf599-a6b6-ed11-b597-0022481b59ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity
 
+# CP420/representing-algorithms-using-flowcharts-and-pseudocode-remote
+activity = Activity.find_by(stem_course_template_no: '07e76ffd-e17f-ea11-a811-000d3a86f6ce')
+pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity
+
 # alternative remote
 
 activity = Activity.find_by(stem_course_template_no: '67a21143-4886-ea11-a811-000d3a86d545')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity
 
-activity = Activity.find_by(stem_course_template_no: '07e76ffd-e17f-ea11-a811-000d3a86f6ce')
-pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity
-
-activity = Activity.find_by(stem_course_template_no: 'e1e54959-db12-eb11-a813-000d3a86d54')
+# CP463/python-programming-advanced-subject-knowledge-implementation-and-testing-remote
+activity = Activity.find_by(stem_course_template_no: 'e1e54959-db12-eb11-a813-000d3a86d545')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity
 
 activity = Activity.find_by(stem_course_template_no: 'ad8580c0-2915-eb11-a813-000d3a86f6ce')
+pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity
+
+# CP430/search-and-sort-algorithms-remote
+activity = Activity.find_by(stem_course_template_no: 'ce24e77f-d312-eb11-a813-000d3a86f6ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity
 
 # alternative online
@@ -143,7 +162,6 @@ pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplemen
 
 activity = Activity.find_by(stem_course_template_no: '55cc7b90-a5b6-ed11-b597-0022481b59ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity
-
 
 ########################################################################################################################
 
@@ -194,9 +212,6 @@ pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplemen
 activity = Activity.find_by(stem_course_template_no: '07e76ffd-e17f-ea11-a811-000d3a86f6ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity
 
-activity = Activity.find_by(stem_course_template_no: '65fe83ad-b188-ea11-a811-000d3a86d545')
-pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity
-
 # alternative online
 
 activity = Activity.find_by(stem_course_template_no: '55cc7b90-a5b6-ed11-b597-0022481b59ce')
@@ -204,6 +219,8 @@ pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplemen
 
 activity = Activity.find_by(stem_course_template_no: 'e9cb65af-a4b6-ed11-b597-0022481b59ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity
+
+########################################################################################################################
 
 pathway = Pathway.find_or_initialize_by(slug: 'new-to-computer-systems')
 pathway.update(
@@ -223,16 +240,14 @@ pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activi
 activity = Activity.find_by(stem_course_template_no: '55cc7b90-a5b6-ed11-b597-0022481b59ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity
 
-activity = Activity.find_by(stem_course_template_no: '65fe83ad-b188-ea11-a811-000d3a86d545')
+# CP422/fundamentals-of-computer-networks-remote
+activity = Activity.find_by(stem_course_template_no: 'dd8a8433-e57f-ea11-a811-000d3a86f6ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity
 
 activity = Activity.find_by(stem_course_template_no: 'e9cb65af-a4b6-ed11-b597-0022481b59ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity
 
 # alternative remote
-
-activity = Activity.find_by(stem_course_template_no: 'dd8a8433-e57f-ea11-a811-000d3a86f6ce')
-pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity
 
 activity = Activity.find_by(stem_course_template_no: '770d8136-3d86-ea11-a811-000d3a86d545')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id, supplementary: true) if activity

--- a/db/seeds/pathways/primary_certificate.rb
+++ b/db/seeds/pathways/primary_certificate.rb
@@ -12,29 +12,23 @@ pathway.update(
   order: 1
 )
 
-# face to face / remote / online
+# face to face / remote
 
-activity = Activity.find_by(stem_course_template_no: '68f5b6c5-556d-4b66-8159-7cd6019da6f3')
+# CP454/introduction-to-primary-computing-remote
+activity = Activity.find_by(stem_course_template_no: 'bb7a0f31-5086-ea11-a811-000d3a86d545')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity && !pathway.pathway_activities.include?(activity)
 
-activity = Activity.find_by(stem_course_template_no: '488bed9b-515b-4295-a488-62b5bb6bf852')
-pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity && !pathway.pathway_activities.include?(activity)
+# online
 
-activity = Activity.find_by(stem_course_template_no: '16aeecbd-d202-4f42-bad3-f86c8f671547')
-pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity && !pathway.pathway_activities.include?(activity)
-
-activity = Activity.find_by(stem_course_template_no: '88975226-811c-ec11-b6e7-0022481a8033')
-pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity && !pathway.pathway_activities.include?(activity)
-
-activity = Activity.find_by(stem_course_template_no: '34ff2768-a7fc-ea11-a813-000d3a86d545')
-pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity && !pathway.pathway_activities.include?(activity)
-
+# CO041/teaching-programming-to-5-to-11-year-olds
 activity = Activity.find_by(stem_course_template_no: '563c4bde-a6b6-ed11-b597-0022481b59ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity && !pathway.pathway_activities.include?(activity)
 
+# CO700/creating-an-inclusive-classroom-approaches-to-supporting-learners-with-send-in-computing
 activity = Activity.find_by(stem_course_template_no: 'ded270cb-a4b6-ed11-b597-0022481b59ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity && !pathway.pathway_activities.include?(activity)
 
+# CO232/introduction-to-programming-with-scratch
 activity = Activity.find_by(stem_course_template_no: '06e59bb7-a1b6-ed11-b597-0022481b59ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity && !pathway.pathway_activities.include?(activity)
 
@@ -60,6 +54,8 @@ pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activi
 activity = Activity.find_by(slug: 'providing-additional-support')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity && !pathway.pathway_activities.include?(activity)
 
+########################################################################################################################
+
 pathway = programme.pathways.find_or_initialize_by(slug: 'specialising-or-leading')
 pathway.update(
   title: 'Specialising or leading',
@@ -70,18 +66,23 @@ pathway.update(
   order: 1
 )
 
+# CP008/leading-primary-computing-face-to-face
 activity = Activity.find_by(stem_course_template_no: 'e3c14378-3015-eb11-a813-000d3a86f6ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity && !pathway.pathway_activities.include?(activity)
 
-activity = Activity.find_by(stem_course_template_no: '11f58c3f-3341-eb11-a813-000d3a86d545')
+# CP456/leading-primary-computing-remote
+activity = Activity.find_by(stem_course_template_no: '3bff03fd-256d-eb11-a812-000d3a872640')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity && !pathway.pathway_activities.include?(activity)
 
+# CP005/outstanding-primary-computing-for-all-face-to-face
 activity = Activity.find_by(stem_course_template_no: '34ff2768-a7fc-ea11-a813-000d3a86d545')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity && !pathway.pathway_activities.include?(activity)
 
-activity = Activity.find_by(stem_course_template_no: 'ee8a70b8-1607-ec11-b6e6-000d3a86d86c')
+# CP255/implementing-the-teach-computing-curriculum-in-your-school
+activity = Activity.find_by(stem_course_template_no: '726ece56-27b0-ec11-983f-002248006a24')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity && !pathway.pathway_activities.include?(activity)
 
+# CO700/creating-an-inclusive-classroom-approaches-to-supporting-learners-with-send-in-computing
 activity = Activity.find_by(stem_course_template_no: 'ded270cb-a4b6-ed11-b597-0022481b59ce')
 pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity && !pathway.pathway_activities.include?(activity)
 

--- a/lib/tasks/fix_pathway_activities.rake
+++ b/lib/tasks/fix_pathway_activities.rake
@@ -1,3 +1,4 @@
+desc 'Refresh all the pathway activities from their seeds'
 task fix_pathway_activities: :environment do
   PathwayActivity.delete_all
 


### PR DESCRIPTION
## Status

* Current Status: WIP 
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2286

## Review progress:
- [x] Tech review completed

## What's changed?

- Update CP463 and CP464 titles to reflect production

- Admin activities index: add activity code

- Fix a typo in a seed (CO010R)

New to computing pathway
- Remove CP431 from additional

New to algorithms and programming pathway
- Add CP420 to main
- Remove CP420 from additional
- Add CP430 to additional

New to computer systems pathway
- Move CP422 from additional to main
- Remove CP431 from main

Preparing to teach GCSE pathway
- Add CP439 to main
- Remove CP431 from additional
- Add CP478 to additional

Advanced GCSE pathway
- Add CP478 to main

## After deployment to production

Run

    heroku run ./bin/rails fix_pathway_activities  --app=teachcomputing-production
