### PR TITLE
Fix issue with site search throwing error when you visit page

### DIFF
--- a/app/components/site_search_component/site_search_component_controller.js
+++ b/app/components/site_search_component/site_search_component_controller.js
@@ -16,6 +16,7 @@ export default class extends ApplicationController {
   click() {
     const urlParams = new URLSearchParams(window.location.search)
     urlParams.set('q', this.inputTarget.value)
+    urlParams.delete('page')
     window.location.href = `/search?${urlParams.toString()}`
   }
 }

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -8,7 +8,11 @@ class SearchesController < ApplicationController
 
     @results = SiteSearch.search(@query, order: sort_symbol)
 
-    @pagy, @paged_results = pagy(@results)
+    begin
+      @pagy, @paged_results = pagy(@results)
+    rescue Pagy::OverflowError
+      redirect_to search_path(q: @query)
+    end
   end
 
   private


### PR DESCRIPTION
that doesn't exist

## Status

* Current Status: Ready for (front-end / tech) review
* Review App link(s): 

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Changes searches_controller to handle a pagy overflow error correctly
- Changes site search component to remove page query param
