### PR TITLE
Replacing old CSA handbook links

### DIFF
--- a/app/helpers/external_link_helper.rb
+++ b/app/helpers/external_link_helper.rb
@@ -115,8 +115,8 @@ module ExternalLinkHelper
     "https://static.teachcomputing.org/Completing.your.I.Belong.evidence.Feb.2024.pdf"
   end
 
-  def csa_handbook_url
-    "https://static.teachcomputing.org/CS_Accelerator_handbook.pdf"
+  def gcse_and_ks3_handbook_url
+    "https://static.teachcomputing.org/KS3_and_GCSE_CS_certificate_handbook.pdf"
   end
 
   def i_belong_action_plan_url

--- a/app/views/certificates/cs_accelerator/_aside.html.erb
+++ b/app/views/certificates/cs_accelerator/_aside.html.erb
@@ -3,7 +3,7 @@
   <p class='govuk-body-s'>We are happy to support you along the way. Call 019 0432 8300 or email <%= mail_to 'info@teachcomputing.org', 'info@teachcomputing.org', class: 'ncce-link' %>.</p>
   <p class="govuk-body-s">Have a question about your activities on this page?  Check out our <%= link_to 'Frequently Asked Questions', '/faq/courses', class: 'ncce-link' %></p>
   <p class="govuk-body-s">Need to catch up on your learning?</p>
-  <p class="govuk-body-s"><%= link_to 'Download our Handbook', 'https://static.teachcomputing.org/CS_Accelerator_handbook.pdf', class: 'ncce-link' %></p>
+  <p class="govuk-body-s"><%= link_to 'Download our Handbook', gcse_and_ks3_handbook_url, class: 'ncce-link' %></p>
   <p class="govuk-body-s"><%= link_to 'Download our GCSE Specification Map', 'https://static.teachcomputing.org/GCSE_specifications_to_CSA_course_map.pdf', class: 'ncce-link' %></p>
 	<h2 class="govuk-heading-s ncce-aside__title">Learning pathways for teachers</h2>
 	<p class="govuk-body-s">Are you an aspiring computing teacher or are you unsure about your level of experience? Our learning pathways will help you to get started and offer a structured route through the programme:</p>

--- a/app/views/certificates/cs_accelerator/complete.html.erb
+++ b/app/views/certificates/cs_accelerator/complete.html.erb
@@ -148,7 +148,7 @@
             title: t('.documents_aside.title'),
             class_name: 'documents-aside',
             text: t('.documents_aside.text.html',
-              handbook_link: link_to(t('.documents_aside.handbook_link_text'), 'https://static.teachcomputing.org/CS_Accelerator_handbook.pdf', class: 'ncce-link', data: tracking_data('Handbook PDF')),
+              handbook_link: link_to(t('.documents_aside.handbook_link_text'), gcse_and_ks3_handbook_url, class: 'ncce-link', data: tracking_data('Handbook PDF')),
               spec_link: link_to(t('.documents_aside.spec_link_text'), 'https://static.teachcomputing.org/GCSE_specifications_to_CSA_course_map.pdf', class: 'ncce-link', data: tracking_data('GCSE specs map'))
             )
           ) %>

--- a/app/views/components/_support-aside.html.erb
+++ b/app/views/components/_support-aside.html.erb
@@ -3,6 +3,6 @@
   <p class='govuk-body-s'>We are happy to support you along the way. Call 019 0432 8300 or email <%= mail_to 'info@teachcomputing.org', 'info@teachcomputing.org', class: 'ncce-link', data: { event_action: 'click', event_category: 'CSA enrolled', event_label: 'Email us' }  %>.</p>
   <p class="govuk-body-s">Have a question about your activities on this page?  Check out our <%= link_to 'Frequently Asked Questions', '/faq/courses', class: 'ncce-link', data: { event_action: 'click', event_category: 'CSA enrolled', event_label: 'FAQs' } %></p>
   <p class="govuk-body-s">Need to catch up on your learning?</p>
-  <p class="govuk-body-s"><%= link_to 'Download our Handbook', 'https://static.teachcomputing.org/CS_Accelerator_handbook.pdf', class: 'ncce-link' %></p>
+  <p class="govuk-body-s"><%= link_to 'Download our Handbook', gcse_and_ks3_handbook_url, class: 'ncce-link' %></p>
   <p class="govuk-body-s"><%= link_to 'Download our GCSE Specification Map', 'https://static.teachcomputing.org/GCSE_specifications_to_CSA_course_map.pdf', class: 'ncce-link' %></p>
 </div>

