### PR TITLE
Add new/improved icon

### DIFF
--- a/app/components/course_component/course_component.html.erb
+++ b/app/components/course_component/course_component.html.erb
@@ -1,4 +1,9 @@
 <div class="ncce-courses__course">
+  <% if @course.new_course? %>
+    <p class="govuk-body ncce-courses__new-improved-badge">
+      <%= "New/improved" %>
+    </p>
+  <% end %>
   <h2 id="<%= @course.title %>" class="govuk-heading-s ncce-courses__heading">
     <%= link_to @course.title, course_path(id: @course.activity_code, name: @course.title.parameterize), class: 'ncce-link' %><span class="ncce-courses__heading-code"><%= @course.activity_code %></span>
   </h2>

--- a/app/services/achiever/course/template.rb
+++ b/app/services/achiever/course/template.rb
@@ -22,7 +22,8 @@ class Achiever::Course::Template
     :topics_covered,
     :who_is_it_for,
     :workstream,
-    :always_on
+    :always_on,
+    :last_updated_at
 
   RESOURCE_PATH = "Get?cmd=CourseTemplatesListingByProgramme".freeze
   QUERY_STRINGS = {Page: "1",
@@ -66,6 +67,7 @@ class Achiever::Course::Template
       t.workstream = resource["Template.Workstream"]
 
       t.always_on = activity&.always_on || false
+      t.last_updated_at = activity&.created_at || Date.current
     end
   end
 
@@ -161,6 +163,12 @@ class Achiever::Course::Template
 
   def by_certificate(certificate)
     @programmes.include?(certificate)
+  end
+
+  def new_course?
+    return false unless last_updated_at.present?
+
+    last_updated_at > 3.months.ago
   end
 
   def duration

--- a/app/webpacker/stylesheets/components/courses/_courses_list.scss
+++ b/app/webpacker/stylesheets/components/courses/_courses_list.scss
@@ -15,7 +15,19 @@
   padding: 10px 0;
 }
 
+.ncce-courses__new-improved-badge {
+  display: inline;
+  background-color: #120540;
+  color: #ffffff;
+  padding: 2px 0.5rem;
+  margin-bottom: 0;
+  font-size: medium;
+  font-weight: bold;
+  margin-right: 5px;
+}
+
 .ncce-courses__heading {
+  display: inline;
   margin-bottom: 10px;
 }
 

--- a/spec/components/course_component_spec.rb
+++ b/spec/components/course_component_spec.rb
@@ -29,6 +29,20 @@ RSpec.describe CourseComponent, type: :component do
     expect(page).to have_text("Join anytime")
   end
 
+  context "new/improve course icons" do
+    it "shows a new/improved icon on new courses" do
+      course.last_updated_at = Date.current
+      render_inline(described_class.new(course: course, filter: filter))
+      expect(page).to have_css("p.ncce-courses__new-improved-badge")
+    end
+
+    it "should not show a new/improved icon on old courses" do
+      course.last_updated_at = Date.current - 4.months
+      render_inline(described_class.new(course: course, filter: filter))
+      expect(page).not_to have_css("img.ncce-courses__badge")
+    end
+  end
+
   it "has a title" do
     render_inline(described_class.new(course: course, filter: filter))
     expect(page).to have_text(course.title)


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2631

## Review progress:

- [x] Browser tested
- [x] Tech review completed

## What's changed?

Set the value of the bool `is_new_course` on the `@course` object passed to the course component. This has been currently set to return `true` if `activity.created_at > 3.months.ago`

## Steps to perform after deploying to production

N/A
