### PR TITLE
Updating programme mapping to allow for new tag names

### DIFF
--- a/app/components/course_component.rb
+++ b/app/components/course_component.rb
@@ -2,21 +2,17 @@
 
 class CourseComponent < ViewComponent::Base
   include ViewComponent::Translatable
-  include ProgrammesHelper
 
   delegate :stripped_summary,
     :course_meta_icon_class,
     :course_type,
     :view_course_phrase,
     :tracking_data,
+    :display_programme_tag,
     to: :helpers
 
   def initialize(course:, filter:)
     @course = course
     @course_filter = filter
-  end
-
-  def get_course_tag(programme)
-    display_programme_tag programme
   end
 end

--- a/app/components/course_component.rb
+++ b/app/components/course_component.rb
@@ -2,6 +2,7 @@
 
 class CourseComponent < ViewComponent::Base
   include ViewComponent::Translatable
+  include ProgrammesHelper
 
   delegate :stripped_summary,
     :course_meta_icon_class,
@@ -16,8 +17,6 @@ class CourseComponent < ViewComponent::Base
   end
 
   def get_course_tag(programme)
-    return "#{programme} certificate" if %w[Primary Secondary].include?(programme)
-
-    programme
+    display_programme_tag programme
   end
 end

--- a/app/components/course_component/course_component.html.erb
+++ b/app/components/course_component/course_component.html.erb
@@ -44,7 +44,7 @@
           <% end %>
       <% end %>
       <% @course.programmes.each do |programme| %>
-        <strong class="govuk-tag ncce-courses__tag ncce-courses__tag ncce-courses__filter-tag--<%= programme.parameterize %>"><%= get_course_tag programme %></strong>
+        <strong class="govuk-tag ncce-courses__tag ncce-courses__tag ncce-courses__filter-tag--<%= programme.parameterize %>"><%= display_programme_tag programme %></strong>
       <% end %>
   <% end %>
 </div>

--- a/app/helpers/programmes_helper.rb
+++ b/app/helpers/programmes_helper.rb
@@ -23,12 +23,10 @@ module ProgrammesHelper
     "KS3 and GCSE Computer Science subject knowledge"
   end
 
-  def display_programme_tag(programme)
-    if programme == "Secondary" || programme == "Primary"
-      "#{programme} certificate"
-    else
-      programme
-    end
+  def display_programme_tag(programme_slug)
+    programme = Programme.find_by(slug: programme_slug)
+    return programme.certificate_name if programme
+    programme_slug.titlecase
   end
 
   def programme_pathway_card_data(programme, exclude: nil)

--- a/app/lib/searchable_site_pages.rb
+++ b/app/lib/searchable_site_pages.rb
@@ -57,7 +57,7 @@ class SearchableSitePages
 
   def build_pathway_pages
     Pathway.all.where(programme: [Programme.primary_certificate, Programme.secondary_certificate], legacy: false).includes(:programme).each do |pathway|
-      path pathway_path(pathway.slug), "#{pathway.programme.short_name} pathway - #{pathway.title}", pathway.enrol_copy
+      path pathway_path(pathway.slug), "#{pathway.programme.certificate_name} pathway - #{pathway.title}", pathway.enrol_copy
     end
   end
 

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -46,6 +46,7 @@ class Programme < ApplicationRecord
   end
 
   def certificate_name
+    raise NotImplementedError
   end
 
   def pending_delay

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -41,10 +41,6 @@ class Programme < ApplicationRecord
     Programme.find_by(slug: "a-level-certificate")
   end
 
-  def short_name
-    raise NotImplementedError
-  end
-
   def certificate_name
     raise NotImplementedError
   end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -45,6 +45,9 @@ class Programme < ApplicationRecord
     raise NotImplementedError
   end
 
+  def certificate_name
+  end
+
   def pending_delay
   end
 

--- a/app/models/programmes/a_level.rb
+++ b/app/models/programmes/a_level.rb
@@ -6,6 +6,10 @@ module Programmes
       "A Level"
     end
 
+    def certificate_name
+      "A Level subject knowledge certificate"
+    end
+
     def mailer
       ALevelMailer
     end

--- a/app/models/programmes/a_level.rb
+++ b/app/models/programmes/a_level.rb
@@ -2,10 +2,6 @@ module Programmes
   class ALevel < Programme
     PROGRAMME_TITLE = "A level subject knowledge".freeze
 
