### PR TITLE
2387/identify qualified teachers for certificates

### DIFF
--- a/app/models/programme_activity_grouping.rb
+++ b/app/models/programme_activity_grouping.rb
@@ -3,14 +3,14 @@ class ProgrammeActivityGrouping < ApplicationRecord
   belongs_to :programme
 
   def achievements(user)
-    @achievements ||= user.achievements.in_state(:complete).for_programme(programme).includes(:activity)
+    user.achievements.in_state(:complete).for_programme(programme)
   end
 
   def user_complete?(user)
     completed_activity_count = 0
-    user_achievements = achievements(user)
+    user_achievements = achievements(user).to_a
     programme_activities.each do |programme_activity|
-      completed_activity = user_achievements.find_by(activity_id: programme_activity.activity.id)
+      completed_activity = user_achievements.find { _1.activity_id == programme_activity.activity_id }
       completed_activity_count += 1 if completed_activity
       return true if completed_activity_count >= required_for_completion
     end

--- a/lib/tasks/identify_qualified_teachers.rake
+++ b/lib/tasks/identify_qualified_teachers.rake
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+desc <<~DOC
+  Output stem user id and email address of teachers qualified for a certificate.
+
+  One off task to be run approx June/July 2023
+  Usage: bin/rails identify_qualified_teachers[primary_certificate]
+DOC
+
+task :identify_qualified_teachers, [:certificate] => :environment do |_t, args|
+  raise 'Argument must be primary_certificate or secondary_certificate' unless %w[primary_certificate secondary_certificate].include? args[:certificate]
+
+  programme = Programme.send(args[:certificate])
+
+  enrolments = UserProgrammeEnrolment.where(programme: programme).in_state(:enrolled).order(:created_at)
+
+  num_users = 0
+
+  puts 'stem_user_id,email'
+
+  enrolments.find_each do |enrolment|
+    next unless programme.user_meets_completion_requirement?(enrolment.user)
+
+    num_users += 1
+    puts "\"#{enrolment.user.stem_user_id}\",\"#{enrolment.user.email}\""
+  end
+
+  puts "Identified #{num_users} users."
+  puts 'END OF OUTPUT'
+end

--- a/spec/lib/tasks/identify_qualified_teachers_spec.rb
+++ b/spec/lib/tasks/identify_qualified_teachers_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'rake identify_qualified_teachers', type: :task do
+  let(:programme) { create(:primary_certificate) }
+  let(:grouping1) do
+    create(:programme_activity_grouping,
+           :with_activities,
+           title: 'courses',
+           sort_key: 1,
+           required_for_completion: 1,
+           programme:)
+  end
+
+  let(:qualified_user) { create(:user, email: 'qualified_user@example.com', stem_user_id: '0001') }
+  let(:enrolment1) { create(:user_programme_enrolment, user: qualified_user, programme:) }
+  let(:qu_ach1) { create(:completed_achievement, user: qualified_user, activity: grouping1.programme_activities.first.activity, programme:) }
+
+  let(:pending_user) { create(:user, email: 'pending_user@example.com', stem_user_id: '0002') }
+  let(:enrolment2) do
+    enrolment2 = create(:user_programme_enrolment, user: pending_user, programme:)
+    enrolment2.transition_to(:pending)
+    enrolment2
+  end
+  let(:pu_ach1) { create(:completed_achievement, user: pending_user, activity: grouping1.programme_activities.first.activity, programme:) }
+
+  let(:unqualified_user) { create(:user, email: 'unqualified_user@example.com', stem_user_id: '0003') }
+  let(:enrolment3) { create(:user_programme_enrolment, user: unqualified_user, programme:) }
+  let(:uu_ach1) do
+    ach = create(:achievement, user: unqualified_user, activity: grouping1.programme_activities.first.activity, programme:)
+    ach.transition_to(:in_progress)
+    ach
+  end
+
+  before do
+    create(:secondary_certificate)
+    ## qualified user ##
+    enrolment1
+    qu_ach1
+    ## pending user ##
+    enrolment2
+    pu_ach1
+    ## unqualified user ##
+    enrolment3
+    uu_ach1
+  end
+
+  it 'identifies the qualified primary user' do
+    expect do
+      task.execute(certificate: 'primary_certificate')
+    end.to output(
+      <<~OUTPUT
+        stem_user_id,email
+        "0001","qualified_user@example.com"
+        Identified 1 users.
+        END OF OUTPUT
+      OUTPUT
+    ).to_stdout
+  end
+
+  it 'identifies no secondary users' do
+    expect do
+      task.execute(certificate: 'secondary_certificate')
+    end.to output(
+      <<~OUTPUT
+        stem_user_id,email
+        Identified 0 users.
+        END OF OUTPUT
+      OUTPUT
+    ).to_stdout
+  end
+end


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review 
* Related to https://github.com/NCCE/teachcomputing.org-issues/issues/2387

## Review progress:

- [x] Tech review completed

## What's changed?

1. Fix ProgrammeActivityGrouping achievement caching issue, rm includes

2. One-off temporary script - delete after the data has been extracted

This script is intended to identify users that were already enrolled and had mostly completed their cert when this change happened, and therefore retroactively became qualified for the cert:
 https://github.com/NCCE/teachcomputing.org/pull/1689
> Simplify primary and secondary certificates to require only 1 eligible course rather than 1 of each kind (live and online)

The logic of this search is to find users whose

1. enrolment state is enrolled, and their
2. user_meets_completion_requirement? now returns true.

## Steps to perform after deploying to production

```
heroku run bin/rails identify_qualified_teachers[primary_certificate]
heroku run bin/rails identify_qualified_teachers[secondary_certificate]
```

and save the terminal output