### PR TITLE
2375 cache control: no store HTTP header on private pages

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -6,7 +6,10 @@
 # you're free to overwrite the RESTful controller actions.
 module Admin
   class ApplicationController < Administrate::ApplicationController
-    before_action :authenticate_admin, :discourage_caching
+    include HttpHeaders
+
+    before_action :authenticate_admin
+    after_action :discourage_caching
 
     def authenticate_admin
       return true if ActiveRecord::Type::Boolean.new.cast(ENV.fetch('BYPASS_ADMINISTRATE_CF_AUTH', false)) && !Rails.env.production?
@@ -18,10 +21,6 @@ module Admin
         decoded_token = decode_cookie(cookies[:CF_Authorization])
         @admin_email = decoded_token.first['email']
       end
-    end
-
-    def discourage_caching
-      response.headers['cache-control'] = 'no-store'
     end
 
     private

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -6,7 +6,7 @@
 # you're free to overwrite the RESTful controller actions.
 module Admin
   class ApplicationController < Administrate::ApplicationController
-    before_action :authenticate_admin
+    before_action :authenticate_admin, :discourage_caching
 
     def authenticate_admin
       return true if ActiveRecord::Type::Boolean.new.cast(ENV.fetch('BYPASS_ADMINISTRATE_CF_AUTH', false)) && !Rails.env.production?
@@ -18,6 +18,10 @@ module Admin
         decoded_token = decode_cookie(cookies[:CF_Authorization])
         @admin_email = decoded_token.first['email']
       end
+    end
+
+    def discourage_caching
+      response.headers['cache-control'] = 'no-store'
     end
 
     private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include AuthenticationHelper
+  include HttpHeaders
 
   before_action :authenticate
 

--- a/app/controllers/certificates/certificate_controller.rb
+++ b/app/controllers/certificates/certificate_controller.rb
@@ -1,6 +1,7 @@
 module Certificates
   class CertificateController < ApplicationController
     before_action :authenticate_user!
+    after_action :discourage_caching
 
     def show
       return redirect_to programme.path unless programme.user_completed?(current_user)

--- a/app/controllers/certificates/cs_accelerator_controller.rb
+++ b/app/controllers/certificates/cs_accelerator_controller.rb
@@ -5,6 +5,7 @@ module Certificates
     before_action :find_programme, only: %i[show complete]
     before_action :user_enrolled?, only: %i[show complete]
     before_action :user_completed_diagnostic?, only: %i[show]
+    after_action :discourage_caching
 
     def show
       return redirect_to complete_cs_accelerator_certificate_path if @programme.user_completed?(current_user)

--- a/app/controllers/certificates/primary_certificate_controller.rb
+++ b/app/controllers/certificates/primary_certificate_controller.rb
@@ -5,6 +5,7 @@ module Certificates
     before_action :find_programme, only: %i[show complete pending]
     before_action :user_enrolled?, only: %i[show complete pending]
     before_action :user_programme_enrolment_pending?, only: %i[show complete]
+    after_action :discourage_caching
 
     def show
       return redirect_to complete_primary_certificate_path if @programme.user_completed?(current_user)

--- a/app/controllers/concerns/http_headers.rb
+++ b/app/controllers/concerns/http_headers.rb
@@ -1,0 +1,6 @@
+module HttpHeaders
+  # Respond with 'Cache-Control: no-store' header. Use as a controller after_action
+  def discourage_caching
+    headers['cache-control'] = 'no-store'
+  end
+end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,5 +1,6 @@
 class CoursesController < ApplicationController
   layout 'full-width'
+  after_action :discourage_caching, only: :show
 
   def index
     assign_params

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,6 +1,7 @@
 class DashboardController < ApplicationController
   layout 'full-width'
   before_action :authenticate_user!
+  after_action :discourage_caching
 
   def show
     @incomplete_achievements = current_user.achievements.not_in_state(:dropped, :complete).with_courses.order('created_at DESC')

--- a/app/controllers/diagnostics/base_controller.rb
+++ b/app/controllers/diagnostics/base_controller.rb
@@ -3,6 +3,8 @@ module Diagnostics
     layout 'full-width'
     include Wicked::Wizard
 
+    after_action :discourage_caching
+
     def programme
       raise NotImplementedError
     end

--- a/spec/factories/programme_activity_groupings.rb
+++ b/spec/factories/programme_activity_groupings.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :programme_activity_grouping do
     title { 'A group name' }
     required_for_completion { 1 }
