### PR TITLE
Feature: only one course for certs

### DIFF
--- a/app/components/course_activity_component/course_activity_component.html.erb
+++ b/app/components/course_activity_component/course_activity_component.html.erb
@@ -3,8 +3,12 @@
     <%= content_tag :div, class: ['course-activity-component__objective-text', { "course-activity-component__objective-text--complete": achievements_complete? }] do %>
       <%= @objective %>
     <% end %>
-    <%= link_to t('.book_button_text'), @booking[:path], class: 'govuk-button button course-activity-component__objective-button', data: tracking_data(@booking[:tracking_label]) %>
+
+    <% if @booking.present? %>
+      <%= link_to t('.book_button_text'), @booking[:path], class: 'govuk-button button course-activity-component__objective-button', data: tracking_data(@booking[:tracking_label]) %>
+    <% end %>
   </span>
+
   <% unless @achievements.blank? %>
     <%= content_tag :div, class: 'course-activity-component__course-wrapper' do %>
       <% @achievements.each do |achievement| %>

--- a/app/components/course_activity_component/course_activity_component.scss
+++ b/app/components/course_activity_component/course_activity_component.scss
@@ -28,6 +28,10 @@
     margin-bottom: 0.5rem;
   }
 
+  &:only-child {
+    grid-column: 1 / span 2;
+  }
+
   &--complete {
     background-image: url('../images/icons/tick-green-dark.svg');
     background-position: left top;

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -28,6 +28,7 @@ class Activity < ApplicationRecord
   scope :available_for, lambda { |user|
     where('id NOT IN (SELECT activity_id FROM achievements WHERE user_id = ?)', user.id)
   }
+  scope :courses, -> { where(category: [FACE_TO_FACE_CATEGORY, ONLINE_CATEGORY]) }
   scope :online, -> { where(category: ONLINE_CATEGORY) }
   scope :face_to_face, -> { where(category: FACE_TO_FACE_CATEGORY) }
   scope :future_learn, -> { where(provider: 'future-learn') }

--- a/app/views/certificates/primary_certificate/_achievement_list.html.erb
+++ b/app/views/certificates/primary_certificate/_achievement_list.html.erb
@@ -4,12 +4,12 @@
 <ul class="govuk-list ncce-activity-list ncce-activity-list--programme" role="list">
   <li class="ncce-activity-list__item">
     <%= render CourseActivityComponent.new(
-      objective: t('.face_to_face_prompt.html'),
+      objective: t('.any_course_prompt'),
       booking: {
-        path: courses_path(course_format: %i[face_to_face remote], certificate: @programme.slug),
+        path: courses_path(certificate: @programme.slug),
         tracking_label: 'Book remote or F2F course'
       },
-      achievements: @face_to_face_achievements,
+      achievements: @face_to_face_achievements + @online_achievements,
       tracking_category: tracking_category
     ) %>
   </li>
@@ -22,17 +22,6 @@
       ) %>
     </li>
   <% end %>
-  <li class="ncce-activity-list__item">
-    <%= render CourseActivityComponent.new(
-      objective: t('.online_prompt.html'),
-      booking: {
-        path: courses_path(course_format: %i[online], certificate: @programme.slug),
-        tracking_label: 'Book online course'
-      },
-      achievements: @online_achievements,
-      tracking_category: tracking_category
-    ) %>
-  </li>
   <% if @user_pathway.present? %>
     <li class="ncce-activity-list__item">
       <%= render partial: 'certificates/pathways/recommended_courses', locals: {

--- a/app/views/certificates/secondary_certificate/_achievement_list.html.erb
+++ b/app/views/certificates/secondary_certificate/_achievement_list.html.erb
@@ -4,12 +4,9 @@
 <ul class="govuk-list ncce-activity-list ncce-activity-list--programme" role="list">
   <li class="ncce-activity-list__item">
     <%= render CourseActivityComponent.new(
-      objective: t('.face_to_face_prompt.html'),
-      booking: {
-        path: courses_path(course_format: %i[face_to_face remote], certificate: @programme.slug),
-        tracking_label: 'Book remote or F2F course'
-      },
-      achievements: @face_to_face_achievements,
+      objective: t('.any_course_prompt'),
+      booking: nil,
+      achievements: @face_to_face_achievements + @online_achievements,
       tracking_category: tracking_category
     ) %>
   </li>
@@ -22,17 +19,6 @@
       ) %>
     </li>
   <% end %>
-  <li class="ncce-activity-list__item">
-    <%= render CourseActivityComponent.new(
-      objective: t('.online_prompt.html'),
-      booking: {
-        path: courses_path(course_format: %i[online], certificate: @programme.slug),
-        tracking_label: 'Book online course'
-      },
-      achievements: @online_achievements,
-      tracking_category: tracking_category
-    ) %>
-  </li>
   <li class="ncce-activity-list__item">
     <div class='ncce-activity-list__button-wrapper'>
       <%= link_to t('.all_courses_button'),

--- a/config/locales/views/certificates/pathways/_recommended_courses.en.yml
+++ b/config/locales/views/certificates/pathways/_recommended_courses.en.yml
@@ -4,5 +4,5 @@ en:
       recommended_courses:
         courses_intro:
           html: "Courses based on your pathway"