-    def short_name
-      "A Level"
-    end
-
     def certificate_name
       "A Level subject knowledge certificate"
     end

--- a/app/models/programmes/cs_accelerator.rb
+++ b/app/models/programmes/cs_accelerator.rb
@@ -6,6 +6,10 @@ module Programmes
       "Subject knowledge"
     end
 
+    def certificate_name
+      "KS3 and GCSE subject knowledge certificate"
+    end
+
     def pending_delay
       7.days
     end

--- a/app/models/programmes/cs_accelerator.rb
+++ b/app/models/programmes/cs_accelerator.rb
@@ -2,10 +2,6 @@ module Programmes
   class CSAccelerator < Programme
     PROGRAMME_TITLE = "GCSE Computer Science Subject Knowledge".freeze
 
-    def short_name
-      "Subject knowledge"
-    end
-
     def certificate_name
       "KS3 and GCSE subject knowledge certificate"
     end

--- a/app/models/programmes/i_belong.rb
+++ b/app/models/programmes/i_belong.rb
@@ -2,10 +2,6 @@ module Programmes
   class IBelong < Programme
     PROGRAMME_TITLE = "I Belong: encouraging girls into computer science".freeze
 
-    def short_name
-      "I belong"
-    end
-
     def certificate_name
       "I Belong"
     end

--- a/app/models/programmes/i_belong.rb
+++ b/app/models/programmes/i_belong.rb
@@ -6,6 +6,10 @@ module Programmes
       "I belong"
     end
 
+    def certificate_name
+      "I Belong"
+    end
+
     def pending_delay
       14.days
     end

--- a/app/models/programmes/primary_certificate.rb
+++ b/app/models/programmes/primary_certificate.rb
@@ -6,6 +6,10 @@ module Programmes
       "Primary certificate"
     end
 
+    def certificate_name
+      "Teach primary computing certificate"
+    end
+
     def pending_delay
       7.days
     end

--- a/app/models/programmes/primary_certificate.rb
+++ b/app/models/programmes/primary_certificate.rb
@@ -2,10 +2,6 @@ module Programmes
   class PrimaryCertificate < Programme
     PROGRAMME_TITLE = "Teach Primary Computing".freeze
 
-    def short_name
-      "Primary certificate"
-    end
-
     def certificate_name
       "Teach primary computing certificate"
     end

--- a/app/models/programmes/secondary_certificate.rb
+++ b/app/models/programmes/secondary_certificate.rb
@@ -6,6 +6,10 @@ module Programmes
       "Secondary certificate"
     end
 
+    def certificate_name
+      "Teach secondary computing certificate"
+    end
+
     def pending_delay
       7.days
     end

--- a/app/models/programmes/secondary_certificate.rb
+++ b/app/models/programmes/secondary_certificate.rb
@@ -2,10 +2,6 @@ module Programmes
   class SecondaryCertificate < Programme
     PROGRAMME_TITLE = "Teach Secondary Computing".freeze
 
-    def short_name
-      "Secondary certificate"
-    end
-
     def certificate_name
       "Teach secondary computing certificate"
     end

--- a/app/services/achiever/course/template.rb
+++ b/app/services/achiever/course/template.rb
@@ -31,7 +31,11 @@ class Achiever::Course::Template
   PROGRAMME_NAMES = ["ncce", "PDLP", "Computing Clusters"].freeze
 
   TS_PROGRAMME_MAPPING = {
-    "CS Accelerator" => "Subject Knowledge"
+    "CS Accelerator" => "subject-knowledge",
+    "Secondary" => "secondary-certificate",
+    "Primary" => "primary-certificate",
+    "I Belong" => "i-belong",
+    "A Level" => "a-level-certificate"
   }
 
   def self.from_resource(resource, activity)
@@ -156,18 +160,7 @@ class Achiever::Course::Template
   end
 
   def by_certificate(certificate)
-    case certificate
-    when "subject-knowledge"
-      @programmes.include?("Subject Knowledge")
-    when "secondary-certificate"
-      @programmes.include?("Secondary")
-    when "primary-certificate"
-      @programmes.include?("Primary")
-    when "i-belong"
-      @programmes.include?("I Belong")
-    when "a-level-certificate"
-      @programmes.include?("A Level")
-    end
+    @programmes.include?(certificate)
   end
 
   def duration