-    sequence(:sort_key, 1) { |n| n }
+    sort_key { 1 }
     programme
 
     trait :with_activities do

--- a/spec/requests/admin/root_spec.rb
+++ b/spec/requests/admin/root_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe 'Admin root request spec' do
 
       expect(response).to have_http_status(:ok)
     end
+
+    it 'asks client not to cache potentially sensitive pages' do
+      allow_any_instance_of(Admin::ApplicationController).to receive(:authenticate_admin).and_return('user@example.com')
+
+      get admin_root_path
+
+      expect(response.headers['cache-control']).to eq('no-store')
+    end
   end
 
   context 'without CF access authentication' do

--- a/spec/requests/certificates/certificate_spec.rb
+++ b/spec/requests/certificates/certificate_spec.rb
@@ -61,6 +61,10 @@ RSpec.describe Certificates::CertificateController do
           expect(response.headers['Content-Disposition'])
             .to eq("inline; filename=\"test-certificate.pdf\"; filename*=UTF-8''test-certificate.pdf")
         end
+
+        it 'asks client not to cache private pages' do
+          expect(response.headers['cache-control']).to eq('no-store')
+        end
       end
     end
 

--- a/spec/requests/certificates/cs_accelerator/complete_spec.rb
+++ b/spec/requests/certificates/cs_accelerator/complete_spec.rb
@@ -70,6 +70,10 @@ RSpec.describe Certificates::CSAcceleratorController do
           it 'assigns the assessments' do
             expect(assigns(:user_programme_assessment)).to be_a(UserProgrammeAssessment)
           end
+
+          it 'asks client not to cache a private page' do
+            expect(response.headers['cache-control']).to eq('no-store')
+          end
         end
       end
     end

--- a/spec/requests/certificates/cs_accelerator/show_spec.rb
+++ b/spec/requests/certificates/cs_accelerator/show_spec.rb
@@ -100,6 +100,10 @@ RSpec.describe Certificates::CSAcceleratorController do
             expect(response)
               .to redirect_to(complete_cs_accelerator_certificate_path)
           end
+
+          it 'asks client not to cache a private page' do
+            expect(response.headers['cache-control']).to eq('no-store')
+          end
         end
 
         context 'when the user does not have a diagnostic response' do

--- a/spec/requests/certificates/primary_certificate/complete_spec.rb
+++ b/spec/requests/certificates/primary_certificate/complete_spec.rb
@@ -87,6 +87,10 @@ RSpec.describe Certificates::PrimaryCertificateController do
         it 'assigns the programme' do
           expect(assigns(:programme)).to eq(programme)
         end
+
+        it 'asks client not to cache a private page' do
+          expect(response.headers['cache-control']).to eq('no-store')
+        end
       end
     end
 

--- a/spec/requests/certificates/primary_certificate/pending_spec.rb
+++ b/spec/requests/certificates/primary_certificate/pending_spec.rb
@@ -65,6 +65,11 @@ RSpec.describe Certificates::PrimaryCertificateController do
           expect(assigns(:programme)).to eq(Programme.primary_certificate)
         end
 
+        it 'asks client not to cache a private page' do
+          subject
+          expect(response.headers['cache-control']).to eq('no-store')
+        end
+
         it 'redirects to complete when course complete' do
           user_programme_enrolment.transition_to(:complete)
           subject

--- a/spec/requests/certificates/primary_certificate/show_spec.rb
+++ b/spec/requests/certificates/primary_certificate/show_spec.rb
@@ -3,17 +3,39 @@ require 'rails_helper'
 RSpec.describe Certificates::PrimaryCertificateController do
   let(:user) { create(:user) }
   let(:programme) { create(:primary_certificate) }
+  let(:user_programme_enrolment) do
+    create(:user_programme_enrolment, user_id: user.id, programme_id: programme.id)
+  end
+  let(:online_discussion_grouping) do
+    create(:programme_activity_grouping, sort_key: 3, title: 'online discussion activities', programme: programme)
+  end
+  let(:online_discussion_programme_activity) do
+    create(:programme_activity, programme: programme, programme_activity_grouping: online_discussion_grouping)
+  end
 
   describe '#show' do
     context 'when user is logged in' do
+      before do
+        allow_any_instance_of(AuthenticationHelper)
+          .to receive(:current_user).and_return(user)
+      end
+
       context 'when user is not enrolled' do
         it 'redirects if not enrolled' do
           programme
