### PR TITLE
Altered copy from "find out more" to "choose a pathway"

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -71,7 +71,7 @@ class PagesController < ApplicationController
   end
 
   def isaac_computer_science
-  end 
+  end
 
   def login
     auth_uri = '/auth/stem'
@@ -81,7 +81,7 @@ class PagesController < ApplicationController
 
   # static programme pages except I Belong
   def static_programme_page
-    @programme = Programme.includes(:pathways).find_by!(slug: params[:page_slug])
+    @programme = Programme.find_by!(slug: params[:page_slug])
     redirect_to(@programme.path) and return if @programme.user_enrolled?(current_user)
 
     render template: "pages/enrolment/#{params[:page_slug]}"

--- a/app/views/dashboard/_enrolment-status.html.erb
+++ b/app/views/dashboard/_enrolment-status.html.erb
@@ -6,10 +6,8 @@
       <%= link_to 'View certificate', programme.path, class: 'govuk-button button button--full-width' %>
     <% end %>
 <% else %>
-  <% if programme.primary_certificate? %>
-    <%= link_to 'Find out more', primary_path, class: 'govuk-button button button--full-width', role: 'button', draggable: 'false' %>
-  <% elsif programme.secondary_certificate? %>
-    <%= link_to 'Find out more', secondary_path, class: 'govuk-button button button--full-width', role: 'button', draggable: 'false' %>
+  <% if programme.primary_certificate? || programme.secondary_certificate? %>
+    <%= link_to 'Choose a pathway', programme.public_path, class: 'govuk-button button button--full-width', role: 'button', draggable: 'false' %>
   <% else %>
     <%= link_to 'Enrol', programme.enrol_path(user_programme_enrolment: { user_id: current_user.id, programme_id: programme.id }), method: :post, class: 'govuk-button button button--full-width', role: 'button', draggable: 'false' %>
   <% end %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -26,6 +26,29 @@
     {
       "warning_type": "Redirect",
       "warning_code": 18,
+      "fingerprint": "40947d3dbf33d0b0535f87b2d8bef5f38b6b626b133f8cf47691a6f0d84f9b42",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/pages_controller.rb",
+      "line": 85,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Programme.find_by!(:slug => params[:page_slug]).path)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "PagesController",
+        "method": "static_programme_page"
+      },
+      "user_input": "Programme.find_by!(:slug => params[:page_slug]).path",
+      "confidence": "High",
+      "cwe_id": [
+        601
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
       "fingerprint": "5c6e1a97288d4bb7695b11a2e1ba6e4f8db81fd515d3d6f3d630334e3dae14b3",
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
@@ -53,7 +76,7 @@
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/controllers/pages_controller.rb",
-      "line": 84,
+      "line": 87,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(template => \"pages/enrolment/#{params[:page_slug]}\", {})",
       "render_path": null,
@@ -90,30 +113,7 @@
       "cwe_id": [
         601
       ],
-      "note": ""
-    },
-    {
-      "warning_type": "Redirect",
-      "warning_code": 18,
-      "fingerprint": "8624aa70522eb5581550385e678353e8a33c6d9ba975b181bab22f46a96d321d",
-      "check_name": "Redirect",
-      "message": "Possible unprotected redirect",
-      "file": "app/controllers/pages_controller.rb",
-      "line": 82,
-      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(Programme.includes(:pathways).find_by!(:slug => params[:page_slug]).path)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "PagesController",
-        "method": "static_programme_page"
-      },
-      "user_input": "Programme.includes(:pathways).find_by!(:slug => params[:page_slug]).path",
-      "confidence": "High",
-      "cwe_id": [
-        601
-      ],
-      "note": ""
+      "note": "This has been safly constrained to only valid programmes"
     },
     {
       "warning_type": "Dynamic Render Path",
@@ -196,6 +196,6 @@
       "note": "Pathways can only be edited by admins"
     }
   ],
-  "updated": "2023-09-18 20:59:16 +0000",
+  "updated": "2023-09-21 15:00:09 +0000",
   "brakeman_version": "6.0.1"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -44,7 +44,7 @@
       "cwe_id": [
         601
       ],
-      "note": ""
+      "note": "This has been safely constrained to only valid programmes"
     },
     {
       "warning_type": "Redirect",

--- a/spec/views/dashboard/certificates/_secondary.html_spec.rb
+++ b/spec/views/dashboard/certificates/_secondary.html_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe('dashboard/certificates/_secondary', type: :view) do
   context 'when the user has not enrolled on Secondary programme' do
     it 'the link to find out more' do
       render template: 'dashboard/certificates/_secondary', locals: { programme: programme }
-      expect(rendered).to have_link('Find out more', href: secondary_path)
+      expect(rendered).to have_link('Choose a pathway', href: secondary_path)
     end
   end
 


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App link(s): https://teachcomputing-pr-1806.herokuapp.com/dashboard

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Altered copy from "find out more" to "choose a pathway"
- Removed excess `.includes()`