-        all_courses_button: "View all certificate courses"
+        all_courses_button: "View and book courses"
         other_formats: "Some courses are available in different formats"

--- a/config/locales/views/certificates/primary_certificate/_achievement_list.en.yml
+++ b/config/locales/views/certificates/primary_certificate/_achievement_list.en.yml
@@ -5,8 +5,5 @@ en:
         development:
           title:
             html: "<strong>Participate in professional development</strong>"
-        all_courses_button: "View all certificate courses"
-        face_to_face_prompt:
-          html: "Complete <strong>at least one</strong> face to face, or remote course"
-        online_prompt:
-          html: "Complete <strong>at least one</strong> online course"
+        all_courses_button: "View and book courses"
+        any_course_prompt: "Complete any course from this certificate"

--- a/config/locales/views/certificates/secondary_certificate/_achievement_list.en.yml
+++ b/config/locales/views/certificates/secondary_certificate/_achievement_list.en.yml
@@ -5,8 +5,5 @@ en:
         development:
           title:
             html: "<strong>Participate in professional development</strong>"
-        all_courses_button: "View all certificate courses"
-        face_to_face_prompt:
-          html: "Complete <strong>at least one</strong> face to face, or remote course"
-        online_prompt:
-          html: "Complete <strong>at least one</strong> online course"
+        all_courses_button: "View and book courses"
+        any_course_prompt: "Complete any course from this certificate"

--- a/db/seeds/programme_activity_groupings/primary_certificate.rb
+++ b/db/seeds/programme_activity_groupings/primary_certificate.rb
@@ -2,13 +2,10 @@ primary_certificate = Programme.primary_certificate
 
 puts 'Creating Programme Activity Groupings for Primary certificate'
 
-primary_certificate.programme_activity_groupings.find_or_create_by(title: 'Online courses') do |programme_activity_group|
-  programme_activity_group.sort_key = 1
-  programme_activity_group.required_for_completion = 1
-  programme_activity_group.programme_id = primary_certificate.id
-end
+## The numbering of the groupings starts at 2 for historical reasons: group_one with sort_key 1 existed when users were required
+## to complete 2 courses, one from each of groups 1 and 2.
 
-primary_certificate.programme_activity_groupings.find_or_create_by(title: 'Face to face or remote courses') do |programme_activity_group|
+primary_certificate.programme_activity_groupings.find_or_create_by(title: 'All courses') do |programme_activity_group|
   programme_activity_group.sort_key = 2
   programme_activity_group.required_for_completion = 1
   programme_activity_group.programme_id = primary_certificate.id
@@ -34,21 +31,11 @@ end
 
 puts 'Seeding Programme Activity Groupings for Primary Certificate'
 
-# Online/Future Learn courses
-
-group_one = primary_certificate.programme_activity_groupings.find_by(sort_key: 1)
-
-primary_certificate.activities.online.each do |activity|
-  programme_activity = primary_certificate.programme_activities.find_or_create_by(activity_id: activity.id)
-  programme_activity.update(programme_activity_grouping_id: group_one.id) unless group_one.programme_activities.include?(programme_activity)
-end
-
-# STEM Learning Courses
+# All Courses
 
 group_two = primary_certificate.programme_activity_groupings.find_by(sort_key: 2)
 
-# The face_to_face category covers remote too (as we have no specific remote category)
-primary_certificate.activities.face_to_face.each do |activity|
+primary_certificate.activities.courses.each do |activity|
   programme_activity = primary_certificate.programme_activities.find_or_create_by(activity_id: activity.id)
   programme_activity.update(programme_activity_grouping_id: group_two.id) unless group_two.programme_activities.include?(programme_activity)
 end

--- a/db/seeds/programme_activity_groupings/secondary_certificate.rb
+++ b/db/seeds/programme_activity_groupings/secondary_certificate.rb
@@ -2,13 +2,10 @@ secondary = Programme.secondary_certificate
 
 puts 'Creating Programme Activity Groupings'
 
-secondary.programme_activity_groupings.find_or_create_by(title: 'Online courses') do |programme_activity_group|
-  programme_activity_group.sort_key = 1
-  programme_activity_group.required_for_completion = 1
-  programme_activity_group.programme_id = secondary.id
-end
+## The numbering of the groupings starts at 2 for historical reasons: group_one with sort_key 1 existed when users were required
+## to complete 2 courses, one from each of groups 1 and 2.
 
-secondary.programme_activity_groupings.find_or_create_by(title: 'Face to face or remote courses') do |programme_activity_group|
+secondary.programme_activity_groupings.find_or_create_by(title: 'All courses') do |programme_activity_group|
   programme_activity_group.sort_key = 2
   programme_activity_group.required_for_completion = 1
   programme_activity_group.programme_id = secondary.id
@@ -34,21 +31,11 @@ end
 
 puts 'Seeding Programme Activity Groupings for Secondary'
 