-          allow_any_instance_of(AuthenticationHelper)
-            .to receive(:current_user).and_return(user)
 
           get primary_certificate_path
           expect(response).to redirect_to(primary_path)
+        end
+      end
+
+      context 'when user is enrolled' do
+        it 'asks client not to cache a private page' do
+          user_programme_enrolment
+          online_discussion_programme_activity
+
+          get primary_certificate_path
+          expect(response.headers['cache-control']).to eq('no-store')
         end
       end
     end

--- a/spec/requests/courses/show_spec.rb
+++ b/spec/requests/courses/show_spec.rb
@@ -111,6 +111,11 @@ RSpec.describe CoursesController do
           expect(response.body).not_to include('You are enrolled')
         end
       end
+
+      it 'asks client not to cache private progress' do
+        get course_path(course.activity_code, name: 'this-is-a-dud')
+        expect(response.headers['cache-control']).to eq('no-store')
+      end
     end
 
     context 'when the course is online' do

--- a/spec/requests/dashboard/show_spec.rb
+++ b/spec/requests/dashboard/show_spec.rb
@@ -49,6 +49,10 @@ RSpec.describe DashboardController do
       it 'renders the correct template' do
         expect(response).to render_template('show')
       end
+
+      it 'asks client not to cache a private page' do
+        expect(response.headers['cache-control']).to eq('no-store')
+      end
     end
 
     describe 'while logged out' do

--- a/spec/requests/diagnostics/class_marker/cs_accelerator/show_spec.rb
+++ b/spec/requests/diagnostics/class_marker/cs_accelerator/show_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Diagnostics::ClassMarker::CSAcceleratorController do
         expect(response).to redirect_to(/register/)
       end
 
-      it 'creates an Achievement if one does not exist already' do
+      it 'does not create an Achievement' do
         expect(Achievement.count).to eq 0
       end
     end

--- a/spec/requests/diagnostics/cs_accelerator/show_spec.rb
+++ b/spec/requests/diagnostics/cs_accelerator/show_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe Diagnostics::CSAcceleratorController do
       it 'renders the first question' do
         expect(response.body).to include('Question 1 of 5')
       end
+
+      it 'asks client not to cache private pages' do
+        expect(response.headers['cache-control']).to eq('no-store')
+      end
     end
 
     context 'when the user has completed the diagnostic' do

--- a/spec/requests/diagnostics/cs_accelerator/update_spec.rb
+++ b/spec/requests/diagnostics/cs_accelerator/update_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Diagnostics::CSAcceleratorController do
   let!(:new_to_computing_pathway) { create(:new_to_computing) }
   let!(:preparing_to_teach_pathway) { create(:prepare_to_teach_gcse_computer_science) }
 
-  describe 'GET update' do
+  describe 'PUT update' do
     before do
       cs_accelerator_enrolment_unanswered
       allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)

--- a/spec/requests/pages/home_news_spec.rb
+++ b/spec/requests/pages/home_news_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe PagesController do
       expect(response.headers['X-Content-Type-Options']).to eq('nosniff')
     end
 
+    it 'asks browsers to always check for content updates' do
+      stub_featured_posts
+      get root_path
+      expect(response.headers['cache-control']).to eq('max-age=0, private, must-revalidate')
+    end
+
     context 'featured posts' do
       before do
         stub_featured_posts


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2375

## Review progress:

- [ ] ~Browser tested~
- [ ] ~Front-end review completed~
- [x] Tech review completed

## What's changed?

[Add cache-control: no-store header to private user-facing pages](https://github.com/NCCE/teachcomputing.org/commit/f6c49c2eba3af167d05ab60a9cd544a4ea699287)

including:
certificates
course show pages (that show enrolment when logged in)
dashboard
diagnostics

[Add cache-control: no-store header to admin pages](https://github.com/NCCE/teachcomputing.org/commit/a81d3df10be564ec511608601a45a444e7a5c755)

Header for these pages changes from
```
Cache-Control: max-age=0, private, must-revalidate
```
to
```
Cache-Control: no-store, must-revalidate, private, max-age=0
```

Also add a basic request spec for primary certificate show page (enrolled state) increasing coverage by 0.5%

[Add regression spec for current always fresh cache-control header](https://github.com/NCCE/teachcomputing.or/commit/9db2bf26792f34960ee8d2e7c8fc6dd05c8d2194)

and fixed a couple of misnamed specs