### PR TITLE
Rescue and report missing course template on cert dashboard

### DIFF
--- a/app/services/achiever/course/template.rb
+++ b/app/services/achiever/course/template.rb
@@ -68,10 +68,27 @@ class Achiever::Course::Template
     templates.map { |course| Achiever::Course::Template.from_resource(course, activities) }
   end
 
+  # @return [Achiever::Course::Template] !!raises ActiveRecord::RecordNotFound!! if none . Use this method if you are using
+  # untrusted data such as a URL path to show a page for a course, otherwise use #maybe_find_by_activity_code.
   def self.find_by_activity_code(activity_code)
     templates = all
     template = templates.find { |val| val.activity_code == activity_code.upcase }
-    raise ActiveRecord::RecordNotFound unless template
+    raise ActiveRecord::RecordNotFound, "Could not find template #{activity_code} in Smart Connector" unless template
+
+    template
+  end
+
+  # @return [Achiever::Course::Template|nil] nil if not found. Silently logs and reports an error if not found, so use this method
+  # if you know the course should exist (because you have a matching course Activity)
+  def self.maybe_find_by_activity_code(activity_code)
+    templates = all
+    template = templates.find { |val| val.activity_code == activity_code.upcase }
+
+    unless template
+      message = "Could not find template #{activity_code} in Smart Connector"
+      Rails.logger.error(message)
+      Sentry.capture_message(message, level: :error)
+    end
 
     template
   end

--- a/app/services/achiever/course/template.rb
+++ b/app/services/achiever/course/template.rb
@@ -1,4 +1,6 @@
 class Achiever::Course::Template
+  include ActionView::Helpers::TextHelper
+
   attr_accessor :activity_code,
                 :age_groups,
                 :booking_url,
@@ -122,5 +124,16 @@ class Achiever::Course::Template
 
   def nearest_occurrence_distance
     occurrences.map(&:distance).compact.min
+  end
+
+  def duration_present?
+    duration_unit.present? && duration_value.present?
+  end
+
+  # For example, "8 hours" or "1 week"
+  def formatted_duration
+    return '' unless duration_present?
+
+    pluralize(duration_value, duration.downcase.chomp('s'))
   end
 end

--- a/app/views/certificates/pathways/_recommended_courses.html.erb
+++ b/app/views/certificates/pathways/_recommended_courses.html.erb
@@ -26,9 +26,9 @@
                 <%= activity_type(pa) %>
               </p>
               <% course = Achiever::Course::Template.maybe_find_by_activity_code(pa.stem_activity_code)%>
-              <% if (duration = course&.duration.presence) && (duration_value = course&.duration_value.presence) %>
+              <% if course&.duration_present? %>
                 <p class="ncce-pathway-courses__location icon-clock govuk-!-margin-top-0">
-                  <%= pluralize(duration_value, duration.downcase.chomp('s')) %>
+                  <%=  course.formatted_duration %>
                 </p>
               <% end %>
               <% if @current_user.achievements.find_by_activity_id(pa.activity_id) %>

--- a/app/views/certificates/pathways/_recommended_courses.html.erb
+++ b/app/views/certificates/pathways/_recommended_courses.html.erb
@@ -25,10 +25,12 @@
               <p class="ncce-pathway-courses__location <%= activity_icon_class(pa) %> govuk-!-margin-top-0">
                 <%= activity_type(pa) %>
               </p>
-              <p class="ncce-pathway-courses__location icon-clock govuk-!-margin-top-0">
-                <% course = Achiever::Course::Template.find_by_activity_code(pa.stem_activity_code)%>
-                <%= pluralize(course.duration_value, course.duration.downcase.chomp('s')) if course.duration.present? %> 
-              </p>
+              <% course = Achiever::Course::Template.maybe_find_by_activity_code(pa.stem_activity_code)%>
+              <% if (duration = course&.duration.presence) && (duration_value = course&.duration_value.presence) %>
+                <p class="ncce-pathway-courses__location icon-clock govuk-!-margin-top-0">
+                  <%= pluralize(duration_value, duration.downcase.chomp('s')) %>
+                </p>
+              <% end %>
               <% if @current_user.achievements.find_by_activity_id(pa.activity_id) %>
                 <strong class="govuk-tag ncce-pathway-courses__status ncce-courses__tag">
                   <%= @current_user.achievements.find_by_activity_id(pa.activity_id).complete? ? 'Completed' : 'In progress' %>

--- a/spec/services/achiever/course/template_spec.rb
+++ b/spec/services/achiever/course/template_spec.rb
@@ -144,6 +144,50 @@ RSpec.describe Achiever::Course::Template do
     end
   end
 
+  describe '#duration_present?' do
+    before do
+      stub_duration_units
+      stub_course_templates
+    end
+
+    context 'when present' do
+      it 'is true' do
+        expect(described_class.all.second.duration_present?).to be true
+      end
+    end
+
+    context 'when absent' do
+      it 'is false' do
+        expect(described_class.maybe_find_by_activity_code('cp007').duration_present?).to be false
+      end
+    end
+  end
+
+  describe '#formatted_duration' do
+    before do
+      stub_duration_units
+      stub_course_templates
+    end
+
+    it 'is pluralized correctly' do
+      expect(described_class.maybe_find_by_activity_code('cp428')
+               .formatted_duration)
+        .to eq '5 hours'
+    end
+
+    it 'is singular when needed' do
+      expect(described_class.maybe_find_by_activity_code('cp228')
+               .formatted_duration)
+        .to eq '1 day'
+    end
+
+    it 'is empty when source data missing' do
+      expect(described_class.maybe_find_by_activity_code('cp007')
+               .formatted_duration)
+        .to eq ''
+    end
+  end
+
   describe '#with_occurrences' do
     before do
       stub_course_templates


### PR DESCRIPTION
## Status

* Current Status: WIP
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2421

## Review progress:

- [x] Tech review completed

## What's changed?

~Rescue~ Handle and report missing course template on cert dashboard
when recommended course doesn't match a real or stubbed template

This should make dev, review and staging environments more stable, and will also help if there is ever missing data in production Dynamics.
