### PR TITLE
Alter docker configuration to use just one "web" container.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,6 +28,7 @@ module ApplicationHelper
   def safe_redirect_url(url)
     allowed_redirect_urls = [
       %r{^https://teachcomputing.rpfdev.com},
+      %r{^https://teachcomputing.test},
       %r{^https://teachcomputing.org},
       %r{^https://staging.teachcomputing.org},
       %r{^https://stem.org.uk},

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -99,4 +99,6 @@ Rails.application.configure do
       exception_object: event.payload[:exception_object] # the exception instance
     }
   end
+
+  config.active_job.queue_adapter = :sidekiq
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,5 @@
 Sidekiq.default_job_options = { retry: false }
-Sidekiq.logger.level = Logger::WARN
+Sidekiq.logger.level = Logger::WARN unless ENV['SIDEKIQ_DEBUG'] == 'true'
 
 Sidekiq.configure_client do |config|
   config.redis = { url: ENV['REDIS_URL'], size: 2, ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,19 +26,6 @@ services:
       - "6379:6379"
     restart: unless-stopped
 
-  sidekiq:
-    build: .
-    command: bundle exec sidekiq
-    volumes:
-      - .:/app
-      - bundle:/usr/local/bundle
-    depends_on:
-      - redis
-      - web
-    env_file:
-      - ${ENV_FILE:-.env.defaults}
-    restart: unless-stopped
-
   web:
     build: .
     command: ./scripts/docker-entrypoint.sh
@@ -54,14 +41,14 @@ services:
       - "1234:1234"
       - "1235:1235"
       - "3000:3000"
+      - "3035:3035"
     depends_on:
       - db
       - redis
       - docker-host
-      - webpack
     environment:
       - RAILS_DEV_DB_PASS=password
-      - WEBPACKER_DEV_SERVER_HOST=webpack
+      - WEBPACKER_DEV_SERVER_HOST=web
     stdin_open: true
     tty: true # Allow interactive byebug sessions
     restart: unless-stopped
@@ -73,19 +60,6 @@ services:
       start_period: 45s
     env_file:
       - ${ENV_FILE:-.env.defaults}
-
-  webpack:
-    build: .
-    command: ./scripts/webpack-docker-entrypoint.sh
-    volumes:
-      - .:/app
-      - node_modules:/app/node_modules
-      - bundle:/usr/local/bundle
-    ports:
-      - "3035:3035"
-    environment:
-      - WEBPACKER_DEV_SERVER_HOST=webpack
-    restart: unless-stopped
 
 volumes:
   bundle: null

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -25,7 +25,7 @@ yarn install
 echo "- Starting rails (with debugging enabled):"
 (trap 'kill 0' SIGINT;
   rdebug-ide --skip_wait_for_start -h $HOST -p $DEBUG_PORT --dispatcher-port $DISPATCHER_PORT -- ./bin/rails s -b $HOST -p $PORT &
-  bundle exec sidekiq &
-  ./scripts/webpack-docker-entrypoint.sh
+  bundle exec sidekiq > ./log/sidekiq.log &
+  ./scripts/webpack-docker-entrypoint.sh > ./log/webpack.log
 )
 # ./bin/rails s -b $HOST -p $PORT

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -23,5 +23,9 @@ echo "- Installing node packages with yarn:"
 yarn install
 
 echo "- Starting rails (with debugging enabled):"
-rdebug-ide --skip_wait_for_start -h $HOST -p $DEBUG_PORT --dispatcher-port $DISPATCHER_PORT -- ./bin/rails s -b $HOST -p $PORT
+(trap 'kill 0' SIGINT;
+  rdebug-ide --skip_wait_for_start -h $HOST -p $DEBUG_PORT --dispatcher-port $DISPATCHER_PORT -- ./bin/rails s -b $HOST -p $PORT &
+  bundle exec sidekiq &
+  ./scripts/webpack-docker-entrypoint.sh
+)
 # ./bin/rails s -b $HOST -p $PORT


### PR DESCRIPTION

## Status

* Current Status: Ready for tech review

## Review progress:

- [x] Tech review completed

## What's changed?

Previously, the docker setup used a seperate sidekiq and webpack container. "web" "sidekiq" and "webpack" all use the same dockerfile so it makes no sense to have these running on seperate containers.

This Commit, combines them into just one container called "web". It also adds "teachcomputing.test" into the list of safe redirect URLs to help puma-dev users have a more realistic environment