### PR TITLE
2486/update primary and secondary seeds

### DIFF
--- a/app/helpers/external_link_helper.rb
+++ b/app/helpers/external_link_helper.rb
@@ -30,4 +30,16 @@ module ExternalLinkHelper
   def cyber_centurion_webinar_url
     'https://www.stem.org.uk/cpd/527935/cyber-centurion-competition-cyber-security'
   end
+
+  def primary_stem_community_url
+    'https://community.stem.org.uk/communities/community-home?communitykey=1238654a-fe3d-4173-99e1-4ecf11c98cdc'
+  end
+
+  def secondary_stem_community_url
+    'https://community.stem.org.uk/communities/community-home?CommunityKey=f5098030-41d2-43f9-8f5d-67b536b18b97'
+  end
+
+  def stem_community_points_help_url
+    'https://community.stem.org.uk/helpfaqs/points'
+  end
 end

--- a/db/seeds/activities/community.rb
+++ b/db/seeds/activities/community.rb
@@ -381,6 +381,21 @@ Activity.find_or_initialize_by(slug: 'share-tips-on-using-an-ncce-resource-in-yo
   activity.programmes = [primary_certificate]
 end.save
 
+Activity.find_or_initialize_by(slug: 'support-other-teachers-and-earn-a-stem-community-participation-badge-secondary').tap do |activity|
+  activity.title = 'Support other teachers and earn a STEM Community participation badge'
+  activity.credit = 10
+  activity.slug = 'support-other-teachers-and-earn-a-stem-community-participation-badge-secondary'
+  activity.category = 'community'
+  activity.provider = 'stem-learning'
+  activity.self_certifiable = true
+  activity.description = "You’ll earn points for your activities on the <a href=\"#{secondary_stem_community_url}\">STEM Community</a>. Your points add up, and over time you will be <a href=\"#{stem_community_points_help_url}\">rewarded with badges</a> in recognition of your activity and participation in the community."
+  activity.public_copy_description = 'You’ll earn points for your activities on the STEM Community. Your points add up, and over time you will be rewarded with badges in recognition of your activity and participation in the community.'
+  activity.public_copy_title_url = 'https://community.stem.org.uk/helpfaqs/points'
+  activity.self_verification_info = 'Please provide us with evidence of participation'
+
+  activity.programmes = [secondary_certificate]
+end.save
+
 Activity.find_or_initialize_by(slug: 'support-other-teachers-and-earn-a-stem-community-participation-badge').tap do |activity|
   activity.title = 'Support other teachers and earn a STEM Community participation badge'
   activity.credit = 10
@@ -388,12 +403,12 @@ Activity.find_or_initialize_by(slug: 'support-other-teachers-and-earn-a-stem-com
   activity.category = 'community'
   activity.provider = 'stem-learning'
   activity.self_certifiable = true
-  activity.description = 'You’ll earn points for your activities on the <a href="https://community.stem.org.uk/helpfaqs/points">STEM Community</a>. Your points add up, and over time you will be <a href="https://community.stem.org.uk/helpfaqs/points">rewarded with badges</a> in recognition of your activity and participation in the community.'
+  activity.description = "You’ll earn points for your activities on the <a href=\"#{primary_stem_community_url}\">STEM Community</a>. Your points add up, and over time you will be <a href=\"#{stem_community_points_help_url}\">rewarded with badges</a> in recognition of your activity and participation in the community."
   activity.public_copy_description = 'You’ll earn points for your activities on the STEM Community. Your points add up, and over time you will be rewarded with badges in recognition of your activity and participation in the community.'
   activity.public_copy_title_url = 'https://community.stem.org.uk/helpfaqs/points'
   activity.self_verification_info = 'Please provide us with evidence of participation'
 
-  activity.programmes = [primary_certificate, secondary_certificate]
+  activity.programmes = [primary_certificate]
 end.save
 
 Activity.find_or_initialize_by(slug: 'run-or-support-a-code-club-in-your-school').tap do |activity|

--- a/db/seeds/pathways/primary_certificate.rb
+++ b/db/seeds/pathways/primary_certificate.rb
@@ -176,6 +176,7 @@ programme.pathways.find_or_initialize_by(slug: 'specialising-or-leading-2').tap 
     'work-with-your-local-computing-hub-to-develop-a-school-level-action-plan-for-professional-development',
     'lead-your-school-into-a-computing-cluster-and-develop-an-action-plan-with-a-cluster-advisor',
     'join-and-present-at-your-local-computing-at-school-community',
+    'run-an-enrichment-activity-in-your-classroom'
   ]
 
   activities.each do |activity|

--- a/db/seeds/pathways/secondary_certificate.rb
+++ b/db/seeds/pathways/secondary_certificate.rb
@@ -49,7 +49,7 @@ programme.pathways.find_or_initialize_by(slug: 'curriculum-leadership').tap do |
     'download-and-use-the-ncce-teaching-and-assessment-resources-in-your-classroom',
     # Support your professional community
     'gain-accreditation-as-a-professional-development-leader',
-    'support-other-teachers-and-earn-a-stem-community-participation-badge',
+    'support-other-teachers-and-earn-a-stem-community-participation-badge-secondary',
     'undertake-the-initial-assessment-of-your-school-using-computing-quality-framework',
     'work-with-your-local-computing-hub-to-develop-a-school-level-action-plan-for-professional-development',
     'lead-your-school-into-a-computing-cluster-and-develop-an-action-plan-with-a-cluster-advisor',
@@ -58,6 +58,14 @@ programme.pathways.find_or_initialize_by(slug: 'curriculum-leadership').tap do |
 
   activities.each do |activity|
     maybe_attach_activity_to_pathway(pathway, slug: activity)
+  end
+
+  remove_activities = [
+    'support-other-teachers-and-earn-a-stem-community-participation-badge'
+  ]
+
+  remove_activities.each do |activity|
+    maybe_detach_activity_from_pathway(pathway, slug: activity)
   end
 end.save
 
@@ -100,11 +108,19 @@ programme.pathways.find_or_initialize_by(slug: 'supporting-other-teachers').tap 
     'undertake-the-initial-assessment-of-your-school-using-computing-quality-framework',
     'lead-your-school-into-a-computing-cluster-and-develop-an-action-plan-with-a-cluster-advisor',
     'join-and-present-at-your-local-computing-at-school-community',
-    'support-other-teachers-and-earn-a-stem-community-participation-badge'
+    'support-other-teachers-and-earn-a-stem-community-participation-badge-secondary'
   ]
 
   activities.each do |activity|
     maybe_attach_activity_to_pathway(pathway, slug: activity)
