### PR TITLE
Added CSA to secondary computing dashboard.

### DIFF
--- a/app/components/progress_bar_component.rb
+++ b/app/components/progress_bar_component.rb
@@ -6,6 +6,6 @@ class ProgressBarComponent < ViewComponent::Base
       @body = body
       @steps_to_accreditation = steps_to_accreditation
 
-      @programme_activity_groupings = @programme.programme_activity_groupings.progress_bar_groupings.includes(:programme_activities).order(:sort_key)
+      @programme_objectives = programme.programme_objectives_displayed_in(:progress_bar)
     end
   end

--- a/app/components/progress_bar_component.rb
+++ b/app/components/progress_bar_component.rb
@@ -6,6 +6,6 @@ class ProgressBarComponent < ViewComponent::Base
       @body = body
       @steps_to_accreditation = steps_to_accreditation
 
-      @programme_objectives = programme.programme_objectives_displayed_in(:progress_bar)
+      @programme_objectives = programme.programme_objectives_displayed_in_progress_bar
     end
   end

--- a/app/components/progress_bar_component/progress_bar_component.html.erb
+++ b/app/components/progress_bar_component/progress_bar_component.html.erb
@@ -17,12 +17,13 @@
       <p class="govuk-body-s">Choose your first step to accreditation:</p>
     <% end %>
     <div class="ncce-progress-section">
-      <% @programme_activity_groupings.each_with_index do |grouping, index| %>
-        <% class_name = grouping&.user_complete?(@current_user) ? "icon-ticked-circle" : "icon-blank-circle" %>
-        <a href="#" class="<%= class_name %> ncce-link ncce-progress-section--text">
-          <span><%= grouping.progress_bar_title.html_safe %></span>
+      <% @programme_objectives.each_with_index do |programme_objective, index| %>
+        <% class_name = programme_objective&.user_complete?(@current_user) ? "icon-ticked-circle" : "icon-blank-circle" %>
+        <a href="<%= programme_objective.progress_bar_path %>" class="<%= class_name %> ncce-link ncce-progress-section--text">
+          <span><%= programme_objective.progress_bar_title.html_safe %></span>
         </a>
-        <% unless index == @programme_activity_groupings.size - 1 %>
+
+        <% unless index == @programme_objectives.size - 1 %>
           <div class="icon-dotted-line"></div>
         <% end %>
       <% end %>

--- a/app/lib/programme_objectives/programme_completion_required.rb
+++ b/app/lib/programme_objectives/programme_completion_required.rb
@@ -1,0 +1,22 @@
+# Plays role "ProgrammeObjective" and "ProgressBarItem"
+class ProgrammeObjectives::ProgrammeCompletionRequired
+  attr_reader :progress_bar_title, :progress_bar_path
+
+  def initialize(required_programme:, progress_bar_title:, progress_bar_path:)
+    @required_programme = required_programme
+    @progress_bar_title = progress_bar_title
+    @progress_bar_path = progress_bar_path
+  end
+
+  def user_complete?(user)
+    required_programme.user_completed?(user)
+  end
+
+  def objective_displayed_in?(role)
+    role.in? %i[progress_bar]
+  end
+
+  private
+
+  attr_reader :required_programme
+end

--- a/app/lib/programme_objectives/programme_completion_required.rb
+++ b/app/lib/programme_objectives/programme_completion_required.rb
@@ -12,8 +12,12 @@ class ProgrammeObjectives::ProgrammeCompletionRequired
     required_programme.user_completed?(user)
   end
 
-  def objective_displayed_in?(role)
-    role.in? %i[progress_bar]
+  def objective_displayed_in_progress_bar?
+    true
+  end
+
+  def objective_displayed_in_body?
+    false
   end
 
   private

