### PR TITLE
Improve error handling for curriculum

### DIFF
--- a/app/services/curriculum_client/request.rb
+++ b/app/services/curriculum_client/request.rb
@@ -20,6 +20,10 @@ module CurriculumClient
       raise ActionController::RoutingError, e.message if e.message.include?("not found")
 
       raise
+    rescue Graphlient::Errors::FaradayServerError
+      Sentry.capture_exception(e)
+      raise e if Rails.env.development?
+      raise ActiveRecord::RecordNotFound
     end
 
     def self.fetch_data(query, client, params)

--- a/app/services/curriculum_client/request.rb
+++ b/app/services/curriculum_client/request.rb
@@ -16,14 +16,10 @@ module CurriculumClient
         fetch_data(query, client, params)
       end
     # Handle 404s gracefully...
-    rescue Graphlient::Errors::ExecutionError => e
-      raise ActionController::RoutingError, e.message if e.message.include?("not found")
-
-      raise
-    rescue Graphlient::Errors::FaradayServerError
+    rescue Graphlient::Errors::ExecutionError, Graphlient::Errors::FaradayServerError => e
       Sentry.capture_exception(e)
       raise e if Rails.env.development?
-      raise ActiveRecord::RecordNotFound
+      raise ActionController::RoutingError, e.message
     end
 
     def self.fetch_data(query, client, params)

--- a/spec/requests/curriculum/lessons/show_spec.rb
+++ b/spec/requests/curriculum/lessons/show_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Curriculum::LessonsController do
           unit_slug: "representations-from-clay-to-silicon",
           lesson_slug: "a-dud"
         )
-      end.to raise_error(ActiveRecord::RecordNotFound)
+      end.to raise_error(ActionController::RoutingError)
     end
   end
 end

--- a/spec/requests/curriculum/lessons/show_spec.rb
+++ b/spec/requests/curriculum/lessons/show_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Curriculum::LessonsController do
           unit_slug: "representations-from-clay-to-silicon",
           lesson_slug: "a-dud"
         )
-      end.to raise_error(Graphlient::Errors::FaradayServerError)
-    end
+      end.to raise_error(ActiveRecord::RecordNotFound)
+
   end
 end

--- a/spec/requests/curriculum/lessons/show_spec.rb
+++ b/spec/requests/curriculum/lessons/show_spec.rb
@@ -29,6 +29,6 @@ RSpec.describe Curriculum::LessonsController do
           lesson_slug: "a-dud"
         )
       end.to raise_error(ActiveRecord::RecordNotFound)
-
+    end
   end
 end

--- a/spec/services/curriculum_client/request_spec.rb
+++ b/spec/services/curriculum_client/request_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe CurriculumClient::Request do
       response = JSON.parse(other_error_response_json, object_class: OpenStruct)
 
       stub_request(:post, url)
-        .to_raise(Graphlient::Errors::ExecutionError.new(response))
+        .to_raise(ActionController::RoutingError.new(response))
 
       query = <<~GRAPHQL
         query {
@@ -43,7 +43,7 @@ RSpec.describe CurriculumClient::Request do
       GRAPHQL
 
       expect { described_class.run(query: client.parse(query), client:) }
-        .to raise_error(Graphlient::Errors::ExecutionError)
+        .to raise_error(ActionController::RoutingError)
     end
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2567

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Added rescue for FaradayServerErrors
Made both error types report to sentry

## Reason for change

There was an attempt to inject code into the URL of the curriculum pages, these injections caused the Curriculum GraphQL server to respond with Graphlient::Errors::FaradayServerError. We have decided to have those errors instead return a 404 error rather than passing down the 500 to the end user. These errors will be logged to Sentry so we can continue to monitor for any future issues.