### PR TITLE
Enable Auto enrolment for i belong programme

### DIFF
--- a/app/controllers/certificates/cs_accelerator/auto_enrolments_controller.rb
+++ b/app/controllers/certificates/cs_accelerator/auto_enrolments_controller.rb
@@ -11,7 +11,7 @@ module Certificates
 
         if enrolment.present?
           enrolment.transition_to(:unenrolled)
-          flash[:notice] = "You have successfully opted out of the #{Programme.cs_accelerator.certificate_name}"
+          flash[:notice] = "You have successfully opted out of the KS3 and GCSE subject knowledge programme"
         end
 
         redirect_to dashboard_path

--- a/app/controllers/certificates/i_belong/auto_enrolments_controller.rb
+++ b/app/controllers/certificates/i_belong/auto_enrolments_controller.rb
@@ -1,17 +1,17 @@
 module Certificates
-  module CSAccelerator
+  module IBelong
     class AutoEnrolmentsController < ApplicationController
       before_action :authenticate_user!, only: %i[destroy]
 
       def destroy
         enrolment = UserProgrammeEnrolment.find_by(
-          programme: Programme.cs_accelerator,
+          programme: Programme.i_belong,
           user: current_user
         )
 
         if enrolment.present?
           enrolment.transition_to(:unenrolled)
-          flash[:notice] = "You have successfully opted out of the #{Programme.cs_accelerator.certificate_name}"
+          flash[:notice] = "You have successfully opted out of #{Programme.i_belong.certificate_name}"
         end
 
         redirect_to dashboard_path

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,6 +27,10 @@ module ApplicationHelper
     cms_posts_url(tag: :press)
   end
 