--- a/app/lib/programme_objectives/readme.md
+++ b/app/lib/programme_objectives/readme.md
@@ -1,0 +1,23 @@
+# Programme Objectives
+
+I've introduced programme objectives as a new abstraction to try and standarize
+how programmes are defined. We've reached the point where we have things that
+are not ProgrammeActivityGroupings which need completion before the course can
+be considered complete.
+
+I've specifically chosen to not have a "ProgrammeObjective" class or concern
+dispite the strong "is_a" type relationship. My reason behind this is to allow
+many objects of different shapes and sizes to play this role. Especially as we
+already have objects like ProgrammeActivityGroupings which play this role well.
+
+Each item which needs completed shall be encapsulated in an object playing the
+"ProgrammeObjective" role. ProgrammeObjectives will respond to
+`user_complete?(user)`. It will also respond to
+`objective_displayed_in?(location)` which can be used to decided where on the
+page it should be shown.
+
+## Progress Bar
+
+Programme objectives that are to be displayed in the `progress_bar` must play
+the role of "ProgressBarObjective" and respond to `progress_bar_title` and
+`progress_bar_path`

--- a/app/lib/programme_objectives/readme.md
+++ b/app/lib/programme_objectives/readme.md
@@ -10,14 +10,12 @@ dispite the strong "is_a" type relationship. My reason behind this is to allow
 many objects of different shapes and sizes to play this role. Especially as we
 already have objects like ProgrammeActivityGroupings which play this role well.
 
-Each item which needs completed shall be encapsulated in an object playing the
+Each item which needs completed shall be represented by an object playing the
 "ProgrammeObjective" role. ProgrammeObjectives will respond to
-`user_complete?(user)`. It will also respond to
-`objective_displayed_in?(location)` which can be used to decided where on the
-page it should be shown.
+`user_complete?(user)`.
 
 ## Progress Bar
 
-Programme objectives that are to be displayed in the `progress_bar` must play
-the role of "ProgressBarObjective" and respond to `progress_bar_title` and
-`progress_bar_path`
+Programme objectives that are to be displayed in the `progress_bar` will have
+"objective_displayed_in_progress_bar?" return true and respond to
+`progress_bar_title` and `progress_bar_path`

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -69,7 +69,7 @@ class Programme < ApplicationRecord
   end
 
   def user_meets_completion_requirement?(user)
-    programme_activity_groupings.all? { |group| group.user_complete?(user) }
+    programme_objectives.all? { |group| group.user_complete?(user) }
   end
 
   def user_enrolled?(user)
@@ -133,5 +133,13 @@ class Programme < ApplicationRecord
 
   def enrichment_enabled?
     false
+  end
+
+  def programme_objectives
+    programme_activity_groupings.includes(:programme_activities).order(:sort_key)
+  end
+
+  def programme_objectives_displayed_in(position)
+    programme_objectives.select { _1.objective_displayed_in? position }
   end
 end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -139,7 +139,11 @@ class Programme < ApplicationRecord
     programme_activity_groupings.includes(:programme_activities).order(:sort_key)
   end
 
-  def programme_objectives_displayed_in(position)
-    programme_objectives.select { _1.objective_displayed_in? position }
+  def programme_objectives_displayed_in_progress_bar
+    programme_objectives.select { _1.objective_displayed_in_progress_bar? }
+  end
+
+  def programme_objectives_displayed_in_body
+    programme_objectives.select { _1.objective_displayed_in_body? }
   end
 end

--- a/app/models/programme_activity_grouping.rb
+++ b/app/models/programme_activity_grouping.rb
@@ -71,8 +71,12 @@ class ProgrammeActivityGrouping < ApplicationRecord
     completed_legacy_activities + completed_non_legacy_activities + non_completed_non_legacy_activities
   end
 
-  def objective_displayed_in?(role)
-    role.in? %i[progress_bar body]
+  def objective_displayed_in_progress_bar?
+    true
+  end
+
+  def objective_displayed_in_body?
+    true
   end
 
   def progress_bar_path

--- a/app/models/programme_activity_grouping.rb
+++ b/app/models/programme_activity_grouping.rb
@@ -1,3 +1,4 @@
+# Plays "ProgrammeObjective" role app/lib/programme_objectives/readme.md
 class ProgrammeActivityGrouping < ApplicationRecord
   include ActionView::Helpers::TagHelper
   include StiPreload
@@ -68,5 +69,13 @@ class ProgrammeActivityGrouping < ApplicationRecord
       .select { completed_activity_ids.include?(_1.activity_id) }
 
     completed_legacy_activities + completed_non_legacy_activities + non_completed_non_legacy_activities
