### PR TITLE
Dashboard - update logos and copy of online course (stem-learning provider only) and remove logos for FutureLearn course

### DIFF
--- a/app/components/provider_logos_component.rb
+++ b/app/components/provider_logos_component.rb
@@ -3,37 +3,22 @@
 class ProviderLogosComponent < ViewComponent::Base
   include ViewComponent::Translatable
 
-  def initialize(online:, dashboard: false, class_name: nil)
-    @online = online
-    @org_prefix = @online ? 'rpf' : 'stem'
+  def initialize(provider: 'stem-learning', dashboard: true, class_name: nil)
+    @provider = provider
     @dashboard = dashboard
 
-    standard_logos = online ? online_logos : other_logos
-    dashboard_logos = online ? dashboard_online_logos : other_logos
-    @logos = dashboard ? dashboard_logos : standard_logos
+    # Won't display logos for retired course providers to minimize untested layouts and stale logos. 'future-learn' courses were
+    # retired in February 2023.
+    @logos = (provider == 'stem-learning') ? logos : []
 
     @class_name = class_name
   end
 
-  def online_logos
+  def logos
+    # no alt texts as they don't add to the information in provider_text
     [
-      { filename: 'tc-logo-small.svg', alt: 'Teachcomputing logo' },
-      { filename: 'rpf-logo-small.svg', alt: 'Raspberry Pi Foundation logo' }
-    ]
-  end
-
-  def dashboard_online_logos
-    [
-      { filename: 'tc-logo-small.svg', alt: 'Teachcomputing logo' },
-      { filename: 'rpf-logo-small.svg', alt: 'Raspberry Pi Foundation logo' },
-      { filename: 'fl-logo-small.svg', alt: 'Futurelearn logo' }
-    ]
-  end
-
-  def other_logos
-    [
-      { filename: 'tc-logo-small.svg', alt: 'Teachcomputing logo' },
-      { filename: 'stem-logo-small.svg', alt: 'STEM Learning logo' }
+      { filename: 'ncce-logo.svg', alt: '' },
+      { filename: 'stem-logo-small.svg', alt: '' }
     ]
   end
 end

--- a/app/components/provider_logos_component/provider-logos_component.scss
+++ b/app/components/provider_logos_component/provider-logos_component.scss
@@ -10,12 +10,18 @@
     margin-bottom: 0;
   }
 
-  &--dashboard {
-    .provider-logos-component__copy {
-      font-size: 1rem;
-    }
+  img {
+    height: 43px;
+    width: auto;
+  }
 
+  &--dashboard {
     border-top: none;
     padding-bottom: 0;
+
+    img {
+      height: 30px;
+      width: auto;
+    }
   }
 }

--- a/app/components/provider_logos_component/provider_logos_component.html.erb
+++ b/app/components/provider_logos_component/provider_logos_component.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag :div, class: ['govuk-body', 'govuk-!-margin-bottom-0', 'provider-logos-component', { "provider-logos-component--dashboard": @dashboard }, { "#{@class_name}": @class_name.present? }] do %>
-  <div class='govuk-body-s provider-logos-component__copy'><%= t(".#{@org_prefix}_provider_text") %></div>
+  <div class='govuk-body-s provider-logos-component__copy'><%= t(".provider_text.#{@provider}") %></div>
   <div class='govuk-body-s provider-logos-component__logo-wrapper'>
     <% @logos.each do | logo | %>
       <div class='provider-logos-component__logo'><%= image_pack_tag "media/images/logos/#{logo[:filename]}", alt: logo[:alt] %></div>

--- a/app/components/provider_logos_component/provider_logos_component.yml
+++ b/app/components/provider_logos_component/provider_logos_component.yml
@@ -1,3 +1,4 @@
 en:
-  rpf_provider_text: "This course is from Teach Computing and delivered by Raspberry Pi Foundation"
-  stem_provider_text: "This course is from Teach Computing and delivered by STEM Learning"
+  provider_text:
+    future-learn: "This course is from Teach Computing and delivered by Raspberry Pi Foundation."
+    stem-learning: "This course is from the National Centre for Computing Education and is delivered by STEM Learning."

--- a/app/models/achievement.rb
+++ b/app/models/achievement.rb
@@ -124,7 +124,7 @@ class Achievement < ApplicationRecord
   private_class_method :initial_state, :transition_class
 
   delegate :can_transition_to?, :current_state, :transition_to, :last_transition, :in_state?, to: :state_machine
-  delegate :title, :stem_activity_code, :slug, to: :activity
+  delegate :provider, :title, :stem_activity_code, :slug, to: :activity
 
   private
 

--- a/app/views/courses/_aside-booking.html.erb
+++ b/app/views/courses/_aside-booking.html.erb
@@ -154,15 +154,8 @@
     <% end %>
   <% end %>
 
