### PR TITLE
Odd colouring of focused links in the teach computing footer

### DIFF
--- a/app/webpacker/stylesheets/settings/_colors.scss
+++ b/app/webpacker/stylesheets/settings/_colors.scss
@@ -38,6 +38,7 @@ $green: #4FA88B;
 $orange: #FF8300;
 $red: #ea3345;
 $ncce-highlight: #F8F8F8;
+$brand-yellow: #ffc000;
 
 $govuk-text-colour: $grey-dark-x;
 $govuk-button-text-colour: $grey-dark-x;

--- a/app/webpacker/stylesheets/settings/_links.scss
+++ b/app/webpacker/stylesheets/settings/_links.scss
@@ -34,7 +34,7 @@ a:not([class]) {
   }
   &:focus {
     color: $white;
-    box-shadow: 0 -2px #fd0, 0 2px #fd0;
+    box-shadow: 0 -2px $brand-yellow, 0 2px $brand-yellow;
   }
   &:active {
     color: $ncce-grey;

--- a/app/webpacker/stylesheets/settings/_links.scss
+++ b/app/webpacker/stylesheets/settings/_links.scss
@@ -34,6 +34,7 @@ a:not([class]) {
   }
   &:focus {
     color: $white;
+    box-shadow: 0 -2px #fd0, 0 2px #fd0;
   }
   &:active {
     color: $ncce-grey;


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2652

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Added brand-yellow colour variable
- Footer links box-shadow to brand yellow on focus