--- a/app/services/achiever/course_filter.rb
+++ b/app/services/achiever/course_filter.rb
@@ -83,7 +83,7 @@ module Achiever
       @certificates ||= Programme.all.each_with_object({}) do |item, hash|
         next if !FeatureFlagService.new.flags[:alevel_programme_feature] && item.a_level?
 
-        hash[item.slug.titlecase] = item.slug
+        hash[item.certificate_name] = item.slug
       end
     end
 

--- a/app/views/dashboard/_achievement_list.html.erb
+++ b/app/views/dashboard/_achievement_list.html.erb
@@ -11,7 +11,7 @@
     <div class="ncce-activity-list__info">
       <div class="govuk-body ncce-activity-list__tags">
         <% achievement.activity.programmes.select { _1.user_enrolled?(current_user) }.each do |programme| %>
-          <strong class="dashboard-tags--<%= programme.slug %>"><%= programme.short_name %></strong>
+          <strong class="dashboard-tags--<%= programme.slug %>"><%= programme.certificate_name %></strong>
         <% end %>
       </div>
       <% details = stem_course_details(user_course_info, achievement.activity.stem_course_template_no) %>

--- a/app/webpacker/stylesheets/components/_tags.scss
+++ b/app/webpacker/stylesheets/components/_tags.scss
@@ -21,14 +21,14 @@
   background-color: $concrete;
 }
 
