### PR TITLE
Updated primary activity copy

### DIFF
--- a/db/seeds/activities/community.rb
+++ b/db/seeds/activities/community.rb
@@ -328,8 +328,8 @@ Activity.find_or_initialize_by(slug: 'participate-fully-in-an-ncce-curriculum-en
   activity.category = 'community'
   activity.provider = 'stem-learning'
   activity.self_certifiable = true
-  activity.description = 'Encourage young people to develop important life skills through <a href="https://teachcomputing.org/primary-enrichment">enrichment</a> and engage with the wider community in practical, enjoyable, and meaningful ways.'
-  activity.public_copy_description = 'Encourage young people to develop important life skills through enrichment and engage with the wider community in practical, enjoyable, and meaningful ways.'
+  activity.description = 'Participate in a webinar or explore our partner enrichment resources to enable you to run an enrichment activity in your classroom.'
+  activity.public_copy_description = 'Participate in a webinar or explore our partner enrichment resources to enable you to run an enrichment activity in your classroom.'
   activity.public_copy_title_url = 'http://www.teachcomputing.org/primary-enrichment'
   activity.self_verification_info = 'Please provide us with evidence of delivery'
 


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App link(s):
- https://teachcomputing-pr-1817.herokuapp.com/certificate/pathways/specialising-or-leading-2 (logged out)
- https://teachcomputing-pr-1817.herokuapp.com/certificate/pathways/developing-in-the-classroom-2 (logged out)
- https://teachcomputing-pr-1817.herokuapp.com/certificate/primary-certificate (logged in)
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2484

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [N/A] Tech review completed


## What's changed?

Updates the seed of an activity to match new copy.

The "Participate fully in an NCCE curriculum enrichment opportunity" ticket should have new copy on the /certificate/primary-certificate and on both the pathway pages /certificate/pathways/specialising-or-leading-2 and /certificate/pathways/developing-in-the-classroom-2
