### PR TITLE
Fix missing translation errors

### DIFF
--- a/app/views/pages/primary-senior-leaders.html.erb
+++ b/app/views/pages/primary-senior-leaders.html.erb
@@ -93,27 +93,7 @@
             {
               class_name: 'bordered-card--primary-cert',
               title: t('.how-we-help.cards.certification.title'),
-              text: t(
-                '.how-we-help.cards.certification.text.html',
-                our_accelerator_link: (link_to(
-                  t('.how-we-help.cards.certification.text.accelerator-link.title'),
-                  t('.how-we-help.cards.certification.text.accelerator-link.url'),
-                  data: {
-                    event_action: 'click',
-                    tracking_page: 'Primary SLT',
-                    tracking_label: t('.how-we-help.cards.certification.text.accelerator-link.event-label')
-                  }
-                )),
-                primary_certificate_link: (link_to(
-                  t('.how-we-help.cards.certification.text.certificate-link.title'),
-                  t('.how-we-help.cards.certification.text.certificate-link.url'),
-                  data: {
-                    event_action: 'click',
-                    tracking_page: 'Primary SLT',
-                    tracking_label: t('.how-we-help.cards.certification.text.certificate-link.event-label')
-                  }
-                ))
-              ),
+              text: t('.how-we-help.cards.certification.text.html'),
               link: {
                 link_title: t('.how-we-help.cards.certification.link.title'),
                 link_url: t('.how-we-help.cards.certification.link.url'),

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'http://localhost:3000' }
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # config.web_console.whitelisted_ips = '172.25.0.0/16'
   config.web_console.whiny_requests = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   config.assets.css_compressor = nil
   config.sass.style = :compressed


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App link(s): https://teachcomputing-pr-1710.herokuapp.com/primary-senior-leaders

## Review progress:

- [x] Tech review completed

## What's changed?

When removing the old FutureLearn code I needed to check that I hadn't broken any translations, so I turned on raising errors. I recommend keeping this on to catch regressions early.

I found these missing translations on the Primary Senior Leaders page, which were easily fixed by removed the options that used them.