+  def static_asset_url(filename)
+    "#{ENV.fetch("STATIC_FILE_PATH")}/#{filename}"
+  end
+
   def safe_redirect_url(url)
     allowed_redirect_urls = [
       %r{^https://teachcomputing.rpfdev.com},

--- a/app/mailers/i_belong_mailer.rb
+++ b/app/mailers/i_belong_mailer.rb
@@ -49,6 +49,13 @@ class IBelongMailer < ApplicationMailer
     mail(to: @user, subject: @subject, record_sent_mail: true, mailer_type: InactivityQueries.i_belong_all_but_increase_engagement_type)
   end
 
+  def auto_enrolled
+    @user = params[:user]
+    @subject = "Welcome to I Belong"
+
+    mail(to: @user, subject: @subject)
+  end
+
   private
 
   def assign_user

--- a/app/mailers/i_belong_mailer.rb
+++ b/app/mailers/i_belong_mailer.rb
@@ -1,5 +1,6 @@
 class IBelongMailer < ApplicationMailer
   before_action :assign_user
+  helper ApplicationHelper
 
   def completed
     @subject = "Congratulations on your achievement #{@user.full_name}"
@@ -51,7 +52,7 @@ class IBelongMailer < ApplicationMailer
 
   def auto_enrolled
     @user = params[:user]
-    @subject = "Welcome to I Belong"
+    @subject = "Welcome to I Belong: Encouraging girls into computer science!"
 
     mail(to: @user, subject: @subject)
   end

--- a/app/models/programmes/i_belong.rb
+++ b/app/models/programmes/i_belong.rb
@@ -36,6 +36,10 @@ module Programmes
       # enrolment.save
     end
 
+    def auto_enrollable?
+      true
+    end
+
     def auto_enrollment_ignored_activity_codes
       ["FD022"]
     end

--- a/app/views/i_belong_mailer/auto_enrolled.html.erb
+++ b/app/views/i_belong_mailer/auto_enrolled.html.erb
@@ -1,0 +1,51 @@
+<div class='mailer__content'>
+  <p class='govuk-body'>Hi <%= @user.first_name %>,</p>
+  <p class='govuk-body'>
+    We can see you've been working on your professional development by engaging in our Encouraging girls into GCSE computer science course. 
+    We're assuming from your interest in this course that you would be interested in our <%= link_to 'I Belong: encouraging girls into computer science', '/i-belong' %> programme. 
+  </p>
+  <p class='govuk-body'>
+    As such, we've enrolled you on the programme, giving you access to a wider range of resources designed to help your school achieve your goals. 
+    If you don't want to continue the programme at this time, let us know, and we will update our records. You can still re-enrol yourself in the future on our <%= link_to 'website', '/i-belong' %>. 
+  </p>
+  <p class='govuk-body'>
+    <%= link_to 'Unenrol me from the programme', unenroll__i_belong_auto_enrolment_url, class: 'govuk-button button' %>
+  </p>
+  <p class='govuk-body'>
+    <strong>Next steps</strong>
+  </p>
+  <p class='govuk-body'>
+    Did you know that completing the Encouraging girls into GCSE computer science course means you're already on the way to achieving the I Belong certificate for your school? 
+  </p>
+  <p class='govuk-body'>
+    Now you're enrolled, you will be able to access your personal dashboard, where you can find out more about the certificate and the next steps required to achieve it.  
+  </p>
+
+  <p class='govuk-body'>
+    <%= link_to 'Explore activities in your dashboard', i_belong_url, class: 'govuk-button button' %>
+  </p>
+
+  <p class='govuk-body'>
+    Has your school already completed some of the activities required to achieve the certificate? Tick them off by submitting evidence in your dashboard.  
+  </p>
+ 
+  <p class='govuk-body'>
+    Ideas to get you started 
+  </p>
+  <ul class="govuk-list govuk-list--bullet">
+  	<li>Maximise our recommended key stage 3 curriculum resources, aligned to evidence-based approaches supporting girls' engagement in computer science. 
+    Examples include 
+    <%= link_to 'Clear messaging in digital media, Developing for the Web', '/curriculum/key-stage-3/clear-messaging-in-digital-media' %>, 
+    and 
+    <%= link_to 'Media - Animations', 'https://teachcomputing.org/curriculum/key-stage-3/media-animations' %>.</li>
+    <li>Provide access for students to a computing-related STEM lunchtime or after-school club and show how your approach is gender responsive. You and your colleagues may be doing this already and be ready to submit your evidence.</li>
+  </ul>
+ 
+  <p class='govuk-body'>
+    <strong>Need more support?</strong>
+  </p>
+ 
+  <p class='govuk-body'>
+    Guidance is available in the <%= link_to 'programme handbook', static_asset_url('I+Belong+Handbook.pdf') %> to help you and your colleagues choose meaningful activities for your school. 
+  </p>
+</div>

--- a/app/views/i_belong_mailer/auto_enrolled.text.erb
+++ b/app/views/i_belong_mailer/auto_enrolled.text.erb
@@ -1,0 +1,25 @@
+Hi <%= @user.first_name %>,
+
+We can see you've been working on your professional development by engaging in our Encouraging girls into GCSE computer science course. We're assuming from your interest in this course that you would be interested in our I Belong: encouraging girls into computer science programme. 
+
+As such, we've enrolled you on the programme, giving you access to a wider range of resources designed to help your school achieve your goals. If you don't want to continue the programme at this time, let us know, and we will update our records. You can still re-enrol yourself in the future on our website (https://teachcomputing.org/i-belong). 
+
+Unenrol me from the programme (<%= unenroll__i_belong_auto_enrolment_url %>)
+
+Next steps
+Did you know that completing the Encouraging girls into GCSE computer science course means you're already on the way to achieving the I Belong certificate for your school? 
+
+Now you're enrolled, you will be able to access your personal dashboard, where you can find out more about the certificate and the next steps required to achieve it.  
+
+Explore activities in your dashboard (<%= i_belong_url %>)
+
+Has your school already completed some of the activities required to achieve the certificate? Tick them off by submitting evidence in your dashboard.  
+ 
+Ideas to get you started 
+•	Maximise our recommended key stage 3 curriculum resources, aligned to evidence-based approaches supporting girls' engagement in computer science. Examples include Clear messaging in digital media (https://teachcomputing.org/curriculum/key-stage-3/clear-messaging-in-digital-media), Developing for the Web, and Media - Animations (https://teachcomputing.org/curriculum/key-stage-3/media-animations). 
+•	Provide access for students to a computing-related STEM lunchtime or after-school club and show how your approach is gender responsive. You and your colleagues may be doing this already and be ready to submit your evidence.  
+ 
+Need more support?  
+ 
+Guidance is available in the programme handbook (<%= static_asset_url('I+Belong+Handbook.pdf') %>) to help you and your colleagues choose meaningful activities for your school. 
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,12 @@ Rails.application.routes.draw do
       end
     end
 
+    namespace "i_belong" do
+      resource "auto_enrolment", only: [] do
+        get "/unenroll", action: :destroy
+      end
+    end
+
     resources :pathways, param: :slug, only: %i[show]
   end
 

--- a/previews/mailers/i_belong_mailer_preview.rb
+++ b/previews/mailers/i_belong_mailer_preview.rb
@@ -30,4 +30,8 @@ class IBelongMailerPreview < ActionMailer::Preview
   def inactive_everything_but_increase_engagement
     IBelongMailer.with(user: User.first, preview: true).inactive_everything_but_increase_engagement
   end
+
+  def auto_enrolled
+    IBelongMailer.with(user: User.first, preview: true).auto_enrolled
+  end
 end

--- a/spec/mailers/i_belong_mailer_spec.rb
+++ b/spec/mailers/i_belong_mailer_spec.rb
@@ -32,6 +32,39 @@ RSpec.describe IBelongMailer, type: :mailer do
     end
   end
 
+  describe "auto_enrolled" do
+    let(:mail) { IBelongMailer.with(user: user).auto_enrolled }
+    let(:mail_subject) { "Welcome to I Belong: Encouraging girls into computer science!" }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq(mail_subject)
+      expect(mail.to).to eq([user.email])
+      expect(mail.from).to eq(["noreply@teachcomputing.org"])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match(/Hi Tobias,\s*We can see you've been working/)
+    end
+
+    it "includes the subject in the email" do
+      expect(mail.body.encoded).to include("<title>#{mail_subject}</title>")
+    end
+
+    it "contains the certificate dashboard link" do
+      expect(mail.body.encoded).to have_link("Explore activities in your dashboard", href: %r{/certificate/i-belong})
+    end
+
+    it "contains the unenroll link" do
+      expect(mail.body.encoded).to have_link("Unenrol me from the programme", href: %r{/i_belong/auto_enrolment/unenroll})
+    end
+
+    context "when viewing plain text" do
+      it "greets the user" do
+        expect(mail.text_part.body.to_s).to match(/Hi Tobias,\s*We can see you've been working/)
+      end
+    end
+  end
+
   describe "pending" do
     let(:mail) { IBelongMailer.with(user: user).pending }
     let(:mail_subject) { "Thank you for participating in the I Belong programme" }

--- a/spec/models/programmes/i_belong_spec.rb
+++ b/spec/models/programmes/i_belong_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Programmes::IBelong do
 
   describe "#auto_enrollable?" do
     it "should return false" do
-      expect(programme.auto_enrollable?).to be false
+      expect(programme.auto_enrollable?).to be true
     end
   end
 

--- a/spec/requests/certificates/cs_accelerator/auto_enrolment/destroy_spec.rb
+++ b/spec/requests/certificates/cs_accelerator/auto_enrolment/destroy_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Certificates::CSAccelerator::AutoEnrolmentsController do
 
       it "flash notice has correct info" do
         unenroll
-        expect(flash[:notice]).to match(/You have successfully opted out of the KS3 and GCSE subject knowledge certificate/)
+        expect(flash[:notice]).to match(/You have successfully opted out of the KS3 and GCSE subject knowledge programme/)
       end
     end
 

--- a/spec/requests/certificates/i_belong/auto_enrolment/destroy_spec.rb
+++ b/spec/requests/certificates/i_belong/auto_enrolment/destroy_spec.rb
@@ -2,16 +2,16 @@ require "rails_helper"
 
 RSpec.describe Certificates::CSAccelerator::AutoEnrolmentsController do
   let(:user) { create(:user) }
-  let(:programme) { create(:cs_accelerator) }
+  let(:programme) { create(:i_belong) }
 
   describe "GET #destroy" do
-    subject(:unenroll) { get unenroll__cs_accelerator_auto_enrolment_path }
+    subject(:unenroll) { get unenroll__i_belong_auto_enrolment_path }
 
     before do
       allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
     end
 
-    context "when user is enrolled on cs_accelerator" do
+    context "when user is enrolled on i_belong" do
       let!(:enrolment) { create(:user_programme_enrolment, user: user, programme: programme) }
 
       it "redirects to the dashboard path" do
@@ -35,7 +35,7 @@ RSpec.describe Certificates::CSAccelerator::AutoEnrolmentsController do
 
       it "flash notice has correct info" do
         unenroll
-        expect(flash[:notice]).to match(/You have successfully opted out of the KS3 and GCSE subject knowledge certificate/)
+        expect(flash[:notice]).to match(/You have successfully opted out of I Belong/)
       end
     end
 


### PR DESCRIPTION
## Status

* Current Status: Ready for front-end / tech review
* Review App link(s): 
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2591

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [x] Tech review completed

## What's changed?

Enabling the auto enrolment for I Belong
Adding in the email for the I Belong programme auto enrolment, and associated tests
Created a helper method for static resources, will add ticket for removing hard code links in other places when time allows
