### PR TITLE
Marking i belong community groups correctly as groups

### DIFF
--- a/db/seeds/programme_activity_groupings/i_belong.rb
+++ b/db/seeds/programme_activity_groupings/i_belong.rb
@@ -25,6 +25,7 @@ i_belong.programme_activity_groupings.find_or_initialize_by(sort_key: 3).tap do 
   group.required_for_completion = 2
   group.programme_id = i_belong.id
   group.progress_bar_title = '<strong>Access</strong> resources to support you'
+  group.community = true
 
   group.save
 
@@ -45,6 +46,7 @@ i_belong.programme_activity_groupings.find_or_initialize_by(sort_key: 4).tap do 
   group.required_for_completion = 1
   group.programme_id = i_belong.id
   group.progress_bar_title = '<strong>Increase</strong> girls’ engagement by completing at least one activity'
+  group.community = true
 
   group.save
 


### PR DESCRIPTION
This issue occurred due to a change in how we fetch community / non-community groups.

This commit, fixes the problem by correctly flagging them