-# Online/Future Learn courses
-
-group_one = secondary.programme_activity_groupings.find_by(sort_key: 1)
-
-secondary.activities.online.each do |activity|
-  programme_activity = secondary.programme_activities.find_or_create_by(activity_id: activity.id)
-  programme_activity.update(programme_activity_grouping_id: group_one.id) unless group_one.programme_activities.include?(programme_activity)
-end
-
-# STEM Learning Courses
+# Courses
 
 group_two = secondary.programme_activity_groupings.find_by(sort_key: 2)
 
-# The face_to_face category covers remote too (as we have no specific remote category)
-secondary.activities.face_to_face.each do |activity|
+secondary.activities.courses.each do |activity|
   programme_activity = secondary.programme_activities.find_or_create_by(activity_id: activity.id)
   programme_activity.update(programme_activity_grouping_id: group_two.id) unless group_two.programme_activities.include?(programme_activity)
 end

--- a/spec/views/certificates/primary-certificate/show.html_spec.rb
+++ b/spec/views/certificates/primary-certificate/show.html_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe('certificates/primary_certificate/show', type: :view) do
       assign(:current_user, user)
       assign(:user_pathway, nil)
 
+      assign(:face_to_face_achievements, [])
+      assign(:online_achievements, [])
+
       assign(:professional_development_groups, professional_development_groups)
       assign(:online_discussion_activity, community_activity)
       assign(:community_groups, community_groups)
@@ -50,8 +53,7 @@ RSpec.describe('certificates/primary_certificate/show', type: :view) do
     end
 
     it 'has the expected section titles' do
-      expect(rendered).to have_text('Complete at least one online course')
-      expect(rendered).to have_text('Complete at least one face to face, or remote course')
+      expect(rendered).to have_text('Complete any course from this certificate')
       expect(rendered).to have_text('Choose at least one activity to A group name', count: 2)
     end
 
@@ -60,7 +62,7 @@ RSpec.describe('certificates/primary_certificate/show', type: :view) do
     end
 
     it 'shows all activities' do
-      expect(rendered).to have_css('.ncce-activity-list__item', count: 6)
+      expect(rendered).to have_css('.ncce-activity-list__item', count: 5)
     end
 
     it 'shows no hidden activity title' do
@@ -68,7 +70,7 @@ RSpec.describe('certificates/primary_certificate/show', type: :view) do
     end
 
     it 'has view all courses button' do
-      expect(rendered).to have_link('View all certificate courses')
+      expect(rendered).to have_link('View and book courses')
     end
 
     it 'has bursary information' do
@@ -110,6 +112,9 @@ RSpec.describe('certificates/primary_certificate/show', type: :view) do
   describe 'when the user has a pathway' do
     before do
       assign(:current_user, user)
+
+      assign(:face_to_face_achievements, [])
+      assign(:online_achievements, [])
 
       assign(:professional_development_groups, professional_development_groups)
       assign(:online_discussion_activity, community_activity)

--- a/spec/views/certificates/secondary-certificate/show.html_spec.rb
+++ b/spec/views/certificates/secondary-certificate/show.html_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe('certificates/secondary_certificate/show', type: :view) do
   before do
     assign(:current_user, user)
     assign(:programme, secondary_certificate)
+    assign(:face_to_face_achievements, [])
+    assign(:online_achievements, [])
     assign(:professional_development_groups, programme_activity_groupings)
     assign(:community_groups, programme_activity_groupings)
 
@@ -27,8 +29,7 @@ RSpec.describe('certificates/secondary_certificate/show', type: :view) do
   end
 
   it 'has the expected section titles' do
-    expect(rendered).to have_text('Complete at least one online course')
-    expect(rendered).to have_text('Complete at least one face to face, or remote course')
+    expect(rendered).to have_text('Complete any course from this certificate')
     expect(rendered).to have_text('Choose at least one activity to a group name', count: 2)
   end
 
@@ -41,7 +42,11 @@ RSpec.describe('certificates/secondary_certificate/show', type: :view) do
   end
 
   it 'has view all courses button' do
-    expect(rendered).to have_link('View all certificate courses')
+    expect(rendered).to have_link('View and book courses')
+  end
+
+  it 'shows all activities' do
+    expect(rendered).to have_css('.ncce-activity-list__item', count: 4)
   end
 
   it 'has support information' do


### PR DESCRIPTION
## Status

* Current Status: Ready for front-end & tech review
* Review App link(s): *not yet deployed*
  * https://qa.teachcomputing.org/certificate/secondary-certificate (note: need to have completed the accelerator and enroled)
  * https://qa.teachcomputing.org/certificate/primary-certificate (note: need to have enroled)
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2287

## Review progress:

- [x] Front-end review completed
- [x] Tech review completed

## What's changed?

Simplify primary and secondary certificates to require only 1 eligible course rather than 1 of each kind (live and online)

- https://docs.google.com/document/d/1rifqkHlOsnS8iRv3pKM9dCuAqc53jaRT/edit
- https://docs.google.com/document/d/1tVxTLG6vBzir5rO0vRwSvMCwlnEKFCUh/edit

## Steps to perform after deploying to production

Run
```
heroku run  bin/rails update_certificate_data && bin/rails db:seed --app=teachcomputing-production
```
