### PR TITLE
Increase the delay of the IB programme pending state

### DIFF
--- a/app/jobs/certificate_pending_transition_job.rb
+++ b/app/jobs/certificate_pending_transition_job.rb
@@ -11,7 +11,7 @@ class CertificatePendingTransitionJob < ApplicationJob
     return if enrolment&.current_state == :complete.to_s
 
     enrolment.transition_to(:pending, meta)
-    ScheduleCertificateCompletionJob.set(wait: 7.days).perform_later(enrolment)
+    ScheduleCertificateCompletionJob.set(wait: programme.pending_delay).perform_later(enrolment)
   end
 
   private

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -41,6 +41,10 @@ class Programme < ApplicationRecord
     Programme.find_by(slug: 'a-level')
   end
 
+  def pending_delay
+    raise NotImplementedError
+  end
+
   def badgeable?
     badges.active.exists?
   end

--- a/app/models/programmes/cs_accelerator.rb
+++ b/app/models/programmes/cs_accelerator.rb
@@ -3,6 +3,10 @@ module Programmes
     PROGRAMME_TITLE = 'GCSE Computer Science Subject Knowledge'.freeze
     REQUIRED_ASSESSMENT_PERCENTAGE = 65.0
 
+    def pending_delay
+      7.days
+    end
+
     def mailer
       CSAcceleratorMailer
     end

--- a/app/models/programmes/i_belong.rb
+++ b/app/models/programmes/i_belong.rb
@@ -2,6 +2,10 @@ module Programmes
   class IBelong < Programme
     PROGRAMME_TITLE = 'I Belong: encouraging girls into computer science'.freeze
 
+    def pending_delay
+      14.days
+    end
+
     def mailer
       IBelongMailer
     end

--- a/app/models/programmes/primary_certificate.rb
+++ b/app/models/programmes/primary_certificate.rb
@@ -2,6 +2,10 @@ module Programmes
   class PrimaryCertificate < Programme
     PROGRAMME_TITLE = 'Primary Computing Teaching'.freeze
 
+    def pending_delay
+      7.days
+    end
+
     def mailer
       PrimaryMailer
     end

--- a/app/models/programmes/secondary_certificate.rb
+++ b/app/models/programmes/secondary_certificate.rb
@@ -2,6 +2,10 @@ module Programmes
   class SecondaryCertificate < Programme
     PROGRAMME_TITLE = 'Secondary Computing Teaching'.freeze
 
+    def pending_delay
+      7.days
+    end
+
     def mailer
       SecondaryMailer
     end

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe Programme, type: :model do
     end
   end
 
+  describe '#pending_delay' do
+    it 'should raise NotImplementedError' do
+      expect { generic_programme.pending_delay }.to raise_error(NotImplementedError)
+    end
+  end
+
   describe '#user_enrolled?' do
     it 'returns true if user is enrolled on the programme' do
       user_programme_enrolment

--- a/spec/models/programmes/cs_accelerator_spec.rb
+++ b/spec/models/programmes/cs_accelerator_spec.rb
@@ -84,6 +84,12 @@ RSpec.describe Programmes::CSAccelerator do
     end
   end
 
+  describe '#pending_delay' do
+    it 'should return 7 days' do
+      expect(programme.pending_delay).to eq 7.days
+    end
+  end
+
   describe '#diagnostic' do
     context 'when an associated diagnostic activity exists' do
       it 'returns record' do

--- a/spec/models/programmes/i_belong_spec.rb
+++ b/spec/models/programmes/i_belong_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Programmes::IBelong do
     end
   end
 
+  describe '#pending_delay' do
+    it 'should return 14 days' do
+      expect(programme.pending_delay).to eq 14.days
+    end
+  end
+
   describe '#enrol_path' do
     it 'returns the path for the enrol' do
       expect(programme.enrol_path(user_programme_enrolment: { user_id: 'user_id',

--- a/spec/models/programmes/primary_certificate_spec.rb
+++ b/spec/models/programmes/primary_certificate_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe Programmes::PrimaryCertificate do
     end
   end
 
+  describe '#pending_delay' do
+    it 'should return 7 days' do
+      expect(programme.pending_delay).to eq 7.days
+    end
+  end
+
   describe '#path' do
     it 'returns the path for the programme' do
       expect(programme.path).to eq('/certificate/primary-certificate')

--- a/spec/models/programmes/secondary_certificate_spec.rb
+++ b/spec/models/programmes/secondary_certificate_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Programmes::SecondaryCertificate do
   let(:secondary_certificate) { create(:secondary_certificate) }
   let(:programme_activity_groupings) { create_list(:programme_activity_grouping, 3, :with_activities, programme: secondary_certificate) }
 
+  describe '#pending_delay' do
+    it 'should return 7 days' do
+      expect(secondary_certificate.pending_delay).to eq 7.days
+    end
+  end
+
   describe '#user_meets_completion_requirement?' do
     before do
       user


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App link(s): *populate this with links to the relevant parts of the review app*

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Adds a method which contains the length of time that a UPE should be pending and makes IB 14 days