-  <div class='govuk-body govuk-!-margin-bottom-0 provider-logos' %>
-    <div class='govuk-body-s'>
-      This course is from the National Centre for Computing Education and is delivered by STEM Learning.
-    </div>
-    <div class='govuk-body-s provider-logos__logo-wrapper'>
-      <%= image_pack_tag 'media/images/logos/ncce-logo.svg', alt: '' %>
-      <%= image_pack_tag 'media/images/logos/stem-logo-small.svg', alt: '', class: '' %>
-    </div>
-  </div>
+  <%= render ProviderLogosComponent.new(dashboard: false)%>
+
   <% if current_user && user_achievement_state(current_user, @activity) == :enrolled && @course.online_cpd %>
     <p class='govuk-body-s ncce-booking-list__progress'>
       Can't see the progress of your course? You may need to rejoin the course.

--- a/app/views/courses/_aside-booking.html.erb
+++ b/app/views/courses/_aside-booking.html.erb
@@ -51,7 +51,7 @@
                 target: :_blank
                 ) %>
           </p>
-          <%= render('courses/start-date', date: @start_date) unless @started %>
+          <%= render('start-date', date: @start_date) unless @started %>
         <% end %>
       </div>
     <% elsif user_achievement_state(current_user, @activity) == :enrolled && @course.online_cpd %>
@@ -71,7 +71,7 @@
         </p>
       <% end %>
 
-      <%= render('courses/start-date', date: @start_date) unless @started %>
+      <%= render('start-date', date: @start_date) unless @started %>
     <% elsif user_achievement_state(current_user, @activity) == :enrolled && !@course.online_cpd %>
        <h2 class="govuk-heading-m ncce-aside__title"><%= @booking.enrolled_title %></h2>
        <p class="govuk-body-s ncce-aside__text"><%= @booking.introduction %></p>
@@ -150,7 +150,7 @@
           class: 'ncce-link', draggable: 'false',
           data: { event_action: 'click', event_category: 'course details'} %>
       </p>
-      <%= render('courses/start-date', date: @start_date) if (@course.online_cpd && !@started) %>
+      <%= render('start-date', date: @start_date) if (@course.online_cpd && !@started) %>
     <% end %>
   <% end %>
 

--- a/app/views/dashboard/_achievement_list.html.erb
+++ b/app/views/dashboard/_achievement_list.html.erb
@@ -33,7 +33,7 @@
         <%= get_date_string(achievement) %>
       </div>
       <div class="ncce-activity-list__subtext govuk-!-margin-top-0">
-        <%= render ProviderLogosComponent.new(online: achievement.activity.category.to_sym == :online, dashboard: true) %>
+        <%= render ProviderLogosComponent.new(dashboard: true, provider: achievement.provider) %>
       </div>
     </div>
   </li>

--- a/app/views/dashboard/_achievement_list.html.erb
+++ b/app/views/dashboard/_achievement_list.html.erb
@@ -17,7 +17,12 @@
       <% details = stem_course_details(user_course_info, achievement.activity.stem_course_template_no) %>
       <% if details.present? %>
         <div class="govuk-body ncce-activity-list__subtext <%= course_icon_class(achievement.activity) %>">
-          <%= t("shared.course_types.#{achievement.activity.category}") %>: <strong><%= course_start_date(details.start_date) %></strong>
+          <%= t("shared.course_types.#{achievement.activity.category}") %>:
+            <% if achievement.activity.online? %>
+              <%= online_course_availability(Date.parse(details.start_date)) %>
+            <% else %>
+              <strong><%= course_start_date(details.start_date) %></strong>
+            <% end %>
         </div>
         <% unless achievement.activity.remote_delivered_cpd || achievement.activity.online? %>
           <div class="govuk-body ncce-activity-list__subtext ncce-activity-list__subtext--address">

--- a/app/webpacker/stylesheets/components/courses/_aside_booking.scss
+++ b/app/webpacker/stylesheets/components/courses/_aside_booking.scss
@@ -53,20 +53,3 @@
   display: grid;
   grid-template-columns: 0.4fr 1fr;
 }
-
-.provider-logos {
-  border-top: solid 1px #CCCCCC;
-  padding: 1rem 0;
-
-  &__logo-wrapper {
-    display: inline-flex;
-    flex-wrap: wrap;
-    gap: 1.5rem;
-    align-self: center;
-    margin-bottom: 0;
-    img {
-      height: 43px;
-      width: auto;
-    }
-  }
-}

--- a/previews/components/provider_logos_component_preview.rb
+++ b/previews/components/provider_logos_component_preview.rb
@@ -1,17 +1,14 @@
 class ProviderLogosComponentPreview < ViewComponent::Preview
-  def dashboard_online
-    render(ProviderLogosComponent.new(online: true, dashboard: true))
+  def booking_aside
+    render(ProviderLogosComponent.new(dashboard: false))
   end
 
