### PR TITLE
Add anchor links to each year of a key stage

### DIFF
--- a/app/helpers/curriculum_helper.rb
+++ b/app/helpers/curriculum_helper.rb
@@ -20,6 +20,10 @@ module CurriculumHelper
     "Year #{year_number}"
   end
 
+  def year_group_anchor(year_number)
+    year_group_title(year_number).parameterize
+  end
+
   def user_has_rated?(id)
     raw_cookie = cookies.encrypted[:ratings]
     ratings = JSON.parse(raw_cookie) unless raw_cookie.nil?

--- a/app/views/curriculum/key_stages/_years.html.erb
+++ b/app/views/curriculum/key_stages/_years.html.erb
@@ -2,12 +2,17 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <hr class="curriculum__line">
-      <h3 class="govuk-heading-m"><%= year_group_title(year.year_number) %></h3>
+
+      <h3 class="govuk-heading-m govuk-!-margin-bottom-2"><%= year_group_title(year.year_number) %></h3>
+      <a class="govuk-link ncce-link" id="<%= year_group_anchor(year.year_number) %>" href="#<%= year_group_anchor(year.year_number)%>" >
+        Jump to <%= year_group_title(year.year_number) %>
+      </a>
+
     </div>
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <ul class="govuk-list govuk-body govuk-!-padding-bottom-4 govuk-!-padding-top-2">
+      <ul class="govuk-list govuk-body govuk-!-padding-bottom-4 govuk-!-padding-top-6">
         <% year.units.each do |unit| %>
           <li class="curriculum__list--item <%= key_stage_list_color(key_stage.level) %>">
             <% if unit.order.present? %>

--- a/spec/helpers/curriculum_helper_spec.rb
+++ b/spec/helpers/curriculum_helper_spec.rb
@@ -49,6 +49,16 @@ describe CurriculumHelper, type: :helper do
     end
   end
 
+  describe("#year_group_anchor") do
+    context "when the year number contains GCSE" do
+      it { expect(helper.year_group_anchor("GCSE")).to eq "gcse" }
+    end
+
+    context "when the year number contains anything but GCSE" do
+      it { expect(helper.year_group_anchor("1")).to eq "year-1" }
+    end
+  end
+
   describe(".sorted_years") do
     before do
       stub_const("Year", Struct.new(:year, :year_number))


### PR DESCRIPTION
This will enable users to share links to a specific year.

We may want to bear in mind this GOVUK guidance that suggests against using anchor links:
> Try to avoid using anchor links in your content. Anchor links can be disorientating for some users with access needs who may have problems getting back to the previous page.
> 
> For example, screen magnifier users and those with motor function impairments. People using assistive technology may find it hard to see what they’ve missed or realise that they’ve skipped forward.
> 
> Avoid using anchor links to content on the same page. Instead, rearrange the structure of your content so that people can navigate the content more easily.

Instead of making the headings themselves the link, I've added small links beneath the headings so we can use the normal link styles:
![image](https://github.com/NCCE/teachcomputing.org/assets/90186562/c2d7e6d5-8e6e-4669-af7c-9f25545be5cc)
