### PR TITLE
Taking the last element out of the auth information rather than the f…

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -20,7 +20,7 @@ module OmniAuth::Strategies
         achiever_organisation_no: "achieverOrganisationNo",
         school_name: "school"
       }.each_pair do |key, stem_key|
-        our_info[key] = user_info["attributes"][stem_key][0] if user_info["attributes"].has_key?(stem_key)
+        our_info[key] = user_info["attributes"][stem_key].last if user_info["attributes"].has_key?(stem_key)
       end
       our_info
     end

--- a/spec/omniauth/strategies/stem_spec.rb
+++ b/spec/omniauth/strategies/stem_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe OmniAuth::Strategies::Stem do
       "firstName" => ["Keymaster of"],
       "lastName" => ["Gozer"],
       "mail" => ["vince@gozer.com"],
-      "achieverContactNo" => ["abc123"]
+      "achieverContactNo" => ["abc123"],
+      "school" => ["St Johns", "St Peters"]
     }
   }
 
@@ -38,6 +39,10 @@ RSpec.describe OmniAuth::Strategies::Stem do
 
     it "achieverContactNo" do
       expect(strategy.info[:achiever_contact_no]).to eq("abc123")
+    end
+
+    it "should take the last email" do
+      expect(strategy.info[:school_name]).to eq("St Peters")
     end
   end
 


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App link(s): N/A We can't test oauth in a reivew app
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2561


## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

The reason benhid this change is that it turns out that whenever a user detail is changed, it is appended to that list rather than prepended, so we've been pulling through old data. As such, changing from [0] to .last will ensure we're getitng the latest information