### PR TITLE
Download option for lesson files in Unit view

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -32,7 +32,7 @@ module NavigationHelper
          {text: "Secondary question banks", link: secondary_question_banks_path, label: "Teaching resources"},
          {text: "Artificial Intelligence", link: cms_page_path(page_slug: "artificial-intelligence"), label: "Artificial Intelligence"},
          {text: "Pedagogy", link: cms_page_path(page_slug: "pedagogy"), label: "Pedagogy"},
-         {text: "Primary computing glossary", link: cms_page_path(page_slug: "/primary-computing-glossary"), label: "Resources primary glossary"},
+         {text: "Primary computing glossary", link: cms_page_path(page_slug: "primary-computing-glossary"), label: "Resources primary glossary"},
          {text: "Physical computing kits", link: cms_page_path("physical-computing-kit"), label: "Physical computing kits"}
        ]},
       {text: "About us",

--- a/app/services/curriculum_client/queries/unit.rb
+++ b/app/services/curriculum_client/queries/unit.rb
@@ -47,6 +47,9 @@ module CurriculumClient
             from
             to
           }
+          zippedContents {
+            #{file_fields}
+          }
         }
       GRAPHQL
 

--- a/app/views/curriculum/lessons/show.html.erb
+++ b/app/views/curriculum/lessons/show.html.erb
@@ -38,8 +38,8 @@
 						<li>Unit overviews</li>
 						<li>Activities</li>
 					</ul>
-          <% if current_user %>
-            <% if @lesson.zipped_contents&.file.present? %>
+          <% if @lesson.zipped_contents&.file.present? %>
+            <% if current_user %>
               <%= link_to generate_download_url(@lesson.zipped_contents.file), class: 'govuk-button button button--aside lesson-download-button govuk-!-margin-bottom-3' do %>
                 Download all lesson files <span class="lesson-download-button__meta-data">(<%= @lesson.zipped_contents.size %>)</span>
               <% end %>
@@ -48,13 +48,13 @@
                 <%= render partial: 'curriculum/gcse-revision', locals: { isaac_url: @lesson.isaac_url, category: "Lesson" }, :class => 'govuk-button button button--aside' %>
               <% end %>
               <%= render partial: 'curriculum/rating', locals: { path: :create_curriculum_lesson_rating_path, comment_path: :update_curriculum_lesson_rating, choices_path: :update_curriculum_lesson_rating_choices, id: @lesson.id, user_id: current_user.id } %>
-            <% end %>
-          <% else %>
-            <%= link_to 'Log in to download', "#{auth_url}?source_uri=#{CGI.escape(request.original_url)}", method: :post, :class => 'govuk-button button button--aside govuk-!-margin-bottom-7' %>
-            <p class="govuk-body-s ncce-aside__text">Not registered yet?</p>
-            <p class="govuk-body-s ncce-aside__text"><%= link_to 'Create an account', create_account_url, class: 'govuk-link' %> and get access to over 500 hours of free teaching resources.</p>
-            <% if @lesson.isaac_url.present? %>
-              <%= render partial: 'curriculum/gcse-revision', locals: { isaac_url: @lesson.isaac_url, category: "Lesson" }, :class => 'govuk-button button button--aside' %>
+            <% else %>
+              <%= link_to 'Log in to download', "#{auth_url}?source_uri=#{CGI.escape(request.original_url)}", method: :post, :class => 'govuk-button button button--aside govuk-!-margin-bottom-7' %>
+              <p class="govuk-body-s ncce-aside__text">Not registered yet?</p>
+              <p class="govuk-body-s ncce-aside__text"><%= link_to 'Create an account', create_account_url, class: 'govuk-link' %> and get access to over 500 hours of free teaching resources.</p>
+              <% if @lesson.isaac_url.present? %>
+                <%= render partial: 'curriculum/gcse-revision', locals: { isaac_url: @lesson.isaac_url, category: "Lesson" }, :class => 'govuk-button button button--aside' %>
+              <% end %>
             <% end %>
           <% end %>
 				</div>

--- a/app/views/curriculum/units/_lessons.html.erb
+++ b/app/views/curriculum/units/_lessons.html.erb
@@ -3,7 +3,19 @@
 		<h3 class="govuk-heading-m">Lessons</h3>
 			<ul class="govuk-list govuk-body govuk-!-padding-bottom-7">
         <% lessons.each do |lesson| %>