+  end
+
+  remove_activities = [
+    'support-other-teachers-and-earn-a-stem-community-participation-badge'
+  ]
+
+  remove_activities.each do |activity|
+    maybe_detach_activity_from_pathway(pathway, slug: activity)
   end
 end.save
 
@@ -144,7 +160,7 @@ programme.pathways.find_or_initialize_by(slug: 'championing-diversity-and-inclus
     'download-and-use-isaac-computer-science-classroom-resources-and-displays',
     # Support your professional community
     'gain-accreditation-as-a-professional-development-leader',
-    'support-other-teachers-and-earn-a-stem-community-participation-badge',
+    'support-other-teachers-and-earn-a-stem-community-participation-badge-secondary',
     'work-with-local-business-and-industry-to-inspire-inclusive-computing',
     'lead-your-school-into-a-computing-cluster-and-develop-an-action-plan-with-a-cluster-advisor',
     'join-and-present-at-your-local-computing-at-school-community'
@@ -152,6 +168,14 @@ programme.pathways.find_or_initialize_by(slug: 'championing-diversity-and-inclus
 
   activities.each do |activity|
     maybe_attach_activity_to_pathway(pathway, slug: activity)
+  end
+
+  remove_activities = [
+    'support-other-teachers-and-earn-a-stem-community-participation-badge'
+  ]
+
+  remove_activities.each do |activity|
+    maybe_detach_activity_from_pathway(pathway, slug: activity)
   end
 end.save
 
@@ -193,7 +217,7 @@ programme.pathways.find_or_initialize_by(slug: 'raising-student-attainment').tap
     'download-and-use-the-ncce-teaching-and-assessment-resources-in-your-classroom',
     # Support your local professional community
     'gain-accreditation-as-a-professional-development-leader',
-    'support-other-teachers-and-earn-a-stem-community-participation-badge',
+    'support-other-teachers-and-earn-a-stem-community-participation-badge-secondary',
     'undertake-the-initial-assessment-of-your-school-using-computing-quality-framework',
     'work-with-your-local-computing-hub-to-develop-a-school-level-action-plan-for-professional-development',
     'lead-your-school-into-a-computing-cluster-and-develop-an-action-plan-with-a-cluster-advisor',
@@ -202,6 +226,14 @@ programme.pathways.find_or_initialize_by(slug: 'raising-student-attainment').tap
 
   activities.each do |activity|
     maybe_attach_activity_to_pathway(pathway, slug: activity)
+  end
+
+  remove_activities = [
+    'support-other-teachers-and-earn-a-stem-community-participation-badge'
+  ]
+
+  remove_activities.each do |activity|
+    maybe_detach_activity_from_pathway(pathway, slug: activity)
   end
 end.save
 
@@ -240,12 +272,20 @@ programme.pathways.find_or_initialize_by(slug: 'developing-teachers').tap do |pa
     'implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit',
     # Support your lcal professional community
     'gain-accreditation-as-a-professional-development-leader',
-    'support-other-teachers-and-earn-a-stem-community-participation-badge',
+    'support-other-teachers-and-earn-a-stem-community-participation-badge-secondary',
     'gain-accreditation-as-an-i-belong-champion',
     'work-with-local-business-and-industry-to-inspire-inclusive-computing'
   ]
 
   activities.each do |activity|
     maybe_attach_activity_to_pathway(pathway, slug: activity)
+  end
+
+  remove_activities = [
+    'support-other-teachers-and-earn-a-stem-community-participation-badge'
+  ]
+
+  remove_activities.each do |activity|
+    maybe_detach_activity_from_pathway(pathway, slug: activity)
   end
 end.save

--- a/db/seeds/programme_activity_groupings/secondary_certificate.rb
+++ b/db/seeds/programme_activity_groupings/secondary_certificate.rb
@@ -73,7 +73,7 @@ secondary.programme_activity_groupings.find_or_initialize_by(title: 'Support you
 
   activities = [
     { slug: 'gain-accreditation-as-a-professional-development-leader', legacy: false },
-    { slug: 'support-other-teachers-and-earn-a-stem-community-participation-badge', legacy: false },
+    { slug: 'support-other-teachers-and-earn-a-stem-community-participation-badge-secondary', legacy: false },
     { slug: 'undertake-the-initial-assessment-of-your-school-using-computing-quality-framework', legacy: false },
     { slug: 'gain-accreditation-as-an-i-belong-champion', legacy: false },
     { slug: 'work-with-local-business-and-industry-to-inspire-inclusive-computing', legacy: false },
@@ -87,6 +87,7 @@ secondary.programme_activity_groupings.find_or_initialize_by(title: 'Support you
   end
 
   remove_activities = [
+    { slug: 'support-other-teachers-and-earn-a-stem-community-participation-badge', legacy: false },
     { slug: 'provide-feedback-on-our-curriculum-resources', legacy: true },
     { slug: 'provide-feedback-on-a-cas-resource', legacy: true },
     { slug: 'complete-a-cs-accelerator-course', legacy: true },

--- a/spec/helpers/external_link_helper_spec.rb
+++ b/spec/helpers/external_link_helper_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe ExternalLinkHelper do
       secondary_astro_pi_webinar_url
       climate_detectives_webinar_url
       cyber_centurion_webinar_url
+      secondary_stem_community_url
+      primary_stem_community_url
+      stem_community_points_help_url
   ].each do |external_link_method|
     describe "##{external_link_method}" do
       it 'should return a string' do


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App link(s):
- https://teachcomputing-pr-1819.herokuapp.com/certificate/pathways/specialising-or-leading-2 (logged out)
- https://teachcomputing-pr-1819.herokuapp.com/certificate/primary-certificate (logged in)
- https://teachcomputing-pr-1819.herokuapp.com/certificate/secondary-certificate (logged in)
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2486


## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Split "support other teachers and earn a STEM Community participation badge" into a primary and secondary variant which links to the specific stem community.

Added "Run an enrichment activity in your classroom" to primary specialising and leading pathway
