### PR TITLE
Fixing issues in badge assignment

### DIFF
--- a/app/jobs/badge_assignment_check_job.rb
+++ b/app/jobs/badge_assignment_check_job.rb
@@ -2,26 +2,6 @@ class BadgeAssignmentCheck < ApplicationJob
   queue_as :default
 
   def perform(days_to_check: 31)
-    users_with_recent_achievements = User.joins(:achievements).merge(Achievement.in_state(:complete))
-      .where("most_recent_achievement_transition.updated_at": days_to_check.days.ago..).distinct
-
-    missing_badges = []
-    users_with_recent_achievements.each do |user|
-      user.user_programme_enrolments.each do |user_programme_enrolment|
-        programme = user_programme_enrolment.programme
-        badge = programme.badges.active.first
-
-        next unless badge
-        next unless programme.badgeable?
-        next unless programme.user_qualifies_for_credly_badge?(user)
-        has_badge = user_has_badge?(user, programme)
-
-        if !has_badge
-          missing_badges << [user.email, programme.title]
-        end
-      end
-    end
-
     recent_achievements = Achievement.in_state(:complete).where("most_recent_achievement_transition.updated_at": days_to_check.days.ago..)
 
     missing_badges = []
@@ -33,11 +13,9 @@ class BadgeAssignmentCheck < ApplicationJob
         next unless badge
         next unless programme.badgeable?
         next unless programme.user_qualifies_for_credly_badge?(user)
-        has_badge = user_has_badge?(user, programme)
+        next if user_has_badge?(user, programme)
 
-        if !has_badge
-          missing_badges << [user.email, programme.title]
-        end
+        missing_badges << [user.email, programme.title]
       end
     end
 

--- a/app/jobs/badge_assignment_check_job.rb
+++ b/app/jobs/badge_assignment_check_job.rb
@@ -1,0 +1,52 @@
+class BadgeAssignmentCheck < ApplicationJob
+  queue_as :default
+
+  def perform(days_to_check: 31)
+    users_with_recent_achievements = User.joins(:achievements).merge(Achievement.in_state(:complete))
+      .where("most_recent_achievement_transition.updated_at": days_to_check.days.ago..).distinct
+
+    missing_badges = []
+    users_with_recent_achievements.each do |user|
+      user.user_programme_enrolments.each do |user_programme_enrolment|
+        programme = user_programme_enrolment.programme
+        badge = programme.badges.active.first
+
+        next unless badge
+        next unless programme.badgeable?
+        next unless programme.user_qualifies_for_credly_badge?(user)
+        has_badge = user_has_badge?(user, programme)
+
+        if !has_badge
+          missing_badges << [user.email, programme.title]
+        end
+      end
+    end
+
+    recent_achievements = Achievement.in_state(:complete).where("most_recent_achievement_transition.updated_at": days_to_check.days.ago..)
+
+    missing_badges = []
+    recent_achievements.each do |achievement|
+      achievement.activity.programmes.each do |programme|
+        user = achievement.user
+        badge = programme.badges.active.first
+
+        next unless badge
+        next unless programme.badgeable?
+        next unless programme.user_qualifies_for_credly_badge?(user)
+        has_badge = user_has_badge?(user, programme)
+
+        if !has_badge
+          missing_badges << [user.email, programme.title]
+        end
+      end
+    end
+
+    missing_badges
+  end
+
+  private
+
+  def user_has_badge?(user, programme)
+    Credly::Badge.by_programme_badge_template_ids(user.id, programme.badges.pluck(:credly_badge_template_id))
+  end
+end

--- a/app/jobs/badge_assignment_check_job.rb
+++ b/app/jobs/badge_assignment_check_job.rb
@@ -15,7 +15,7 @@ class BadgeAssignmentCheck < ApplicationJob
         next unless programme.user_qualifies_for_credly_badge?(user)
         next if user_has_badge?(user, programme)
 
-        missing_badges << [user.email, programme.title]
+        missing_badges << [user, programme]
       end
     end
 

--- a/app/jobs/badge_assignment_check_job.rb
+++ b/app/jobs/badge_assignment_check_job.rb
@@ -1,4 +1,4 @@
-class BadgeAssignmentCheck < ApplicationJob
+class BadgeAssignmentCheckJob < ApplicationJob
   queue_as :default
 
   def perform(days_to_check: 31)

