### PR TITLE
Tighten ratings cookie flag settings

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -65,3 +65,6 @@ DEFAULT_ADMIN_EMAIL=web@teachcomputing.org
 
 # This must exist in .env for docker-compose to detect it
 ENV_FILE=.env
+
+# set to off to turn off secure cookies; not needed in production
+SECURE_COOKIES=off

--- a/.env.test
+++ b/.env.test
@@ -35,3 +35,6 @@ BYPASS_OAUTH=false
 BYPASS_ADMINISTRATE_CF_AUTH=false
 
 DEFAULT_ADMIN_EMAIL=web@teachcomputing.org
+
+# set to off to turn off secure cookies
+SECURE_COOKIES=off

--- a/app/controllers/concerns/curriculum/rateable.rb
+++ b/app/controllers/concerns/curriculum/rateable.rb
@@ -86,7 +86,7 @@ module Curriculum
       raw_cookie = cookies.encrypted[:ratings]
       ratings = raw_cookie.nil? ? [] : JSON.parse(raw_cookie)
       ratings << id
-      cookies.encrypted[:ratings] = { value: JSON.generate(ratings), expires: 1.month }
+      cookies.encrypted[:ratings] = { value: JSON.generate(ratings), expires: 1.month, httponly: true, secure: Rails.configuration.secure_cookies }
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,8 @@ module TeachComputing
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**/*.{rb,yml}').to_s]
 
     config.mylearning_dashboard_url = ENV['MYLEARNING_DASHBOARD_URL']
+
+    # default is true
+    config.secure_cookies = ENV['SECURE_COOKIES'] != 'off'
   end
 end


### PR DESCRIPTION
## Status

* Current Status: WIP / Ready for (front-end / tech) review
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2373

## Review progress:

- [ ] Browser tested
- [ ] Tech review completed

## What's changed?

The browser will be more strict with these flags set.

The secure flag is false in development and test where we don't use
https.

In development, if you are working with ratings, add this to your `.env`
```
SECURE_COOKIES=false
```