### PR TITLE
Revert "Bump cloudflare-rails from 1.2.0 to 5.0.1"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "attr_encrypted"
 gem "audited"
 gem "aws-sdk-s3", require: false
 gem "bootsnap", ">= 1.5.1", require: false
-gem "cloudflare-rails", "~> 5.0"
+gem "cloudflare-rails", "~> 1.1"
 gem "combine_pdf", ">= 1.0.18"
 gem "connection_pool"
 gem "dalli"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,11 +143,9 @@ GEM
     childprocess (3.0.0)
     choice (0.2.0)
     climate_control (1.2.0)
-    cloudflare-rails (5.0.1)
-      actionpack (>= 6.1, < 7.2.0)
-      activesupport (>= 6.1, < 7.2.0)
-      railties (>= 6.1, < 7.2.0)
-      zeitwerk (>= 2.5.0)
+    cloudflare-rails (1.2.0)
+      httparty
+      rails (>= 5.0, < 6.2.0)
     cocoon (1.2.15)
     coderay (1.1.3)
     coercible (1.0.0)
@@ -271,6 +269,9 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     humanize (2.5.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -320,7 +321,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.0.4)
+    marcel (1.0.2)
     matrix (0.4.2)
     memcachier (0.0.2)
     method_source (1.0.0)
@@ -685,7 +686,7 @@ DEPENDENCIES
   byebug
   capybara
   climate_control
-  cloudflare-rails (~> 5.0)
+  cloudflare-rails (~> 1.1)
   combine_pdf (>= 1.0.18)
   connection_pool
   dalli


### PR DESCRIPTION
It looks like we rely on some undocumented behavior that only exists < 2.0 to get a list of cloudflare Ips.

This causes our rack attack config to fail in staging.

This reverts commit 6d5f4c3c4757400b33688dc162d835d93d5f29e6.