--- a/app/jobs/issue_badge_job.rb
+++ b/app/jobs/issue_badge_job.rb
@@ -15,8 +15,8 @@ class IssueBadgeJob < ApplicationJob
 
       next unless badge
       next unless programme.badgeable?
-      next if user_has_badge?(user, programme)
       next unless programme.user_qualifies_for_credly_badge?(user)
+      next if user_has_badge?(user, programme)
 
       Credly::Badge.issue(user.id, badge.credly_badge_template_id)
       NewBadgeMailer.new_badge_email(user, programme).deliver_now

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -68,6 +68,7 @@ class Programme < ApplicationRecord
   end
 
   def user_meets_completion_requirement?(user)
+    return false if programme_objectives.empty?
     programme_objectives.all? { |group| group.user_complete?(user) }
   end
 

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -71,6 +71,15 @@ class Programme < ApplicationRecord
     programme_objectives.all? { |group| group.user_complete?(user) }
   end
 
+  def user_has_f2f_achievement?(user)
+    user
+      .achievements
+      .in_state(:complete)
+      .with_category(Activity::FACE_TO_FACE_CATEGORY)
+      .belonging_to_programme(self)
+      .count >= 1
+  end
+
   def user_enrolled?(user)
     return false if user.nil?
 
@@ -152,14 +161,7 @@ class Programme < ApplicationRecord
   end
 
   def user_qualifies_for_credly_badge?(user)
-    has_a_f2f_achievement = user
-      .achievements
-      .in_state(:complete)
-      .with_category(Activity::FACE_TO_FACE_CATEGORY)
-      .belonging_to_programme(self)
-      .count >= 1
-
-    user_enrolled?(user) && (has_a_f2f_achievement || user_meets_completion_requirement?(user))
+    user_enrolled?(user) && (user_has_f2f_achievement?(user) || user_meets_completion_requirement?(user))
   end
 
   def auto_enrollable?

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -68,7 +68,6 @@ class Programme < ApplicationRecord
   end
 
   def user_meets_completion_requirement?(user)
-    return false if programme_objectives.empty?
     programme_objectives.all? { |group| group.user_complete?(user) }
   end
 

--- a/app/models/programmes/cs_accelerator.rb
+++ b/app/models/programmes/cs_accelerator.rb
@@ -101,14 +101,7 @@ module Programmes
     end
 
     def user_qualifies_for_credly_badge?(user)
-      has_a_f2f_achievement = user
-        .achievements
-        .in_state(:complete)
-        .with_category(Activity::FACE_TO_FACE_CATEGORY)
-        .belonging_to_programme(self)
-        .count >= 1
-
-      user_enrolled?(user) && has_a_f2f_achievement
+      user_enrolled?(user) && user_has_f2f_achievement?(user)
     end
   end
 end

--- a/app/models/programmes/cs_accelerator.rb
+++ b/app/models/programmes/cs_accelerator.rb
@@ -99,5 +99,16 @@ module Programmes
     def auto_enrollable?
       true
     end
+
+    def user_qualifies_for_credly_badge?(user)
+      has_a_f2f_achievement = user
+        .achievements
+        .in_state(:complete)
+        .with_category(Activity::FACE_TO_FACE_CATEGORY)
+        .belonging_to_programme(self)
+        .count >= 1
+
+      user_enrolled?(user) && has_a_f2f_achievement
+    end
   end
 end

--- a/app/models/programmes/cs_accelerator.rb
+++ b/app/models/programmes/cs_accelerator.rb
@@ -100,8 +100,12 @@ module Programmes
       true
     end
 
-    def user_qualifies_for_credly_badge?(user)
-      user_enrolled?(user) && user_has_f2f_achievement?(user)
+    def programme_objectives
+      [
+        ProgrammeObjectives::AssessmentPassRequired.new(
+          assessment: Assessment.find_by(programme: self)
+        )
+      ]
     end
   end
 end

--- a/app/services/credly/badge.rb
+++ b/app/services/credly/badge.rb
@@ -24,7 +24,7 @@ module Credly
 
     def self.issued(user_id)
       user = User.find(user_id)