-  def dashboard_other
-    render(ProviderLogosComponent.new(online: false, dashboard: true))
+  def dashboard_default
+    # provided by stem_learning
+    render(ProviderLogosComponent.new)
   end
 
-  def online
-    render(ProviderLogosComponent.new(online: true, dashboard: false))
-  end
-
-  def other
-    render(ProviderLogosComponent.new(online: false))
+  def dashboard_retired
+    render(ProviderLogosComponent.new(dashboard: true, provider: 'future-learn'))
   end
 end

--- a/spec/components/provider_logos_component_spec.rb
+++ b/spec/components/provider_logos_component_spec.rb
@@ -1,15 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe ProviderLogosComponent, type: :component do
-  let(:data) do
-    {
-      online: false,
-      dashboard: false,
-      class_name: 'custom-class'
-    }
-  end
+  context 'outside dashboard' do
+    let(:data) do
+      {
+        dashboard: false,
+        class_name: 'custom-class',
+      }
+    end
 
-  context 'when options are all false' do
     before do
       render_inline(described_class.new(**data))
     end
@@ -18,67 +17,79 @@ RSpec.describe ProviderLogosComponent, type: :component do
       expect(page).to have_css('.custom-class')
     end
 
-    it 'does not add the modifier' do
+    it 'does not add the dashboard modifier' do
       expect(page).not_to have_css('.provider-logos-component--dashboard')
     end
 
-    it 'falls back to stem org_prefix' do
-      expect(page).to have_text('This course is from Teach Computing and delivered by STEM Learning')
+    it 'falls back to stem-learning copy' do
+      expect(page).to have_text('This course is from the National Centre for Computing Education and is delivered by STEM Learning.')
     end
 
     it 'has the expected logos' do
-      expect(page).to have_css("img[src*='tc-logo-small']")
+      expect(page).to have_css("img[src*='ncce-logo']")
       expect(page).to have_css("img[src*='stem-logo-small']")
     end
   end
 
-  context 'when online is true' do
+  context 'when provider is not stem-learning' do
+    let(:data) do
+      {
+        provider: 'future-learn',
+        dashboard: false,
+        class_name: 'custom-class'
+      }
+    end
+
     before do
-      data[:online] = true
       render_inline(described_class.new(**data))
     end
 
-    it 'uses the rpf org_prefix' do
-      expect(page).to have_text('This course is from Teach Computing and delivered by Raspberry Pi Foundation')
+    it 'uses the text for the retired Raspberry Pi/FutureLearn online courses' do
+      expect(page).to have_text('This course is from Teach Computing and delivered by Raspberry Pi Foundation.')
     end
 
-    it 'has the expected logos' do
-      expect(page).to have_css("img[src*='tc-logo-small']")
-      expect(page).to have_css("img[src*='rpf-logo-small']")
+    it 'does not display logos' do
+      expect(page).not_to have_css('img')
     end
   end
 
-  context 'when dashboard is true and online is false' do
+  context 'on the dashboard' do
+    let(:data) do
+      {
+        dashboard: true,
+        class_name: 'custom-class',
+      }
+    end
+
     before do
-      data[:dashboard] = true
       render_inline(described_class.new(**data))
     end
 
     it 'adds the modifier' do
       expect(page).to have_css('.provider-logos-component--dashboard')
     end
-
-    it 'has the expected logos' do
-      expect(page).to have_css("img[src*='tc-logo-small']")
-      expect(page).to have_css("img[src*='stem-logo-small']")
-    end
   end
 
-  context 'when dashboard is true and online is true' do
+  context 'when provider is stem-learning' do
+    let(:data) do
+      {
+        provider: 'stem-learning',
+        dashboard: false,
+        class_name: 'custom-class'
+      }
+    end
+
     before do
-      data[:dashboard] = true
-      data[:online] = true
       render_inline(described_class.new(**data))
     end
 
-    it 'adds the modifier' do
-      expect(page).to have_css('.provider-logos-component--dashboard')
+    it 'shows the stem-learning copy' do
+      expect(page).to have_text('This course is from the National Centre for Computing Education and is delivered by STEM Learning.')
     end
 
     it 'has the expected logos' do
-      expect(page).to have_css("img[src*='tc-logo-small']")
-      expect(page).to have_css("img[src*='rpf-logo-small']")
-      expect(page).to have_css("img[src*='fl-logo-small']")
+      expect(page).to have_css("img[src*='ncce-logo']")
+      expect(page).to have_css("img[src*='stem-logo-small']")
     end
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for front-end & tech review
* Review App link(s): https://teachcomputing-pr-1690.herokuapp.com/dashboard
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2312

## Review progress:

- [x] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Update provider logos and copy in the dashboard course list items
- Rm time and emphasis from dashboard online course start date
<img width="1473" alt="Screenshot 2023-03-15 at 15 09 43 copy" src="https://user-images.githubusercontent.com/2813357/225363695-b8b3b22d-f549-49ef-8518-ef3fef3fe1d3.png">



