### PR TITLE
Change computing hub name to Leicestershire, Nottinghamshire and Rutland

### DIFF
--- a/lib/tasks/hubs.rake
+++ b/lib/tasks/hubs.rake
@@ -22,8 +22,8 @@ namespace :hubs do
     Hub.destroy_all
     east_midlands = HubRegion.find_by(name: 'East Midlands')
     east_midlands_hubs = [
-      { hub_name: 'Leicester and East Midlands',
-        subdeliverer_id: '52f37f29-32de-e911-a812-000d3a86d6ce',
+      { hub_name: 'Leicestershire, Nottinghamshire and Rutland',
+        subdeliverer_id: 'c04b44d6-81e2-ed11-8846-002248c6b31a',
         address: 'Beauchamp College, Ridge Way, Oadby',
         postcode: 'LE2 5TP',
         email: 'teachcomputing@lionhearttrust.org.uk',


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review

* Related to https://github.com/NCCE/teachcomputing.org-issues/issues/2351

## Review progress:

- [ ] Tech review completed

## What's changed?

Change name and subdeliverer_id form Leicester computing hub
This is already done in production (with Administrate), but will be handy for re-populating staging and dev environments (it is the rake task `rails hubs:populate_hubs`).