-      query_strings = "?filter=recipient_email::#{user.email}"
+      query_strings = "?filter=issuer_earner_id::#{user.id}"
       Credly::Request.run(BADGES_RESOURCE_PATH + query_strings, {})[:data]
     end
 

--- a/spec/jobs/badge_assigment_check_job_spec.rb
+++ b/spec/jobs/badge_assigment_check_job_spec.rb
@@ -30,17 +30,17 @@ RSpec.describe BadgeAssignmentCheckJob, type: :job do
 
     it "should not match user with existing badge" do
       expect(primary_certificate.user_qualifies_for_credly_badge?(user_with_badge)).to be true
-      matches = described_class.perform_now(days_to_check: 10)
+      matches = described_class.perform_now(days_to_check: 10, programmes_to_check: [primary_certificate])
       expect(matches.include?([user_with_badge, primary_certificate])).to be false
     end
 
     it "should include user without a badge" do
-      matches = described_class.perform_now(days_to_check: 10)
+      matches = described_class.perform_now(days_to_check: 10, programmes_to_check: [primary_certificate])
       expect(matches.include?([user_without_badge, primary_certificate])).to be true
     end
 
     it "should not include user without f2f activity" do
-      matches = described_class.perform_now(days_to_check: 10)
+      matches = described_class.perform_now(days_to_check: 10, programmes_to_check: [primary_certificate])
       expect(matches.include?([user_no_activity, primary_certificate])).to be false
     end
   end

--- a/spec/jobs/badge_assigment_check_job_spec.rb
+++ b/spec/jobs/badge_assigment_check_job_spec.rb
@@ -30,17 +30,17 @@ RSpec.describe BadgeAssignmentCheckJob, type: :job do
 
     it "should not match user with existing badge" do
       expect(primary_certificate.user_qualifies_for_credly_badge?(user_with_badge)).to be true
-      matches = described_class.perform_now(days_to_check: 10, programmes_to_check: [primary_certificate])
+      matches = described_class.perform_now([primary_certificate], days_to_check: 10)
       expect(matches.include?([user_with_badge, primary_certificate])).to be false
     end
 
     it "should include user without a badge" do
-      matches = described_class.perform_now(days_to_check: 10, programmes_to_check: [primary_certificate])
+      matches = described_class.perform_now([primary_certificate], days_to_check: 10)
       expect(matches.include?([user_without_badge, primary_certificate])).to be true
     end
 
     it "should not include user without f2f activity" do
-      matches = described_class.perform_now(days_to_check: 10, programmes_to_check: [primary_certificate])
+      matches = described_class.perform_now([primary_certificate], days_to_check: 10)
       expect(matches.include?([user_no_activity, primary_certificate])).to be false
     end
   end

--- a/spec/jobs/badge_assigment_check_job_spec.rb
+++ b/spec/jobs/badge_assigment_check_job_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe BadgeAssignmentCheckJob, type: :job do
+  let!(:primary_certificate) { create(:primary_certificate, :with_activity_groupings) }
+  let!(:badge) { create(:badge, :active, programme: primary_certificate, credly_badge_template_id: "00cd7d3b-baca-442b-bce5-f20666ed591b") }
+  let(:f2f_activity) { create(:activity, programmes: [primary_certificate]) }
+  let(:user_with_badge) { create(:user) }
+  let(:user_without_badge) { create(:user) }
+  let(:user_no_activity) { create(:user) }
+  let(:user_with_badge_programme_enrolment) { create(:user_programme_enrolment, programme_id: primary_certificate.id, user_id: user_with_badge.id) }
+  let(:user_without_badge_programme_enrolment) { create(:user_programme_enrolment, programme_id: primary_certificate.id, user_id: user_without_badge.id) }
+  let(:user_no_activity_programme_enrolment) { create(:user_programme_enrolment, programme_id: primary_certificate.id, user_id: user_no_activity.id) }
+
+  let(:setup_users) {
+    user_with_badge_programme_enrolment
+    user_without_badge_programme_enrolment
+    user_no_activity_programme_enrolment
+    create(:completed_achievement, user: user_with_badge, activity: f2f_activity)
+    create(:completed_achievement, user: user_without_badge, activity: f2f_activity)
+  }
+
+  describe "#perform" do
+    include ActiveJob::TestHelper
+
+    before do
+      setup_users
+      stub_issued_badges(user_with_badge.id)
+      stub_issued_badges_empty(user_without_badge.id)
+    end
+
+    it "should not match user with existing badge" do
+      expect(primary_certificate.user_qualifies_for_credly_badge?(user_with_badge)).to be true
+      matches = described_class.perform_now(days_to_check: 10)
+      expect(matches.include?([user_with_badge, primary_certificate])).to be false
+    end
+
+    it "should include user without a badge" do
+      matches = described_class.perform_now(days_to_check: 10)
+      expect(matches.include?([user_without_badge, primary_certificate])).to be true
+    end
+
+    it "should not include user without f2f activity" do
+      matches = described_class.perform_now(days_to_check: 10)
+      expect(matches.include?([user_no_activity, primary_certificate])).to be false
+    end
+  end
+end