-.ncce-courses__filter-tag--primary {
+.ncce-courses__filter-tag--primary-certificate {
   background-color: $primary-cert-color;
   border-color: $primary-cert-color;
   color: $grey-dark-x;
 }
 
 .ncce-courses__filter-tag--subject-knowledge,
-.ncce-courses__filter-tag--secondary {
+.ncce-courses__filter-tag--secondary-certificate {
   background-color: $secondary-cert-color;
   border-color: $secondary-cert-color;
   color: $grey-dark-x;

--- a/spec/components/course_component_spec.rb
+++ b/spec/components/course_component_spec.rb
@@ -3,11 +3,14 @@ require "rails_helper"
 RSpec.describe CourseComponent, type: :component do
   let(:course) { build(:achiever_course_template, activity_code: "abc", title: "test course") }
   let(:always_on_course) { build(:achiever_course_template, activity_code: "abc", title: "test course", always_on: true) }
-  let(:course_primary) { build(:achiever_course_template, activity_code: "abc", title: "primary test course", programmes: ["Primary"]) }
-  let(:course_secondary) { build(:achiever_course_template, activity_code: "abc", title: "secondary test course", programmes: ["Secondary"]) }
+  let(:course_primary) { build(:achiever_course_template, activity_code: "abc", title: "primary test course", programmes: ["primary-certificate"]) }
+  let(:course_secondary) { build(:achiever_course_template, activity_code: "abc", title: "secondary test course", programmes: ["secondary-certificate"]) }
   let(:filter) { instance_double(Achiever::CourseFilter) }
 
   before do
+    create(:primary_certificate)
+    create(:secondary_certificate)
+    create(:cs_accelerator)
     allow(filter).to receive_messages(
       subjects: {"Algorithms" => 0o00000000, "Other" => 222_222_222},
       age_groups: {"Key stage 1" => 0o00000000, "Key stage 2" => 222_222_222}
@@ -43,17 +46,17 @@ RSpec.describe CourseComponent, type: :component do
 
   it "shows the expected tag for a CSA course" do
     render_inline(described_class.new(course: course, filter: filter))
-    expect(page).to have_text("Subject Knowledge")
+    expect(page).to have_text(Programme.cs_accelerator.certificate_name)
   end
 
   it "shows the expected tag for a Primary course" do
     render_inline(described_class.new(course: course_primary, filter: filter))
-    expect(page).to have_text("Primary certificate")
+    expect(page).to have_text(Programme.primary_certificate.certificate_name)
   end
 
   it "shows the expected tag for a Secondary course" do
     render_inline(described_class.new(course: course_secondary, filter: filter))
-    expect(page).to have_text("Secondary certificate")
+    expect(page).to have_text(Programme.secondary_certificate.certificate_name)
   end
 
   it "shows age groups" do

--- a/spec/factories/achiever/course_template.rb
+++ b/spec/factories/achiever/course_template.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     meta_description { "Course meta description" }
     online_cpd { false }
     outcomes { "" }
-    programmes { ["Subject Knowledge"] }
+    programmes { ["subject-knowledge"] }
     remote_delivered_cpd { false }
     subjects { %w[000000000] }
     summary { "" }

--- a/spec/helpers/programmes_helper_spec.rb
+++ b/spec/helpers/programmes_helper_spec.rb
@@ -82,13 +82,17 @@ describe ProgrammesHelper, type: :helper do
   end
 
   describe("#display_programme_tag") do
-    it "appends the word certificate for primary and secondary tags" do
-      secondary_certificate = "Secondary"
-      primary_certificate = "Primary"
-      cs_accelerator = "CS Accelerator"
-      expect(display_programme_tag(secondary_certificate)).to eq("Secondary certificate")
-      expect(display_programme_tag(primary_certificate)).to eq("Primary certificate")
-      expect(display_programme_tag(cs_accelerator)).to eq("CS Accelerator")
+    let(:secondary_programme) { create(:secondary_certificate) }
+    let(:primary_programme) { create(:primary_certificate) }
+    let(:a_level_programme) { create(:a_level) }
+    let(:i_belong) { create(:i_belong) }
+    let(:subject_knowledge) { create(:cs_accelerator) }
+    it "returns the programmes certificate name when provided with valid slug" do
+      expect(display_programme_tag(secondary_programme.slug)).to eq(Programme.secondary_certificate.certificate_name)
+      expect(display_programme_tag(primary_programme.slug)).to eq(Programme.primary_certificate.certificate_name)
+      expect(display_programme_tag(a_level_programme.slug)).to eq(Programme.a_level.certificate_name)
+      expect(display_programme_tag(i_belong.slug)).to eq(Programme.i_belong.certificate_name)
+      expect(display_programme_tag(subject_knowledge.slug)).to eq(Programme.cs_accelerator.certificate_name)
     end
   end
 

--- a/spec/lib/searchable_site_pages_spec.rb
+++ b/spec/lib/searchable_site_pages_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe SearchableSitePages do
 
       results = SearchableSitePages.all
 
-      expect(results.include?({title: "Primary certificate pathway - Foo pathway", excerpt: "Foo pathway enrol copy", path: pathway_path("asdf")})).to be true
-      expect(results.include?({title: "Secondary certificate pathway - Bar pathway", excerpt: "Bar pathway enrol copy", path: pathway_path("fdsa")})).to be true
+      expect(results.include?({title: "Teach primary computing certificate pathway - Foo pathway", excerpt: "Foo pathway enrol copy", path: pathway_path("asdf")})).to be true
+      expect(results.include?({title: "Teach secondary computing certificate pathway - Bar pathway", excerpt: "Bar pathway enrol copy", path: pathway_path("fdsa")})).to be true
     end
 
     it "creates entries for curriculum key stages" do

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -305,9 +305,9 @@ RSpec.describe Programme, type: :model do
     end
   end
 
-  describe "#short_name" do
+  describe "#certificate_name" do
     it "should return not implemented error" do
-      expect { generic_programme.short_name }.to raise_error(NotImplementedError)
+      expect { generic_programme.certificate_name }.to raise_error(NotImplementedError)
     end
   end
 

--- a/spec/models/programmes/a_level_spec.rb
+++ b/spec/models/programmes/a_level_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe Programmes::ALevel do
     end
   end
 
-  describe "#short_name" do
-    it "should return its short name" do
-      expect(subject.short_name).to eq "A Level"
+  describe "#certificate_name" do
+    it "should return its certificate name" do
+      expect(subject.certificate_name).to eq "A Level subject knowledge certificate"
     end
   end
 

--- a/spec/models/programmes/cs_accelerator_spec.rb
+++ b/spec/models/programmes/cs_accelerator_spec.rb
@@ -421,9 +421,9 @@ RSpec.describe Programmes::CSAccelerator do
     end
   end
 
-  describe "#short_name" do
-    it "should return its short name" do
-      expect(programme.short_name).to eq "Subject knowledge"
+  describe "#certificate_name" do
+    it "should return its certificate name" do
+      expect(programme.certificate_name).to eq "KS3 and GCSE subject knowledge certificate"
     end
   end
 end

--- a/spec/models/programmes/i_belong_spec.rb
+++ b/spec/models/programmes/i_belong_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe Programmes::IBelong do
     end
   end
 
-  describe "#short_name" do
-    it "should return its short name" do
-      expect(programme.short_name).to eq "I belong"
+  describe "#certificate_name" do
+    it "should return its certificate name" do
+      expect(programme.certificate_name).to eq "I Belong"
     end
   end
 end

--- a/spec/models/programmes/primary_certificate_spec.rb
+++ b/spec/models/programmes/primary_certificate_spec.rb
@@ -66,9 +66,9 @@ RSpec.describe Programmes::PrimaryCertificate do
     end
   end
 
-  describe "#short_name" do
-    it "should return its short name" do
-      expect(programme.short_name).to eq "Primary certificate"
+  describe "#certificate_name" do
+    it "should return its certificate name" do
+      expect(programme.certificate_name).to eq "Teach primary computing certificate"
     end
   end
 end

--- a/spec/models/programmes/secondary_certificate_spec.rb
+++ b/spec/models/programmes/secondary_certificate_spec.rb
@@ -79,9 +79,9 @@ RSpec.describe Programmes::SecondaryCertificate do
     end
   end
 
-  describe "#short_name" do
-    it "should return its short name" do
-      expect(secondary_certificate.short_name).to eq "Secondary certificate"
+  describe "#certificate_name" do
+    it "should return its certificate name" do
+      expect(secondary_certificate.certificate_name).to eq "Teach secondary computing certificate"
     end
   end
 

--- a/spec/requests/courses/index_spec.rb
+++ b/spec/requests/courses/index_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe CoursesController do
-  let(:programme) { create(:programme, slug: "subject-knowledge", title: "CS Accelerator") }
+  let(:programme) { create(:cs_accelerator, title: "CS Accelerator") }
 
   describe "GET #index" do
     before do

--- a/spec/services/achiever/course/template_spec.rb
+++ b/spec/services/achiever/course/template_spec.rb
@@ -53,6 +53,33 @@ RSpec.describe Achiever::Course::Template do
         expect(Achiever::Course::Template::QUERY_STRINGS).to have_key(:HideFromweb)
       end
     end
+
+    describe "TS_PROGRAMME_MAPPING" do
+      it "maps Subject Knowledge" do
+        expect(Achiever::Course::Template::TS_PROGRAMME_MAPPING).to have_key("CS Accelerator")
+        expect(Achiever::Course::Template::TS_PROGRAMME_MAPPING["CS Accelerator"]).to eq("subject-knowledge")
+      end
+
+      it "maps Primary Certificate" do
+        expect(Achiever::Course::Template::TS_PROGRAMME_MAPPING).to have_key("Primary")
+        expect(Achiever::Course::Template::TS_PROGRAMME_MAPPING["Primary"]).to eq("primary-certificate")
+      end
+
+      it "maps Secondary Certificate" do
+        expect(Achiever::Course::Template::TS_PROGRAMME_MAPPING).to have_key("Secondary")
+        expect(Achiever::Course::Template::TS_PROGRAMME_MAPPING["Secondary"]).to eq("secondary-certificate")
+      end
+
+      it "maps I Belong" do
+        expect(Achiever::Course::Template::TS_PROGRAMME_MAPPING).to have_key("I Belong")
+        expect(Achiever::Course::Template::TS_PROGRAMME_MAPPING["I Belong"]).to eq("i-belong")
+      end
+
+      it "maps A Level" do
+        expect(Achiever::Course::Template::TS_PROGRAMME_MAPPING).to have_key("A Level")
+        expect(Achiever::Course::Template::TS_PROGRAMME_MAPPING["A Level"]).to eq("a-level-certificate")
+      end
+    end
   end
 
   describe ".all" do

--- a/spec/services/achiever/course_filter_spec.rb
+++ b/spec/services/achiever/course_filter_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Achiever::CourseFilter do
     build(:achiever_course_occurrence, online_cpd: true, course_template_no: online_template.course_template_no)
   end
   let(:no_occ_template) { build(:achiever_course_template, title: "No occurrence template") }
-  let(:secondary_template) { build(:achiever_course_template, programmes: ["Secondary"], title: "Secondary template") }
+  let(:secondary_template) { build(:achiever_course_template, programmes: ["secondary-certificate"], title: "Secondary template") }
   let(:secondary_occurrence) do
     build(:achiever_course_occurrence, course_template_no: secondary_template.course_template_no, distance: 50)
   end


### PR DESCRIPTION
## Status

* Current Status: Ready for Tech/Front end review
* Review App link(s): https://teachcomputing-pr-1901.herokuapp.com/
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2569

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Created new mapping of dynamic programme names to programme slugs
Updated by certificate filtering
Adding certificate names to programmes
Unifying the tag code into one helper method
Updates of scss class names