+  end
+
+  def objective_displayed_in?(role)
+    role.in? %i[progress_bar body]
+  end
+
+  def progress_bar_path
+    "##{id}"
   end
 end

--- a/app/models/programmes/secondary_certificate.rb
+++ b/app/models/programmes/secondary_certificate.rb
@@ -14,12 +14,6 @@ module Programmes
       SecondaryMailer
     end
 
-    def user_meets_completion_requirement?(user)
-      return false unless Programme.cs_accelerator.user_completed?(user)
-
-      super(user)
-    end
-
     def path
       secondary_certificate_path
     end
@@ -46,6 +40,17 @@ module Programmes
 
     def enrichment_enabled?
       true
+    end
+
+    def programme_objectives
+      [
+        ProgrammeObjectives::ProgrammeCompletionRequired.new(
+          required_programme: Programme.cs_accelerator,
+          progress_bar_title: 'Complete the Secondary subject knowledge',
+          progress_bar_path: cs_accelerator_path
+        ),
+        *programme_activity_groupings.includes(:programme_activities).order(:sort_key)
+      ]
     end
   end
 end

--- a/app/views/certificates/i_belong/_achievement_list.html.erb
+++ b/app/views/certificates/i_belong/_achievement_list.html.erb
@@ -1,4 +1,4 @@
-<p class="govuk-body ncce-activity-list__title govuk-!-margin-top-8 <%= add_groups_complete_icon_class(current_user, @professional_development_groups) %>">
+<p id="<%= @professional_development_groups.first&.id %>" class="govuk-body ncce-activity-list__title govuk-!-margin-top-8 <%= add_groups_complete_icon_class(current_user, @professional_development_groups) %>">
   <%= t('.development.title.html') %>
 </p>
 <ul class="govuk-list ncce-activity-list ncce-activity-list--programme" role="list">
@@ -22,7 +22,7 @@
 
 <!-- Remember additional course handling -->
 <% @community_groups.each do |group| %>
-  <p class="govuk-body ncce-activity-list__title <%= add_group_complete_icon_class(current_user, group) %>">
+  <p id="<%= group.id %>" class="govuk-body ncce-activity-list__title <%= add_group_complete_icon_class(current_user, group) %>">
     <%= group.formatted_title %>
   </p>
   <%= render CommunityActivityListComponent.new(
@@ -31,4 +31,3 @@
     tracking_category:
   ) %>
 <% end %>
-

--- a/app/views/certificates/primary_certificate/_achievement_list.html.erb
+++ b/app/views/certificates/primary_certificate/_achievement_list.html.erb
@@ -1,4 +1,4 @@
-<p class="govuk-body ncce-activity-list__title govuk-!-margin-top-8 <%= add_groups_complete_icon_class(current_user, @professional_development_groups) %>">
+<p id="<%= @professional_development_groups.first&.id %>" class="govuk-body ncce-activity-list__title govuk-!-margin-top-8 <%= add_groups_complete_icon_class(current_user, @professional_development_groups) %>">
   <%= t('.development.title.html') %>
 </p>
 <ul class="govuk-list ncce-activity-list ncce-activity-list--programme" role="list">
@@ -38,7 +38,7 @@
 </ul>
 
 <% @community_groups.each do |group| %>