--- a/spec/models/programmes/a_level_spec.rb
+++ b/spec/models/programmes/a_level_spec.rb
@@ -49,12 +49,9 @@ RSpec.describe Programmes::ALevel do
 
   describe "#user_qualifies_for_credly_badge" do
     let(:setup_completed_programme) {
+      create(:programme_activity_grouping, :with_activities, programme: subject, required_for_completion: 0)
       user_programme_enrolment
-      create_list(:programme_activity_grouping, 2, :with_activities, programme: subject)
       create(:completed_assessment_attempt, user:, assessment:)
-      subject.programme_activity_groupings.each do |pag|
-        create(:completed_achievement, user:, activity: pag.activities.first)
-      end
     }
 
     it "should be false if not enrolled" do

--- a/spec/models/programmes/cs_accelerator_spec.rb
+++ b/spec/models/programmes/cs_accelerator_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Programmes::CSAccelerator do
   let(:user) { create(:user) }
   let(:user_programme_enrolment) { create(:user_programme_enrolment, user_id: user.id, programme_id: programme.id) }
   let(:exam_activity) { create(:activity, :cs_accelerator_exam) }
+  let!(:assessment) { create(:assessment, programme:, activity: exam_activity) }
   let(:programme_activity) { create(:programme_activity, programme_id: programme.id, activity_id: exam_activity.id) }
   let(:passed_exam) { create(:completed_achievement, user_id: user.id, activity_id: exam_activity.id) }
 

--- a/spec/models/programmes/cs_accelerator_spec.rb
+++ b/spec/models/programmes/cs_accelerator_spec.rb
@@ -428,11 +428,6 @@ RSpec.describe Programmes::CSAccelerator do
   end
 
   describe "#user_qualifies_for_credly_badge" do
-    it "user_meets_completion_requirement should fail as cs_accelerator has no programme_activity_groupings" do
-      expect(programme.programme_activity_groupings.count).to eq(0)
-      expect(programme.user_meets_completion_requirement?(user)).to be false
-    end
-
     it "should return false if no face-to-face" do
       setup_one_online_achievement
       expect(programme.user_qualifies_for_credly_badge?(user)).to be false

--- a/spec/models/programmes/cs_accelerator_spec.rb
+++ b/spec/models/programmes/cs_accelerator_spec.rb
@@ -427,6 +427,23 @@ RSpec.describe Programmes::CSAccelerator do
     end
   end
 
+  describe "#user_qualifies_for_credly_badge" do
+    it "user_meets_completion_requirement should fail as cs_accelerator has no programme_activity_groupings" do
+      expect(programme.programme_activity_groupings.count).to eq(0)
+      expect(programme.user_meets_completion_requirement?(user)).to be false
+    end
+
+    it "should return false if no face-to-face" do
+      setup_one_online_achievement
+      expect(programme.user_qualifies_for_credly_badge?(user)).to be false
+    end
+
+    it "should return true if completed face-to-face course" do
+      setup_one_short_f2f_achievement
+      expect(programme.user_qualifies_for_credly_badge?(user)).to be true
+    end
+  end
+
   describe "#auto_enrollable?" do
     it "should return true" do
       expect(programme.auto_enrollable?).to be true

