### PR TITLE
Link computing-clusters embedded Ghost page

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -23,7 +23,8 @@ module NavigationHelper
         children: [
           { text: 'Courses', link: courses_path, label: 'Courses' },
           { text: 'Funding', link: '/funding', label: 'Bursaries' },
-          { text: 'Computing Hubs', link: '/hubs', label: 'Computing hubs' }
+          { text: 'Computing Hubs', link: '/hubs', label: 'Computing hubs' },
+          { text: 'Computing Clusters', link: '/computing-clusters', label: 'Computing clusters' },
         ] },
       { text: 'Teaching resources',
         children: [


### PR DESCRIPTION
## Status

* Current Status: Ready for front-end and tech review
* Review App link(s): https://teachcomputing-pr-1722.herokuapp.com/
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2369

## Review progress:

- [ ] ~Browser tested~
- [x] Front-end review completed
- [x] Tech review completed

## What's changed?

New menu entry, links to Ghost CMS page https://teachcomputing.org/computing-clusters/

Large:
<img width="379" alt="Screenshot 2023-05-25 at 16 49 52" src="https://github.com/NCCE/teachcomputing.org/assets/2813357/a486eab3-2526-4c8e-9c61-97ebb9a53a37">
Small:
<img width="407" alt="Screenshot 2023-05-25 at 17 25 06" src="https://github.com/NCCE/teachcomputing.org/assets/2813357/02fc792d-e014-437a-beb5-7e3f18ebd415">
