### PR TITLE
Fix source metadata from background job in pending certificate

### DIFF
--- a/app/jobs/achiever/fetch_users_completed_courses_from_achiever_job.rb
+++ b/app/jobs/achiever/fetch_users_completed_courses_from_achiever_job.rb
@@ -59,7 +59,8 @@ module Achiever
 
         CertificatePendingTransitionJob.set(wait: 1.minute).perform_later(
           @programme,
-          user_id, source: 'FetchUsersCompletedCoursesFromAchieverJob'
+          user_id,
+          { source: 'FetchUsersCompletedCoursesFromAchieverJob' }
         )
       end
   end

--- a/app/jobs/achiever/fetch_users_completed_courses_from_achiever_job.rb
+++ b/app/jobs/achiever/fetch_users_completed_courses_from_achiever_job.rb
@@ -59,7 +59,7 @@ module Achiever
 
         CertificatePendingTransitionJob.set(wait: 1.minute).perform_later(
           @programme,
-          user_id, source: 'AchievementsController.create'
+          user_id, source: 'FetchUsersCompletedCoursesFromAchieverJob'
         )
       end
   end


### PR DESCRIPTION

## Status

* Current Status: Ready for tech review

* Related to 
  - https://github.com/NCCE/teachcomputing.org-issues/issues/2398
  - https://github.com/NCCE/teachcomputing.org-issues/issues/2334

## Review progress:
- [x] Tech review completed

## What's changed?

- Fix misleading source metadata from background job in pending certificate to improve debugging

(this data is stored in Postgres as JSON in `UserProgrammeEnrolmentTransition#metadata` )