-            <li class="curriculum__list--item <%= key_stage_list_color(key_stage.level) %>"><%= link_to lesson_title_wording(lesson), curriculum_key_stage_unit_lesson_path(key_stage_slug: key_stage.slug, unit_slug: unit.slug, lesson_slug: lesson.slug), class: 'govuk-link ncce-link' %></li>
+					<li class="curriculum__list--item curriculum__list--item-with-download <%= key_stage_list_color(key_stage.level) %>">
+						<%= link_to lesson_title_wording(lesson), curriculum_key_stage_unit_lesson_path(key_stage_slug: key_stage.slug, unit_slug: unit.slug, lesson_slug: lesson.slug), class: 'govuk-link ncce-link' %>
+
+						<% if current_user %>
+							<% if lesson.zipped_contents&.file.present? %>
+								<%= link_to generate_download_url(lesson.zipped_contents.file), class: 'govuk-button button button--aside lesson-download-button' do %>
+									Download all lesson files <span class="lesson-download-button__meta-data">(<%= lesson.zipped_contents.size %>)</span>
+								<% end %>
+							<% end %>
+						<% else %>
+							<%= link_to 'Log in to download', "#{auth_url}?source_uri=#{CGI.escape(request.original_url)}", method: :post, :class => 'govuk-button button button--aside' %>
+						<% end %>
+					</li>
         <% end %>
 			</ul>
 	</div>

--- a/app/views/curriculum/units/_lessons.html.erb
+++ b/app/views/curriculum/units/_lessons.html.erb
@@ -6,15 +6,15 @@
 					<li class="curriculum__list--item curriculum__list--item-with-download <%= key_stage_list_color(key_stage.level) %>">
 						<%= link_to lesson_title_wording(lesson), curriculum_key_stage_unit_lesson_path(key_stage_slug: key_stage.slug, unit_slug: unit.slug, lesson_slug: lesson.slug), class: 'govuk-link ncce-link' %>
 
-						<% if current_user %>
 							<% if lesson.zipped_contents&.file.present? %>
-								<%= link_to generate_download_url(lesson.zipped_contents.file), class: 'govuk-button button button--aside lesson-download-button' do %>
-									Download all lesson files <span class="lesson-download-button__meta-data">(<%= lesson.zipped_contents.size %>)</span>
+								<% if current_user %>
+									<%= link_to generate_download_url(lesson.zipped_contents.file), class: 'govuk-button button button--aside lesson-download-button' do %>
+										Download all lesson files <span class="lesson-download-button__meta-data">(<%= lesson.zipped_contents.size %>)</span>
+									<% end %>
+								<% else %>
+									<%= link_to 'Log in to download', "#{auth_url}?source_uri=#{CGI.escape(request.original_url)}", method: :post, :class => 'govuk-button button button--aside' %>
 								<% end %>
 							<% end %>
-						<% else %>
-							<%= link_to 'Log in to download', "#{auth_url}?source_uri=#{CGI.escape(request.original_url)}", method: :post, :class => 'govuk-button button button--aside' %>
-						<% end %>
 					</li>
         <% end %>
 			</ul>

--- a/app/webpacker/stylesheets/components/pages/_curriculum.scss
+++ b/app/webpacker/stylesheets/components/pages/_curriculum.scss
@@ -23,6 +23,10 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 5px;
+  
+  .lesson-download-button {
+    width: 19em;
+  }
 
   @include govuk-media-query($from: desktop) {
     justify-content: space-between;

--- a/app/webpacker/stylesheets/components/pages/_curriculum.scss
+++ b/app/webpacker/stylesheets/components/pages/_curriculum.scss
@@ -18,6 +18,19 @@
   padding: 1.3rem;
 }
 
+.curriculum__list--item-with-download {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
+
+  @include govuk-media-query($from: desktop) {
+    justify-content: space-between;
+    flex-direction: row;
+    align-items: center;
+  }
+}
+
 .curriculum__list--item-green {
   border-left-color: $lime-green;
 }

--- a/spec/support/curriculum/views/unit.json
+++ b/spec/support/curriculum/views/unit.json
@@ -31,7 +31,11 @@
           "id": "308e4ad1-55c6-4f36-83f1-8a74c1b202ae",
           "slug": "lesson-1",
           "description": "This is a Lesson",
-          "zipped_contents": null,
+          "zipped_contents": {
+            "file": "https://teachcomputing.org",
+            "size": "1.1 MB",
+            "created": "15 Oct 1943"
+          },
           "title": "Lesson 1"
         }
       ]

--- a/spec/views/curriculum/units/_lessons_spec.rb
+++ b/spec/views/curriculum/units/_lessons_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe("curriculum/units/_lessons", type: :view) do
   let(:unit_json) { File.new("spec/support/curriculum/views/unit.json").read }
   let(:key_stage_json) { File.new("spec/support/curriculum/views/key_stage.json").read }
