### PR TITLE
Removed unrelased CPDs from new pathways

### DIFF
--- a/db/seeds/pathways/primary_certificate.rb
+++ b/db/seeds/pathways/primary_certificate.rb
@@ -139,8 +139,6 @@ programme.pathways.find_or_initialize_by(slug: 'specialising-or-leading-2').tap 
     'CP005',
     'CP225',
     'CP003',
-    'CO040',
-    'CO042',
     'CO700',
     'CP486',
     'CP469',
@@ -153,6 +151,15 @@ programme.pathways.find_or_initialize_by(slug: 'specialising-or-leading-2').tap 
 
   cpds.each do |cpd|
     maybe_attach_activity_to_pathway(pathway, stem_activity_code: cpd)
+  end
+
+  remove_cpds = [
+    'CO040',
+    'CO042'
+  ]
+
+  remove_cpds.each do |cpd|
+    maybe_detach_activity_from_pathway(pathway, stem_activity_code: cpd)
   end
 
   activities = [
@@ -199,7 +206,6 @@ programme.pathways.find_or_initialize_by(slug: 'developing-in-the-classroom-2').
     'CO232',
     'CO700',
     'CO041',
-    'CO042',
     'CP462',
     'CP466',
     'CP459',
@@ -212,6 +218,14 @@ programme.pathways.find_or_initialize_by(slug: 'developing-in-the-classroom-2').
 
   cpds.each do |cpd|
     maybe_attach_activity_to_pathway(pathway, stem_activity_code: cpd)
+  end
+
+  remove_cpds = [
+    'CO042'
+  ]
+
+  remove_cpds.each do |cpd|
+    maybe_detach_activity_from_pathway(pathway, stem_activity_code: cpd)
   end
 
   activities = [

--- a/db/seeds/pathways/secondary_certificate.rb
+++ b/db/seeds/pathways/secondary_certificate.rb
@@ -27,9 +27,17 @@ programme.pathways.find_or_initialize_by(slug: 'curriculum-leadership').tap do |
 
   pathway.save
 
-  cpds = %w[CP439 CO230 CP478 CP411 CP211 CP448 CP440 CP444 CO700 CP446 CO222 CP468 CP413 CP212 CP247 CP248 CP249]
+  cpds = %w[CP439 CP478 CP411 CP211 CP448 CP440 CP444 CO700 CP446 CO222 CP468 CP413 CP212 CP247 CP248 CP249]
   cpds.each do |cpd|
     maybe_attach_activity_to_pathway(pathway, stem_activity_code: cpd)
+  end
+
+  remove_cpds = [
+    'CO230'
+  ]
+
+  remove_cpds.each do |cpd|
+    maybe_detach_activity_from_pathway(pathway, stem_activity_code: cpd)
   end
 
   activities = [

--- a/db/seeds/pathways_helper.rb
+++ b/db/seeds/pathways_helper.rb
@@ -8,3 +8,9 @@ def maybe_attach_activity_to_pathway(pathway, slug: nil, stem_activity_code: nil
 
   pathway.pathway_activities.find_or_create_by(activity_id: activity.id) if activity && !pathway.pathway_activities.include?(activity)
 end
+
+def maybe_detach_activity_from_pathway(pathway, stem_activity_code:)
+  activity = Activity.find_by(stem_activity_code:)
+
+  pathway.pathway_activities.find_by(activity:)&.destroy
+end


### PR DESCRIPTION
## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed


## What's changed?

This PR removes CO040, CO042, and CO230 from the pathways as they are yet to be added to dynamics.
