### PR TITLE
Added redirects from cs-accelerator to subject-knowledge

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,6 +212,9 @@ Rails.application.routes.draw do
 
   resource :search, only: :show
 
+  get "/certificate/cs-accelerator", to: redirect("/certificate/subject-knowledge")
+  get "/cs-accelerator", to: redirect("/subject-knowledge")
+
   # CMS ROUTES
   get "/home-teaching-resources" => redirect("/home-teaching")
   get "/home-teaching/:page_slug" => redirect("/home-teaching")


### PR DESCRIPTION
## Status

* Current Status: WIP / Ready for (front-end / tech) review
* Review App link(s):
- https://teachcomputing-pr-1887.herokuapp.com/cs-accelerator
- https://teachcomputing-pr-1887.herokuapp.com/certificate/cs-accelerator
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2563

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Added redirects so old links will still work