+  let(:unit_no_lesson_file_json) { File.new("spec/support/curriculum/views/unit_alt.json").read }
   let(:user) { create(:user) }
   let(:unit) {
     JSON.parse(unit_json, object_class: OpenStruct).data.unit
@@ -10,33 +11,65 @@ RSpec.describe("curriculum/units/_lessons", type: :view) do
   let(:key_stage) {
     JSON.parse(key_stage_json, object_class: OpenStruct).data.key_stage
   }
+  let(:unit_no_lesson_file) {
+    JSON.parse(unit_no_lesson_file_json, object_class: OpenStruct).data.unit
+  }
 
-  context "user not logged in" do
-    before do
-      allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(nil)
-      render partial: "lessons", locals: {key_stage:, unit:, lessons: unit.lessons}
-    end
-    it "has a title" do
-      expect(rendered).to have_css(".govuk-heading-m", text: "Lessons")
+  context "lesson with file" do
+    context "user not logged in" do
+      before do
+        allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(nil)
+        render partial: "lessons", locals: {key_stage:, unit:, lessons: unit.lessons}
+      end
+      it "has a title" do
+        expect(rendered).to have_css(".govuk-heading-m", text: "Lessons")
+      end
+
+      it "has list of lessons" do
+        expect(rendered).to have_css(".govuk-list", count: 1)
+      end
+
+      it "has login button" do
+        expect(rendered).to have_css(".govuk-button", text: "Log in to download")
+      end
     end
 
-    it "has list of lessons" do
-      expect(rendered).to have_css(".govuk-list", count: 1)
-    end
+    context "user logged in" do
+      before do
+        allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
+        render partial: "lessons", locals: {key_stage:, unit:, lessons: unit.lessons}
+      end
 
-    it "has login button" do
-      expect(rendered).to have_css(".govuk-button", text: "Log in to download")
+      it "has download button" do
+        expect(rendered).to have_css(".govuk-button", text: "Download all lesson files")
+      end
     end
   end
 
-  context "user logged in" do
-    before do
-      allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
-      render partial: "lessons", locals: {key_stage:, unit:, lessons: unit.lessons}
+  context "lesson without file" do
+    context "user not logged in" do
+      before do
+        allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(nil)
+        render partial: "lessons", locals: {key_stage:, unit: unit_no_lesson_file, lessons: unit_no_lesson_file.lessons}
+      end
+      it "has list of lessons" do
+        expect(rendered).to have_css(".govuk-list", count: 1)
+      end
+
+      it "does not have login button" do
+        expect(rendered).to have_no_css(".govuk-button", text: "Log in to download")
+      end
     end
 
-    it "has download button" do
-      expect(rendered).to have_css(".govuk-button", text: "Download all lesson files")
+    context "user logged in" do
+      before do
+        allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
+        render partial: "lessons", locals: {key_stage:, unit: unit_no_lesson_file, lessons: unit_no_lesson_file.lessons}
+      end
+
+      it "does not have download button" do
+        expect(rendered).to have_no_css(".govuk-button", text: "Download all lesson files")
+      end
     end
   end
 end

--- a/spec/views/curriculum/units/_lessons_spec.rb
+++ b/spec/views/curriculum/units/_lessons_spec.rb
@@ -2,20 +2,41 @@ require "rails_helper"
 
 RSpec.describe("curriculum/units/_lessons", type: :view) do
   let(:unit_json) { File.new("spec/support/curriculum/views/unit.json").read }
-
   let(:key_stage_json) { File.new("spec/support/curriculum/views/key_stage.json").read }
+  let(:user) { create(:user) }
+  let(:unit) {
+    JSON.parse(unit_json, object_class: OpenStruct).data.unit
+  }
+  let(:key_stage) {
+    JSON.parse(key_stage_json, object_class: OpenStruct).data.key_stage
+  }
 
-  before do
-    unit = JSON.parse(unit_json, object_class: OpenStruct).data.unit
-    key_stage = JSON.parse(key_stage_json, object_class: OpenStruct).data.key_stage
-    render partial: "lessons", locals: {key_stage: key_stage, unit: unit, lessons: unit.lessons}
+  context "user not logged in" do
+    before do
+      allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(nil)
+      render partial: "lessons", locals: {key_stage:, unit:, lessons: unit.lessons}
+    end
+    it "has a title" do
+      expect(rendered).to have_css(".govuk-heading-m", text: "Lessons")
+    end
+
+    it "has list of lessons" do
+      expect(rendered).to have_css(".govuk-list", count: 1)
+    end
+
+    it "has login button" do
+      expect(rendered).to have_css(".govuk-button", text: "Log in to download")
+    end
   end
 
-  it "has a title" do
-    expect(rendered).to have_css(".govuk-heading-m", text: "Lessons")
-  end
+  context "user logged in" do
+    before do
+      allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
+      render partial: "lessons", locals: {key_stage:, unit:, lessons: unit.lessons}
+    end
 
-  it "has list of lessons" do
-    expect(rendered).to have_css(".govuk-list", count: 1)
+    it "has download button" do
+      expect(rendered).to have_css(".govuk-button", text: "Download all lesson files")
+    end
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for front-end / tech review
* Review App link(s): https://teachcomputing-pr-1915.herokuapp.com/
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2571
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2584

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Adding download lesson button to the unit view. This will display the login button or the download button depending if the user is logged in or not.

Also fixing the typo I found in the header navigation