--- a/app/views/cs_accelerator_mailer/auto_enrolled.html.erb
+++ b/app/views/cs_accelerator_mailer/auto_enrolled.html.erb
@@ -5,7 +5,7 @@
    We can see you've been working on your professional development, by engaging in courses that are part of the Key Stage 3 and GCSE Computer Science subject knowledge certificate on <%= link_to 'TeachComputing.org', root_url, class: 'ncce-link' %>. To help you take the next step towards achieving this national accreditation in computer science subject knowledge, which is awarded by BCS, the Chartered Institute for IT, we've enrolled you on the certificate.
   </p>
   <p class='govuk-body'>
-    This means that you'll now be able to access your own personal dashboard, where you can find out more about the certificate and explore a range of resources and support, including our <%= link_to 'handbook', csa_handbook_url, class: 'ncce-link' %>, which will walk you through what to expect over the course of your learning.
+    This means that you'll now be able to access your own personal dashboard, where you can find out more about the certificate and explore a range of resources and support, including our <%= link_to 'handbook', gcse_and_ks3_handbook_url, class: 'ncce-link' %>, which will walk you through what to expect over the course of your learning.
   </p>
   <p class='govuk-body'>
     <%= link_to 'Explore your dashboard', cs_accelerator_certificate_url, class: 'govuk-button button' %>

--- a/app/views/cs_accelerator_mailer/auto_enrolled.text.erb
+++ b/app/views/cs_accelerator_mailer/auto_enrolled.text.erb
@@ -4,7 +4,7 @@ Did you know that you're already well on your way to gaining a nationally recogn
 
 We can see you've been working on your professional development, by engaging in courses that are part of the Key Stage 3 and GCSE Computer Science subject knowledge certificate on TeachComputing.org (<%= root_url %>). To help you take the next step towards achieving this national accreditation in computer science subject knowledge, which is awarded by BCS, the Chartered Institute for IT, we've enrolled you on the certificate.
 
-This means that you'll now be able to access your own personal dashboard, where you can find out more about the certificate and explore a range of resources and support, including our handbook (<%= csa_handbook_url %>), which will walk you through what to expect over the course of your learning.Button:
+This means that you'll now be able to access your own personal dashboard, where you can find out more about the certificate and explore a range of resources and support, including our handbook (<%= gcse_and_ks3_handbook_url %>), which will walk you through what to expect over the course of your learning.Button:
 
 Explore your dashboard (<%= cs_accelerator_certificate_url %>)
 

--- a/app/views/cs_accelerator_mailer/enrolled.html.erb
+++ b/app/views/cs_accelerator_mailer/enrolled.html.erb
@@ -3,7 +3,7 @@
 
   <p class='govuk-body'>You've successfully enrolled on our Key Stage 3 and GCSE Computer Science subject knowledge certificate, and we look forward to guiding you on your journey to achieving this nationally recognised accreditation. This certificate is awarded by BCS, The Chartered Institute for IT.</p>
 
-  <p class='govuk-body'>Now you're enrolled on the programme, you'll find all of the resources and support you need on your <%= link_to 'personal dashboard', dashboard_url, class: 'ncce-link' %>, including our <%= link_to 'handbook', csa_handbook_url, class: 'ncce-link' %>, which will walk you through what to expect as you progress.</p>
+  <p class='govuk-body'>Now you're enrolled on the programme, you'll find all of the resources and support you need on your <%= link_to 'personal dashboard', dashboard_url, class: 'ncce-link' %>, including our <%= link_to 'handbook', gcse_and_ks3_handbook_url, class: 'ncce-link' %>, which will walk you through what to expect as you progress.</p>
 
   <p class='govuk-body'><strong>Next steps...</strong></p>
   <ol class="govuk-list govuk-list--number">

--- a/app/views/cs_accelerator_mailer/enrolled.text.erb
+++ b/app/views/cs_accelerator_mailer/enrolled.text.erb
@@ -2,7 +2,7 @@ Welcome <%= @user.first_name %>, we are delighted to have you on board!
 
 You've successfully enrolled on our Key Stage 3 and GCSE Computer Science subject knowledge certificate, and we look forward to guiding you on your journey to achieving this nationally recognised accreditation. This certificate is awarded by BCS, The Chartered Institute for IT.
 
-Now you're enrolled on the programme, you'll find all of the resources and support you need on your personal dashboard (<%= dashboard_url %>), including our handbook (<%= csa_handbook_url %>), which will walk you through what to expect as you progress.
+Now you're enrolled on the programme, you'll find all of the resources and support you need on your personal dashboard (<%= dashboard_url %>), including our handbook (<%= gcse_and_ks3_handbook_url %>), which will walk you through what to expect as you progress.
 
 Next steps...
 

