### PR TITLE
Update seeds for CP478W and CP439W as these courses are retired

### DIFF
--- a/db/seeds/activities/stem_learning.rb
+++ b/db/seeds/activities/stem_learning.rb
@@ -595,7 +595,8 @@ a = Activity.find_or_create_by(stem_course_template_no: '03fb0a52-a712-eb11-a813
   activity.stem_course_template_no = '03fb0a52-a712-eb11-a813-000d3a86d545'
   activity.category = 'face-to-face'
   activity.provider = 'stem-learning'
-  activity.stem_activity_code = 'CP439'
+  activity.stem_activity_code = 'CP439W'
+  activity.retired = true
 end
 
 a.programmes << cs_accelerator unless a.programmes.include?(cs_accelerator)
@@ -1634,8 +1635,9 @@ a = Activity.find_or_create_by(stem_course_template_no: 'c53a5ed2-3c6e-ec11-8943
   activity.stem_course_template_no = 'c53a5ed2-3c6e-ec11-8943-000d3a874094'
   activity.category = 'face-to-face'
   activity.provider = 'stem-learning'
-  activity.stem_activity_code = 'CP478'
+  activity.stem_activity_code = 'CP478W'
   activity.remote_delivered_cpd = true
+  activity.retired = true
 end
 
 a.programmes << cs_accelerator unless a.programmes.include?(cs_accelerator)


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Related to #1765 and https://github.com/NCCE/teachcomputing.org-issues/issues/2445

## Review progress:
- [ ] Tech review completed

## What's changed?

These reflect changes in the production database I made on Friday 18 Aug 2023 via Administrate, so they won't actually change the production data. However they ensure any fresh databases such as our dev and review apps are consistent, per the business's requirement to keep seeds in sync with any live changes to the database.

Background is that new courses CP478 and CP439 were added on 18 Aug in commit 1c1075e0 (#1765):
> They are the same with the older courses which we have added W at
> the end of. What the programme team came up was that the courses are
> more under Secondary as against CSA. But IT Support has advised that
> it is best to keep the course in order to access historical records
> of those who took the course when it was under CSA.  So essentially,
> the new template should count towards Secondary, the old
> template (with the W in the template code) should be kept under CSA
> certificate to capture historical records