### PR TITLE
Change font-family css for medium headings

### DIFF
--- a/app/views/curriculum/key_stages/index.html.erb
+++ b/app/views/curriculum/key_stages/index.html.erb
@@ -12,7 +12,7 @@
     tracking_label: 'video'
   }
 ) %>
-<div class="govuk-width-container">
+<div class="govuk-width-container curriculum">
   <div class="govuk-main-wrapper govuk-main-wrapper--xl">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/app/views/curriculum/key_stages/show.html.erb
+++ b/app/views/curriculum/key_stages/show.html.erb
@@ -10,7 +10,7 @@
     </div>
   </div>
 </div>
-<div class="govuk-width-container">
+<div class="govuk-width-container curriculum">
   <%= render partial: 'curriculum/breadcrumb', locals: { current: @key_stage.short_title } %>
 	<div class="govuk-main-wrapper resources__wrapper">
 		<div class="govuk-grid-row">

--- a/app/views/curriculum/lessons/show.html.erb
+++ b/app/views/curriculum/lessons/show.html.erb
@@ -11,7 +11,7 @@
     </div>
   </div>
 </div>
-<div class="govuk-width-container">
+<div class="govuk-width-container curriculum">
   <%= render partial: 'curriculum/breadcrumb', locals: {
     key_stage_title: @unit.year_group.key_stage.short_title,
     key_stage_path: curriculum_key_stage_units_path(@unit.year_group.key_stage.slug),

--- a/app/views/curriculum/units/show.html.erb
+++ b/app/views/curriculum/units/show.html.erb
@@ -14,7 +14,7 @@
     </div>
   </div>
 </div>
-<div class="govuk-width-container">
+<div class="govuk-width-container curriculum">
   <%= render partial: 'curriculum/breadcrumb', locals: {
     key_stage_title: @unit.year_group.key_stage.short_title,
     key_stage_path: curriculum_key_stage_units_path(@unit.year_group.key_stage.slug),

--- a/app/webpacker/stylesheets/components/_headings.scss
+++ b/app/webpacker/stylesheets/components/_headings.scss
@@ -9,6 +9,8 @@
   }
 }
 
-.govuk-heading-m {
-  font-family: 'Objectivity', sans-serif !important;
+.curriculum {
+  .govuk-heading-m {
+    font-family: 'Objectivity', sans-serif !important;
+  }
 }


### PR DESCRIPTION
Previous change meant that css was being overridden by "Objectivity" style

## Status

* Current Status: Ready for review
* Possibly needs automated testing
* Closes [#2644](https://github.com/NCCE/teachcomputing.org-issues/issues/2644)

## Review progress:

- [x] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

All govuk-heading-m are being assigned the incorrect font due to change a year ago that should have only effected curriculum pages. Solution was to add a `.curriculum` class to the curriculum pages and modify the scss accordingly. The Medium headers on the curriculum continue to use 'Objectivity' whereas all other medium government headers now use the default 'DM Sans'.

## Steps to perform after deploying to production

N/A
