### PR TITLE
Remove links from key stage pages, but still allow external linking

### DIFF
--- a/app/views/curriculum/key_stages/_years.html.erb
+++ b/app/views/curriculum/key_stages/_years.html.erb
@@ -3,11 +3,9 @@
     <div class="govuk-grid-column-full">
       <hr class="curriculum__line">
 
-      <h3 class="govuk-heading-m govuk-!-margin-bottom-2"><%= year_group_title(year.year_number) %></h3>
-      <a class="govuk-link ncce-link" id="<%= year_group_anchor(year.year_number) %>" href="#<%= year_group_anchor(year.year_number)%>" >
-        Jump to <%= year_group_title(year.year_number) %>
-      </a>
-
+      <h3 class="govuk-heading-m govuk-!-margin-bottom-2" id="<%= year_group_anchor(year.year_number) %>">
+        <%= year_group_title(year.year_number) %>
+      </h3>
     </div>
   </div>
   <div class="govuk-grid-row">


### PR DESCRIPTION
Resolves https://github.com/NCCE/teachcomputing.org-issues/issues/2592#issuecomment-1936037350

This PR removes anchor links from the key stage pages, but retains the generated IDs so the sections can be linked to externally.

It also adds these links to the sitemap