### PR TITLE
2374 Add spec for X-Content-Type-Options: nosniff response header

### DIFF
--- a/spec/requests/pages/home_news_spec.rb
+++ b/spec/requests/pages/home_news_spec.rb
@@ -2,6 +2,12 @@ require 'rails_helper'
 
 RSpec.describe PagesController do
   describe 'GET #home _news' do
+    it 'asks the browser not to sniff MIME types' do
+      stub_featured_posts
+      get root_path
+      expect(response.headers['X-Content-Type-Options']).to eq('nosniff')
+    end
+
     context 'featured posts' do
       before do
         stub_featured_posts


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Related to https://github.com/NCCE/teachcomputing.org-issues/issues/2374

## Review progress:

- [x] Tech review completed

## What's changed?

Regression test for desired HTTP header