-  <p class="govuk-body ncce-activity-list__title <%= add_group_complete_icon_class(current_user, group) %>">
+  <p id="<%= group.id %>" class="govuk-body ncce-activity-list__title <%= add_group_complete_icon_class(current_user, group) %>">
     <strong>Choose at least <%= group.required_for_completion.humanize %> activity</strong> to <%= group.title.downcase %>
   </p>
   <%= render CommunityActivityListComponent.new(

--- a/app/views/certificates/secondary_certificate/_achievement_list.html.erb
+++ b/app/views/certificates/secondary_certificate/_achievement_list.html.erb
@@ -1,4 +1,4 @@
-<p class="govuk-body ncce-activity-list__title govuk-!-margin-top-8 <%= add_groups_complete_icon_class(current_user, @professional_development_groups) %>">
+<p id="<%= @professional_development_groups.first&.id %>" class="govuk-body ncce-activity-list__title govuk-!-margin-top-8 <%= add_groups_complete_icon_class(current_user, @professional_development_groups) %>">
   <%= t('.development.title.html') %>
 </p>
 <ul class="govuk-list ncce-activity-list ncce-activity-list--programme" role="list">
@@ -38,7 +38,7 @@
 </ul>
 
 <% @community_groups.each do |group| %>
-  <p class="govuk-body ncce-activity-list__title <%= add_group_complete_icon_class(current_user, group) %>">
+  <p id="<%= group.id %>" class="govuk-body ncce-activity-list__title <%= add_group_complete_icon_class(current_user, group) %>">
     <strong>Choose at least <%= group.required_for_completion.humanize %> activity</strong> to <%= group.title.downcase %>
   </p>
   <%= render CommunityActivityListComponent.new(

--- a/spec/components/progress_bar_component_spec.rb
+++ b/spec/components/progress_bar_component_spec.rb
@@ -4,11 +4,10 @@ RSpec.describe ProgressBarComponent, type: :component do
     let(:user) { create(:user) }
     let(:primary_certificate) { create(:primary_certificate) }
     let(:primary_programme_activity_groupings) do
-      create_list(:programme_activity_grouping, 4, programme: primary_certificate).tap do |groupings|
-        groupings[0].update(progress_bar_title: nil)
-        groupings[1].update(progress_bar_title: 'Complete professional development')
-        groupings[2].update(progress_bar_title: 'Develop your teaching practice')
-        groupings[3].update(progress_bar_title: 'Develop computing in your community')
+      create_list(:programme_activity_grouping, 3, programme: primary_certificate).tap do |groupings|
+        groupings[0].update(progress_bar_title: 'Complete professional development')
+        groupings[1].update(progress_bar_title: 'Develop your teaching practice')
+        groupings[2].update(progress_bar_title: 'Develop computing in your community')
       end
     end
 

--- a/spec/factories/programme_activity_groupings.rb
+++ b/spec/factories/programme_activity_groupings.rb
@@ -4,10 +4,7 @@ FactoryBot.define do
     required_for_completion { 1 }
     sort_key { 1 }
     programme
-
-    trait :progress_bar_title do
-      progress_bar_title { 'Progress Bar Title' }
-    end
+    progress_bar_title { 'Progress Bar Title' }
 
     trait :with_activities do
       after(:create) do |programme_activity_grouping|

--- a/spec/lib/programme_objectives/programme_completion_required_spec.rb
+++ b/spec/lib/programme_objectives/programme_completion_required_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe ProgrammeObjectives::ProgrammeCompletionRequired do
+  let(:required_programme) { create(:programme) }
+  let(:progress_bar_title) { 'foo' }
+  let(:progress_bar_path) { 'bar' }
+
+  subject { described_class.new(required_programme:, progress_bar_title:, progress_bar_path:) }
+
+  it_behaves_like 'plays programme objective role'
+  it_behaves_like 'plays programme objective progress bar role'
+
+  describe '#user_complete?' do
+    let(:user) { create(:user) }
+
+    it 'should send user_completed? to the required programme' do
+      expect(required_programme).to receive(:user_completed?).with(user)
+
+      subject.user_complete?(user)
+    end
+  end
+
+  describe '#objective_displayed_in?' do
+    it 'should return true when passed progress_bar' do
+      expect(subject.objective_displayed_in?(:progress_bar)).to be true
+    end
+  end
+end

--- a/spec/lib/programme_objectives/programme_completion_required_spec.rb
+++ b/spec/lib/programme_objectives/programme_completion_required_spec.rb
@@ -19,10 +19,4 @@ RSpec.describe ProgrammeObjectives::ProgrammeCompletionRequired do
       subject.user_complete?(user)
     end
   end
-
-  describe '#objective_displayed_in?' do
-    it 'should return true when passed progress_bar' do
-      expect(subject.objective_displayed_in?(:progress_bar)).to be true
-    end
-  end
 end

--- a/spec/models/programme_activity_grouping_spec.rb
+++ b/spec/models/programme_activity_grouping_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe ProgrammeActivityGrouping, type: :model do
   let(:programme_activity_groupings) { create_list(:programme_activity_grouping, 3, :with_activities, programme: programme) }
   let(:user) { create(:user) }
 
+  subject { programme_activity_grouping }
+
+  it_behaves_like 'plays programme objective role'
+  it_behaves_like 'plays programme objective progress bar role'
+
   describe 'associations' do
     it 'has_many programme_activities' do
       expect(programme_activity_grouping).to have_many(:programme_activities)

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -318,4 +318,16 @@ RSpec.describe Programme, type: :model do
       expect { generic_programme.short_name }.to raise_error(NotImplementedError)
     end
   end
+
+  describe '#mailer' do
+    it 'should return not implemented error' do
+      expect { generic_programme.mailer }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#bcs_logo' do
+    it 'should return not implemented error' do
+      expect { generic_programme.bcs_logo }.to raise_error(NotImplementedError)
+    end
+  end
 end

--- a/spec/models/programmes/secondary_certificate_spec.rb
+++ b/spec/models/programmes/secondary_certificate_spec.rb
@@ -84,4 +84,24 @@ RSpec.describe Programmes::SecondaryCertificate do
       expect(secondary_certificate.short_name).to eq 'Secondary certificate'
     end
   end
+
+  describe '#enrol_path' do
+    it 'returns the path for the enrol' do
+      expect(secondary_certificate.enrol_path(user_programme_enrolment: { user_id: 'user_id',
+                                                              programme_id: 'programme_id' })).to eq('/certificate/secondary-certificate/enrol?user_programme_enrolment%5Bprogramme_id%5D=programme_id&user_programme_enrolment%5Buser_id%5D=user_id')
+    end
+  end
+
+  describe '#programme_objectives' do
+    it 'returns one PO::PCR and any PAGs' do
+      pags = create_list(:programme_activity_grouping, 3, programme: secondary_certificate)
+
+      pags.each_with_index do |pag, index|
+        pag.update(sort_key: index + 1)
+      end
+
+      expect(secondary_certificate.programme_objectives.first).to be_a ProgrammeObjectives::ProgrammeCompletionRequired
+      expect(secondary_certificate.programme_objectives[1..]).to eq pags
+    end
+  end
 end

--- a/spec/requests/certificates/secondary_certificate/show_spec.rb
+++ b/spec/requests/certificates/secondary_certificate/show_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Certificates::SecondaryCertificateController do
   let(:user) { create(:user) }
+  let!(:cs_accelerator) { create(:cs_accelerator) }
   let(:secondary_certificate) { create(:secondary_certificate) }
   let(:secondary_certificate_groupings) { create_list(:programme_activity_grouping, 3, programme_id: secondary_certificate.id) }
   let(:secondary_enrolment) { create(:user_programme_enrolment, programme_id: secondary_certificate.id, user_id: user.id) }

--- a/spec/support/shared_examples/plays_programme_objective_progress_bar_role.rb
+++ b/spec/support/shared_examples/plays_programme_objective_progress_bar_role.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples 'plays programme objective progress bar role' do
-  describe '#objective_displayed_in?(:progress_bar)' do
+  describe '#objective_displayed_in_progress_bar?' do
     it 'should return true' do
-      expect(subject.objective_displayed_in?(:progress_bar)).to be true
+      expect(subject.objective_displayed_in_progress_bar?).to be true
     end
   end
 

--- a/spec/support/shared_examples/plays_programme_objective_progress_bar_role.rb
+++ b/spec/support/shared_examples/plays_programme_objective_progress_bar_role.rb
@@ -1,0 +1,27 @@
+RSpec.shared_examples 'plays programme objective progress bar role' do
+  describe '#objective_displayed_in?(:progress_bar)' do
+    it 'should return true' do
+      expect(subject.objective_displayed_in?(:progress_bar)).to be true
+    end
+  end
+
+  it 'should respond to progress_bar_title' do
+    expect(subject.respond_to?(:progress_bar_title)).to be true
+  end
+
+  describe '#progress_bar_title' do
+    it 'should return a string' do
+      expect(subject.progress_bar_title).to be_a String
+    end
+  end
+
+  it 'should respond to progress_bar_path' do
+    expect(subject.respond_to?(:progress_bar_path)).to be true
+  end
+
+  describe '#progress_bar_path' do
+    it 'should return a string' do
+      expect(subject.progress_bar_path).to be_a String
+    end
+  end
+end

--- a/spec/support/shared_examples/plays_programme_objective_role.rb
+++ b/spec/support/shared_examples/plays_programme_objective_role.rb
@@ -3,7 +3,11 @@ RSpec.shared_examples 'plays programme objective role' do
     expect(subject.respond_to?(:user_complete?)).to be true
   end
 
-  it 'should respond_to objective_displayed_in?' do
-    expect(subject.respond_to?(:objective_displayed_in?)).to be true
+  it 'should respond_to objective_displayed_in_progress_bar?' do
+    expect(subject.respond_to?(:objective_displayed_in_progress_bar?)).to be true
+  end
+
+  it 'should respond_to objective_displayed_in_body?' do
+    expect(subject.respond_to?(:objective_displayed_in_body?)).to be true
   end
 end

--- a/spec/support/shared_examples/plays_programme_objective_role.rb
+++ b/spec/support/shared_examples/plays_programme_objective_role.rb
@@ -1,0 +1,9 @@
+RSpec.shared_examples 'plays programme objective role' do
+  it 'should respond_to user_complete?' do
+    expect(subject.respond_to?(:user_complete?)).to be true
+  end
+
+  it 'should respond_to objective_displayed_in?' do
+    expect(subject.respond_to?(:objective_displayed_in?)).to be true
+  end
+end

--- a/spec/views/certificates/secondary-certificate/show.html_spec.rb
+++ b/spec/views/certificates/secondary-certificate/show.html_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe('certificates/secondary_certificate/show', type: :view) do
   let(:user) { create(:user) }
+  let!(:cs_accelerator) { create(:cs_accelerator) }
   let(:secondary_certificate) { create(:secondary_certificate) }
   let(:professional_development_groups) { create_list(:programme_activity_grouping, 2, :with_activities, sort_key: 1, programme: secondary_certificate) }
   let(:community_groups) { create_list(:programme_activity_grouping, 2, :with_activities, sort_key: 4, community: true, programme: secondary_certificate) }


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2496 https://github.com/NCCE/teachcomputing.org-issues/issues/2492


## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

This PR adds the CSA as an item in the progress bar at the top of the secondary programme dashboard.

We've added a handful of new programmes to T/C now and I've held off "drying" up the code as each of the programmes has had a quite distinct set of requirements for completion. In this PR, I've started an abstraction which should let us get rid of having multiple programme controllers, and move to having just one generic controller in the future.

It's clear that we have many different completion requirements for each of our programmes, some being the number of activities needing to be completed, others requiring other programmes to be completed first, and others requiring quizzes to be completed.

I've started on a new abstraction for "ProgrammeObjective"s. The ProgrammeObjective role has been designed to conform to part of the existing interface of the ProgrammeActivityGroupings. Primarily the "user_complete?(user)" method; thus with a little tweaking, making ProgrammeActivityGroupings a programme objective.

I've changed the old logic in the base Programme class which iterated over all the ProgrammeActivityGroupings, and now ask it to iterate over all the ProgrammeObjectives. For most Programmes the list of ProgrammeObjectives will the the same as the ProgrammeActivityGroupings, but it allows us to create different objectives that can test different actions the user has made.

ProgrammeObjectives also have a "objective_displayed_in?(location)" method. Currently, we have two places where we want to display the progress to users. The top "progress bar" and in the main "body" of the programme dashboards. This PR has modified the ProgressBarComponent to use the list of ProgrammeObjectives which are displayed in the :progress_bar, allowing in this case for the CSA programme completion to be one of the steps that needs completing.

In the future, we will be able to create a new generic programme controller which similarly iterates all the ProgrammeObjectives that belong to the body, rendering a ViewComponent which is provided via a method on the ProgrammeObjectives playing the body role, and dynamically render the relevant UI elements.