--- a/spec/models/programmes/primary_certificate_spec.rb
+++ b/spec/models/programmes/primary_certificate_spec.rb
@@ -8,6 +8,16 @@ RSpec.describe Programmes::PrimaryCertificate do
   let(:face_to_face_course) { create(:activity, :stem_learning, credit: 20) }
   let(:community_5_activity) { create(:activity, :community_5) }
 
+  let(:setup_achievements_for_no_face_to_face) do
+    user_programme_enrolment
+    activities = [online_course, community_5_activity]
+
+    activities.each do |activity|
+      create(:programme_activity, programme_id: programme.id, activity_id: activity.id)
+      create(:completed_achievement, user_id: user.id, activity_id: activity.id)
+    end
+  end
+
   let(:setup_achievements_for_partial_completion) do
     user_programme_enrolment
     activities = [online_course, face_to_face_course, community_5_activity]
@@ -75,6 +85,18 @@ RSpec.describe Programmes::PrimaryCertificate do
   describe "#auto_enrollable?" do
     it "should return true" do
       expect(programme.auto_enrollable?).to be true
+    end
+  end
+
+  describe "#user_qualifies_for_credly_badge" do
+    it "should return false if no face-to-face" do
+      setup_achievements_for_no_face_to_face
+      expect(programme.user_qualifies_for_credly_badge?(user)).to be false
+    end
+
+    it "should return true with face-to-face" do
+      setup_achievements_for_partial_completion
+      expect(programme.user_qualifies_for_credly_badge?(user)).to be true
     end
   end
 end

--- a/spec/models/programmes/primary_certificate_spec.rb
+++ b/spec/models/programmes/primary_certificate_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Programmes::PrimaryCertificate do
   let(:user) { create(:user) }
-  let(:programme) { create(:primary_certificate) }
+  let(:programme) { create(:primary_certificate, :with_activity_groupings) }
   let(:user_programme_enrolment) { create(:user_programme_enrolment, user_id: user.id, programme_id: programme.id) }
   let(:online_course) { create(:activity, :future_learn, credit: 20) }
   let(:face_to_face_course) { create(:activity, :stem_learning, credit: 20) }

--- a/spec/support/credly/credly_stubs.rb
+++ b/spec/support/credly/credly_stubs.rb
@@ -16,11 +16,11 @@ module CredlyStubs
 
   def stub_issued_badges(user_id)
     json_response = File.new("spec/support/credly/issued_badges.json")
-    stub_request(:get, "https://api.credly.com/v1/organizations/e52b9e79-9ddb-4110-9883-ae2c44a7440e/badges?filter=recipient_email::web@teachcomputing.org").to_return(body: json_response)
+    stub_request(:get, "https://api.credly.com/v1/organizations/e52b9e79-9ddb-4110-9883-ae2c44a7440e/badges?filter=issuer_earner_id::#{user_id}").to_return(body: json_response)
   end
 
   def stub_issued_badges_empty(user_id)
     json_response = File.new("spec/support/credly/issued_badges_empty.json")
-    stub_request(:get, "https://api.credly.com/v1/organizations/e52b9e79-9ddb-4110-9883-ae2c44a7440e/badges?filter=recipient_email::web@teachcomputing.org").to_return(body: json_response)
+    stub_request(:get, "https://api.credly.com/v1/organizations/e52b9e79-9ddb-4110-9883-ae2c44a7440e/badges?filter=issuer_earner_id::#{user_id}").to_return(body: json_response)
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Review App link(s): 
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2583

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Changed the API call to credly, the email version seems to give inconsistent results, current working theory is it takes time for that search to become active as using email appears to initially fail, but then later returns result. Using the issuer_earner_id seems to not have the same issue. I believe this should help resolve the 422 errors we get when issuing badges, which might also account for the small number of missing badges.

I swapped the ordering of checks in the IssueBadgeJob, so that it checks locally if the user meets the badge requirements before it checks credly, seems more logical to check DB before making API call.

Found a bug in the cs_accelerator programme where due to it not having programme activity groups it was returning true for user_meets_completion_requirement meaning that you could get the badge for just doing any activity (e.g online only). I have added programme_objectives to the programme that check if the user has completed the assessment to stop it resolving only to true. I have added extra testing to ensure that the credly badge checker is correct for different styles of programmes.

Created a job that returns an array of any missing badges for a given number of days, to allow us to check for issues.
