### PR TITLE
Drop all incomplete enrolments on future-learn courses

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,34 +1,8 @@
-# A sample Guardfile
-# More info at https://github.com/guard/guard#readme
-
-## Uncomment and set this to only include directories you want to watch
-# directories %w(app lib config test spec features) \
-#  .select{|d| Dir.exist?(d) ? d : UI.warning("Directory #{d} does not exist")}
-
-## Note: if you are using the `directories` clause above and you are not
-## watching the project directory ('.'), then you will want to move
-## the Guardfile to a watched dir and symlink it back, e.g.
-#
-#  $ mkdir config
-#  $ mv Guardfile config/
-#  $ ln -s config/Guardfile .
-#
-# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
-
-# Note: The cmd option is now required due to the increasing number of ways
-#       rspec may be run, below are examples of the most common uses.
-#  * bundler: 'bundle exec rspec'
-#  * bundler binstubs: 'bin/rspec'
-#  * spring: 'bin/rspec' (This will use spring if running and you have
-#                          installed the spring binstubs per the docs)
-#  * zeus: 'zeus rspec' (requires the server to be started separately)
-#  * 'just' rspec: 'rspec'
+# configures the guard gem
 
 guard :rspec, cmd: 'bundle exec rspec' do
   require 'guard/rspec/dsl'
   dsl = Guard::RSpec::Dsl.new(self)
-
-  # Feel free to open issues for suggestions and improvements
 
   # RSpec files
   rspec = dsl.rspec
@@ -65,12 +39,6 @@ guard :rspec, cmd: 'bundle exec rspec' do
   #   rspec.spec.call("views/layouts//#{m[1]}")
   # end
 
-  # Turnip features and steps
-  # watch(%r{^spec/acceptance/(.+)\.feature$})
-  # watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
-  #   Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
-  # end
-
   # Background jobs
   watch(%r{^app/jobs/(.+)\.rb$}) { |m| "spec/jobs/#{m[1]}_spec.rb" }
   # FactoryGirl factories
@@ -88,5 +56,10 @@ guard :rspec, cmd: 'bundle exec rspec' do
 
   watch(%r{^lib/(.+)\.rb$}) do |m|
     ["#{rspec.spec_dir}/lib/#{m[1]}_spec.rb"]
+  end
+
+  # rake
+  watch(%r{^lib/tasks/(.+)\.rake$}) do |m|
+    ["#{rspec.spec_dir}/lib/tasks/#{m[1]}_spec.rb"]
   end
 end

--- a/lib/tasks/achievements.rake
+++ b/lib/tasks/achievements.rake
@@ -15,4 +15,37 @@ namespace :achievements do
     puts ''
     puts 'Completed'
   end
+
+  # TODO: delete this task after it has been run
+  desc 'A one-off task to drop everyone from uncompleted future-learn courses. Run this once after the completion deadline has passed, that is after 31 March 2023'
+  task drop_all_from_future_learn: :environment do
+    # ignore any that are already dropped or complete.
+    # newly enrolled achievements don't have an achievement_transition
+    enrolled_achievements =
+      Achievement
+      .distinct
+      .joins(:activity)
+      .where('activities.provider': 'future-learn')
+      .in_state(:enrolled, :in_progress)
+
+    progress = 0
+    total = enrolled_achievements.length
+    start_message = "#{$0}: Starting. Dropping #{total} open FutureLearn enrollments"
+    puts start_message
+    Rails.logger.info start_message
+    enrolled_achievements.each do |achievement|
+      print '.'
+      success = achievement.transition_to :dropped
+      if success
+        progress += 1
+        next
+      end
+      puts "** Failed to drop achievement id: #{achievement.id} from #{achievement.activity.stem_activity_code}"
+    end
+
+    puts
+    end_message = "#{$0}: Done. Dropped #{progress} out of #{total} open FutureLearn enrollments"
+    puts end_message
+    Rails.logger.info end_message
+ end
 end

--- a/spec/components/course_activity_component_spec.rb
+++ b/spec/components/course_activity_component_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe CourseActivityComponent, type: :component do
   let(:face_to_face_achievement) { create(:completed_achievement, :face_to_face) }
   let(:remote_achievement) { create(:achievement, :remote_no_activity_code) }
-  let(:online_achievement) { create(:achievement, :online) }
+  let(:online_activity) { create(:activity, :online, title: 'Online activity') }
+  let(:online_achievement) { create(:achievement, :online, activity: online_activity) }
 
   describe 'with no achievements' do
     before do

--- a/spec/factories/achievements.rb
+++ b/spec/factories/achievements.rb
@@ -26,8 +26,16 @@ FactoryBot.define do
       activity { association :activity, :remote, title: 'Remote activity', stem_activity_code: nil }
     end
 
+    trait :future_learn do
+      activity { association :activity, :future_learn, title: 'FutureLearn online activity' }
+    end
+
     trait :online do
-      activity { association :activity, :future_learn, title: 'Online activity' }
+      activity { association :activity, :my_learning, title: 'MyLearning online activity' }
+    end
+
+    trait :my_learning do
+      online
     end
 
     trait :community do

--- a/spec/lib/tasks/achievements_spec.rb
+++ b/spec/lib/tasks/achievements_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'rake achievements:drop_all_from_future_learn', type: :task do
+  it 'drops only the incomplete future-learn achievements' do
+    # expect these to be unchanged
+    create_list(:achievement, 2, :my_learning)
+    create(:dropped_achievement, :future_learn)
+    create(:completed_achievement, :future_learn)
+    completed_achievement_with_history = create(:achievement, :future_learn)
+    completed_achievement_with_history.state_machine.transition_to!(:in_progress)
+    completed_achievement_with_history.state_machine.transition_to!(:complete)
+
+    # expect these to be dropped
+    create(:achievement, :future_learn)
+    create_list(:in_progress_achievement, 3, :future_learn)
+    create(:dropped_achievement, :future_learn).state_machine.transition_to!(:enrolled)
+
+    expect { task.execute }.to change(Achievement.in_state(:dropped), :count)
+      .by(5)
+      .and change(AchievementTransition, :count)
+      .by(5)
+  end
+end


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review

* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2310
  
## Review progress:

- [x] Tech review completed

## What's changed?

A one-off task to unenroll everyone from future-learn courses. Run this once after the completion deadline has passed, that is after 31 March 2023

Transitions each future-learn acheivement to 'dropped' state if is incomplete (that is new, `enrolled` or `in_progress`)

Adds the local rake tasks to guard's watch list.

**Caveat: there is no undo**

## Steps to perform after deploying to production
Run

```
bin/rails achievements:drop_all_from_future_learn
```