--- a/app/views/pages/enrolment/subject_knowledge.html.erb
+++ b/app/views/pages/enrolment/subject_knowledge.html.erb
@@ -54,8 +54,8 @@
         <%= render AsideComponent.new(title: 'Userful documents') do |component| %>
           <% component.with_body do %>
             <p class="govuk-body-s">
-              <%= link_to 'CSA Handbook',
-                          'https://static.teachcomputing.org/CS_Accelerator_handbook.pdf',
+              <%= link_to 'GCSE and KS3 Handbook',
+                          gcse_and_ks3_handbook_url,
                           class: 'ncce-link'
               %>
             </p>

--- a/spec/helpers/external_link_helper_spec.rb
+++ b/spec/helpers/external_link_helper_spec.rb
@@ -30,9 +30,13 @@ RSpec.describe ExternalLinkHelper do
     first_lego_leauge_url
     cansat_webinar_url
     structuring_your_i_belong_evidence_url
-    csa_handbook_url
+    gcse_and_ks3_handbook_url
     i_belong_action_plan_url
     stem_ambassadors_url
+    computing_quality_framework_url
+    sme_support_form_url
+    school_trusts_form_url
+    hubs_local_support_form_url
   ].each do |external_link_method|
     describe "##{external_link_method}" do
       it "should return a string" do

--- a/spec/mailers/cs_accelerator_mailer_spec.rb
+++ b/spec/mailers/cs_accelerator_mailer_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe CSAcceleratorMailer, type: :mailer do
 
     it "contains link to handbook" do
       expect(mail.html_part.body)
-        .to have_link("handbook", href: csa_handbook_url)
+        .to have_link("handbook", href: gcse_and_ks3_handbook_url)
     end
 
     it "contains link to dashboard" do
@@ -128,7 +128,7 @@ RSpec.describe CSAcceleratorMailer, type: :mailer do
 
       it "contains link to handbook" do
         expect(mail.text_part.body)
-          .to include("handbook (#{csa_handbook_url})")
+          .to include("handbook (#{gcse_and_ks3_handbook_url})")
       end
 
       it "contains link to dashboard" do

--- a/spec/views/certificates/cs_accelerator/_aside.html_spec.rb
+++ b/spec/views/certificates/cs_accelerator/_aside.html_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe("certificates/cs_accelerator/_aside", type: :view) do
 
   it "renders a link to the handbook" do
     render
-    expect(rendered).to have_link("Download our Handbook", href: "https://static.teachcomputing.org/CS_Accelerator_handbook.pdf")
+    expect(rendered).to have_link("Download our Handbook", href: "https://static.teachcomputing.org/KS3_and_GCSE_CS_certificate_handbook.pdf")
   end
 
   it "renders a link to the GCSE specification map" do

--- a/spec/views/certificates/cs_accelerator/complete.html_spec.rb
+++ b/spec/views/certificates/cs_accelerator/complete.html_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe("certificates/cs_accelerator/complete") do
     end
 
     it "has a useful documents section" do
-      expect(rendered).to have_link("Download our Handbook", href: "https://static.teachcomputing.org/CS_Accelerator_handbook.pdf")
+      expect(rendered).to have_link("Download our Handbook", href: "https://static.teachcomputing.org/KS3_and_GCSE_CS_certificate_handbook.pdf")
       expect(rendered).to have_link("Download our GCSE Specification Map", href: "https://static.teachcomputing.org/GCSE_specifications_to_CSA_course_map.pdf")
     end
 

--- a/spec/views/pages/enrolment/cs_accelerator.html_spec.rb
+++ b/spec/views/pages/enrolment/cs_accelerator.html_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe("pages/enrolment/subject_knowledge", type: :view) do
 
   context "useful links and documents" do
     it "has link to csa brochure" do
-      expect(rendered).to have_css(".ncce-link", text: "CSA Handbook")
+      expect(rendered).to have_css(".ncce-link", text: "GCSE and KS3 Handbook")
     end
 
     it "has link to csa course map" do


### PR DESCRIPTION
## Status

* Current Status: Ready for front-end / tech review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2645

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Removed old CSA handbook external link helper method
- Added new KS3 handbook external link method
- Removed any hardcoded links to old handbook and replaced with new external link method
- Updated external link testing to include recently introduced methods not previously included

