### PR TITLE
Fix layout bugs in primary and secondary cert dashboards

### DIFF
--- a/app/components/community_activity_component/community_activity_component.html.erb
+++ b/app/components/community_activity_component/community_activity_component.html.erb
@@ -4,7 +4,9 @@
       <span><%= @activity.title %></span>
     </span>
     <% if achievement_complete? %>
-      <span class='community-activity-component__completed-badge'><%= t('.complete') %></span>
+      <span class="community_activity_component__completed_badge_container" >
+        <span class='community-activity-component__completed-badge'><%= t('.complete') %></span>
+      </span>
     <% else %>
       <% if @activity.booking_programme_slug.present? %>
         <%= link_to t('.book_button_text'),

--- a/app/components/community_activity_component/community_activity_component.scss
+++ b/app/components/community_activity_component/community_activity_component.scss
@@ -3,7 +3,7 @@
   background-color: $white;
   display: grid;
   grid-template-rows: auto auto;
-  grid-template-columns: auto 8.5rem;
+  grid-template-columns: auto 11.5rem;
 
   @include govuk-media-query($until: tablet) {
     grid-template-columns: auto;
@@ -40,6 +40,16 @@
   }
 }
 
+.community_activity_component__completed_badge_container {
+  display: block;
+  width: 100%;
+
+  @include govuk-media-query($from: tablet) {
+    text-align: right;
+    width: auto;
+  }
+}
+
 .community-activity-component__objective-text {
   align-self: center;
   grid-column: 1;
@@ -64,6 +74,8 @@
   font-size: 0.9em;
   text-align: center;
   padding: 2px 8px;
+  width: auto;
+  display: inline-block;
 
   @include govuk-media-query($until: tablet) {
     margin-bottom: 1rem;

--- a/app/components/course_activity_component/course_activity_component.scss
+++ b/app/components/course_activity_component/course_activity_component.scss
@@ -3,7 +3,7 @@
   background-color: $white;
   display: grid;
   grid-template-rows: auto auto;
-  grid-template-columns: auto 8.5rem;
+  grid-template-columns: auto 11.5rem;
 
   @include govuk-media-query($until: tablet) {
     grid-template-columns: auto;
@@ -46,6 +46,7 @@
   grid-row: auto;
   grid-column: 2;
   align-self: top;
+  margin-bottom: 0;
 
   @include govuk-media-query($until: tablet) {
     grid-column: 1;

--- a/app/views/layouts/activity_component_preview.html.erb
+++ b/app/views/layouts/activity_component_preview.html.erb
@@ -1,0 +1,25 @@
+<% content_for :content do -%>
+  <div class="govuk-width-container">
+    <main id="main-content">
+      <div class="ncce-programmes-activity">
+        <div class="govuk-width-container">
+          <div class="govuk-main-wrapper govuk-main-wrapper--xl">
+            <div class="govuk-grid-row">
+              <div class="govuk-grid-column-two-thirds">
+                <ul class="govuk-list ncce-activity-list ncce-activity-list--programme" role="list">
+                  <li class="ncce-activity-list__item">
+                    <%= yield %>
+                  </li>
+                </ul>
+              </div>
+              <div class="govuk-grid-column-one-third">
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+<% end -%>
+
+<%= render 'layouts/base' %>

--- a/previews/components/community_activity_component_preview.rb
+++ b/previews/components/community_activity_component_preview.rb
@@ -4,7 +4,30 @@ require 'factory_bot_rails'
 require 'faker'
 
 class CommunityActivityComponentPreview < ViewComponent::Preview
+  layout 'activity_component_preview'
+
   def default
-    render(CommunityActivityComponent.new(activity: FactoryBot.create(:activity)))
+    activity = demo_activity
+    render(CommunityActivityComponent.new(achievement: nil, activity:))
+  end
+
+  def completed
+    achievement = Achievement.in_state(:complete).last.presence || FactoryBot.create(:completed_achievement)
+    activity = demo_activity
+    render(CommunityActivityComponent.new(achievement:, activity:))
+  end
+
+  private
+
+  def demo_activity
+    activity = Activity.last.presence || FactoryBot.create(:activity)
+    activity.title = 'Very long title such as take on a very difficult task, work very hard on it, and publish some evidence about it'
+    activity.description = <<~HTML
+      <a href="https://www.stem.org.uk/stem-ambassadors/schools-and-colleges" data-event-label="STEM Ambassadors"
+      data-event-category="Primary enrolled" data-event-action="click" class="ncce-link">Arrange a visit for your school</a> to
+      help pupils understand real-world applications of computing, and raise their career aspirations through engaging
+      activities. STEM Ambassadors are inspiring and relatable role models who volunteer to support schools.</div>'
+    HTML
+    activity
   end
 end

--- a/previews/components/course_activity_component_preview.rb
+++ b/previews/components/course_activity_component_preview.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CourseActivityComponentPreview < ViewComponent::Preview
+  layout 'activity_component_preview'
+
   def default
     objective = 'Complete in <strong>at least one</strong> <em>certificate</em> course.'.html_safe
     booking = {


### PR DESCRIPTION
## Status

* Current Status: Ready for front-end review
* Review App link(s): 
  * https://teachcomputing-pr-1708.herokuapp.com/certificate/primary-certificate
  * https://teachcomputing-pr-1708.herokuapp.com/rails/components/course_activity_component/default
  * https://teachcomputing-pr-1708.herokuapp.com/rails/components/community_activity_component/default
  * https://teachcomputing-pr-1708.herokuapp.com/rails/components/community_activity_component/completed

* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2340 

## Review progress:

- [X] Browser tested
- [x] Front-end review completed
- [x] Tech review completed

## What's changed?

CommunityActivityComponent

1. Widen button to match longest text 'Submit evidence', and change alignment of objective text, to stop button from overlapping longest objective text
2. Fix vertical alignment of button

(note that we also add a container for the 'Completed' badge to avoid a regression in its layout)

CourseActivityComponent

1. Widen 'Book a course' button to fix its text wrapping
2. Fix vertical alignment of button

<img width="398" alt="Screenshot 2023-04-18 at 11 18 17" src="https://user-images.githubusercontent.com/2813357/232752242-0759e81b-4709-4a95-88ae-97bba495f91e.png">

<img width="398" alt="Screenshot 2023-04-18 at 11 18 02" src="https://user-images.githubusercontent.com/2813357/232752276-c525be21-0039-4325-b4eb-d0d1e69d2995.png">

<img width="1616" alt="Screenshot 2023-04-18 at 11 18 57" src="https://user-images.githubusercontent.com/2813357/232752193-403c5428-bbfa-4c16-bfc3-fdcd2c50f7b8.png">
