### PR TITLE
Allow unenrolled users to re-enroll

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,7 +72,10 @@ class User < ApplicationRecord
   end
 
   def enrolled_on_programme_pathway?(programme:, pathway:)
-    user_programme_enrolments.find_by(programme:, pathway:).present?
+    enrolment = user_programme_enrolments.find_by(programme:, pathway:)
+    return false unless enrolment.present?
+
+    !enrolment.in_state?(:unenrolled)
   end
 
   def programme_enrolment_state(programme_id)

--- a/spec/components/pathway_enrol_component_spec.rb
+++ b/spec/components/pathway_enrol_component_spec.rb
@@ -22,29 +22,58 @@ RSpec.describe PathwayEnrolComponent, type: :component do
     end
   end
 
-  context "when the user is not enrolled" do
-    let(:user_programme_enrolment) { nil }
+  context "when the user is not enrolled with no enrolment record" do
+    context "with no enrolment record" do
+      let(:user_programme_enrolment) { nil }
 
-    it "should render" do
-      expect(page).to have_selector("body")
+      it "should render" do
+        expect(page).to have_selector("body")
+      end
+
+      it "renders enrol_copy with html_safe" do
+        expect(page).to have_css(".test1", text: "one")
+        expect(page).to have_css(".test2", text: "two")
+      end
+
+      it "renders an Enrol button" do
+        expect(page).to have_css(".govuk-button", text: "Enrol")
+      end
+
+      context "when user doesn't meet enrolment requirements" do
+        it "doesn't render an Enrol button" do
+          allow(programme).to receive(:user_is_eligible?).with(user).and_return(false)
+
+          render_inline(described_class.new(programme:, pathway:, current_user: user))
+
+          expect(page).not_to have_css(".govuk-button", text: "Enrol")
+        end
+      end
     end
 
-    it "renders enrol_copy with html_safe" do
-      expect(page).to have_css(".test1", text: "one")
-      expect(page).to have_css(".test2", text: "two")
-    end
+    context "with enrolment record but status set to unenrolled" do
+      let(:user_programme_enrolment) { create(:unenrolled_enrolment, user:, programme:, pathway:) }
 
-    it "renders an Enrol button" do
-      expect(page).to have_css(".govuk-button", text: "Enrol")
-    end
+      it "should render" do
+        expect(page).to have_selector("body")
+      end
 
-    context "when user doesn't meet enrolment requirements" do
-      it "doesn't render an Enrol button" do
-        allow(programme).to receive(:user_is_eligible?).with(user).and_return(false)
+      it "renders enrol_copy with html_safe" do
+        expect(page).to have_css(".test1", text: "one")
+        expect(page).to have_css(".test2", text: "two")
+      end
 
-        render_inline(described_class.new(programme:, pathway:, current_user: user))
+      it "renders an Enrol button" do
+        expect(page).to have_css(".govuk-button", text: "Enrol")
+      end
 
-        expect(page).not_to have_css(".govuk-button", text: "Enrol")
+      context "when user doesn't meet enrolment requirements" do
+        it "doesn't render an Enrol button" do
+          allow(programme).to receive(:user_is_eligible?).with(user).and_return(false)
+
+          render_inline(described_class.new(programme:, pathway:, current_user: user))
+
+          expect(page).not_to have_css(".govuk-button", text: "Enrol")
+        end
       end
     end
   end

--- a/spec/factories/user_programme_enrolments.rb
+++ b/spec/factories/user_programme_enrolments.rb
@@ -20,5 +20,11 @@ FactoryBot.define do
         enrolment.transition_to :pending
       end
     end
+
+    factory :unenrolled_enrolment do
+      after(:create) do |enrolment|
+        enrolment.transition_to :unenrolled
+      end
+    end
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App link(s): Heroku doesn't seem happy to create one as of current so will populate when ready
* Closes [#2692](https://github.com/NCCE/teachcomputing.org-issues/issues/2692)

## Review progress:

- [x] Browser tested
- [ ] Tech review completed

## What's changed?

- Ensure the query for user enrolment checks that the enrolment is in a state of `:unenrolled` as well as whether the enrolment record is present in the first place.
