### PR TITLE
Change slug from a-level to a-level-certificate

### DIFF
--- a/app/jobs/kick_off_emails_job.rb
+++ b/app/jobs/kick_off_emails_job.rb
@@ -7,7 +7,7 @@ class KickOffEmailsJob < ApplicationJob
     case enrolment.programme.slug
     when 'primary-certificate'
       PrimaryMailer.with(user: enrolment.user).enrolled.deliver_now
-    when 'i-belong', 'secondary-certificate', 'a-level'
+    when 'i-belong', 'secondary-certificate', 'a-level-certificate'
       enrolment.programme.mailer.with(user: enrolment.user).welcome.deliver_now
     when 'cs-accelerator'
       CSAcceleratorMailer.with(user: enrolment.user).manual_enrolled_welcome.deliver_now unless enrolment.auto_enrolled

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -38,7 +38,7 @@ class Programme < ApplicationRecord
   end
 
   def self.a_level
-    Programme.find_by(slug: 'a-level')
+    Programme.find_by(slug: 'a-level-certificate')
   end
 
   def short_name
@@ -96,7 +96,7 @@ class Programme < ApplicationRecord
   end
 
   def a_level?
-    slug == 'a-level'
+    slug == 'a-level-certificate'
   end
 
   def pathways?

--- a/app/services/achiever/course/template.rb
+++ b/app/services/achiever/course/template.rb
@@ -119,7 +119,7 @@ class Achiever::Course::Template
       @programmes.include?('Primary')
     when 'i-belong'
       @programmes.include?('I Belong')
-    when 'a-level'
+    when 'a-level-certificate'
       @programmes.include?('A Level')
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,10 +88,10 @@ Rails.application.routes.draw do
       post '/enrol', action: :create, controller: '/user_programme_enrolments', as: :enrol
     end
 
-    resource 'a_level', controller: 'a_level', path: 'a-level', only: :show, as: :a_level do
+    resource 'a_level', controller: 'a_level', path: 'a-level-certificate', only: :show, as: :a_level do
       get '/complete', action: :complete, as: :complete
       get '/view-certificate', action: :show, controller: 'certificate', as: :certificate,
-                               defaults: { slug: 'a-level' }
+                               defaults: { slug: 'a-level-certificate' }
       post '/enrol', action: :create, controller: '/user_programme_enrolments', as: :enrol
     end
 
@@ -160,8 +160,8 @@ Rails.application.routes.draw do
                                            defaults: { page_slug: 'competition-terms-and-conditions' }
   get '/cs-accelerator', to: 'pages#static_programme_page', as: :cs_accelerator,
                          defaults: { page_slug: 'cs-accelerator' }
-  get '/a-level', to: 'pages#static_programme_page', as: :about_a_level,
-                         defaults: { page_slug: 'a-level' }
+  get '/a-level-certificate', to: 'pages#static_programme_page', as: :about_a_level,
+                         defaults: { page_slug: 'a-level-certificate' }
   get '/external/assets/ncce.css', to: 'asset_endpoint#css_endpoint', as: :css_endpoint
 
   get '/i-belong', to: 'pages#i_belong', as: :about_i_belong, defaults: { page_slug: 'i-belong' }

--- a/db/seeds/programmes/a_level.rb
+++ b/db/seeds/programmes/a_level.rb
@@ -1,6 +1,8 @@
-a_level = Programmes::ALevel.find_or_initialize_by(slug: 'a-level').tap do |programme|
+Programmes::ALevel.where(slug: 'a-level').update(slug: 'a-level-certificate')
+
+a_level = Programmes::ALevel.find_or_initialize_by(slug: 'a-level-certificate').tap do |programme|
   programme.title = 'A level subject knowledge'
-  programme.slug = 'a-level'
+  programme.slug = 'a-level-certificate'
   programme.description = 'A level subject knowledege'
   programme.enrollable = true
 

--- a/spec/factories/programmes/a_level.rb
+++ b/spec/factories/programmes/a_level.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :a_level, class: 'Programmes::ALevel' do
     title { 'A level subject knowledge' }
-    slug { 'a-level' }
+    slug { 'a-level-certificate' }
     description { 'A level subject knowledge' }
     enrollable { true }
 

--- a/spec/models/programmes/a_level_spec.rb
+++ b/spec/models/programmes/a_level_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Programmes::ALevel do
 
   describe '#path' do
     it 'returns the path for the programme' do
-      expect(subject.path).to eq('/certificate/a-level')
+      expect(subject.path).to eq('/certificate/a-level-certificate')
     end
   end
 
   describe '#enrol_path' do
     it 'returns the path for the enrol' do
       expect(subject.enrol_path(user_programme_enrolment: { user_id: 'user_id',
-                                                              programme_id: 'programme_id' })).to eq('/certificate/a-level/enrol?user_programme_enrolment%5Bprogramme_id%5D=programme_id&user_programme_enrolment%5Buser_id%5D=user_id')
+                                                              programme_id: 'programme_id' })).to eq('/certificate/a-level-certificate/enrol?user_programme_enrolment%5Bprogramme_id%5D=programme_id&user_programme_enrolment%5Buser_id%5D=user_id')
     end
   end
 

--- a/spec/requests/certificates/a_level_dashboard_spec.rb
+++ b/spec/requests/certificates/a_level_dashboard_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Certificates::ALevelController do
       before do
         certificate
         allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
-        get '/certificate/a-level'
+        get '/certificate/a-level-certificate'
       end
 
       it 'redirects to A Level public page' do
@@ -28,7 +28,7 @@ RSpec.describe Certificates::ALevelController do
       before do
         enrolment
         allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
-        get '/certificate/a-level'
+        get '/certificate/a-level-certificate'
       end
 
       it 'renders the correct template' do
@@ -42,7 +42,7 @@ RSpec.describe Certificates::ALevelController do
 
     describe 'while logged out' do
       before do
-        get '/certificate/a-level'
+        get '/certificate/a-level-certificate'
       end
 
       it 'redirects to login' do

--- a/spec/views/certificates/a_level/complete_spec.rb
+++ b/spec/views/certificates/a_level/complete_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe('certificates/a_level/complete', type: :view) do
   end
 
   it 'has the download button' do
-    expect(rendered).to have_link('Download your certificate', href: '/certificate/a-level/view-certificate')
+    expect(rendered).to have_link('Download your certificate', href: '/certificate/a-level-certificate/view-certificate')
   end
 
   it 'has the next steps section' do


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2502

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

Review will involve exploring all a-level related dashboard pages

## What's changed?
Renamed the slug from 'a-level' to 'a-level-certificate'
I've chosen to not rename the Programmes::ALevel class or other methods from "a_level" to "a_level_certificate" as I felt it was excessive.

