### PR TITLE
Move "Implement selected key stage 3 Teach Computing Curriculum resources" from section 2 to 3

### DIFF
--- a/app/models/programme_activity_grouping.rb
+++ b/app/models/programme_activity_grouping.rb
@@ -58,6 +58,34 @@ class ProgrammeActivityGrouping < ApplicationRecord
     end.to_h
   end
 
+  # Move "Implement selected key stage 3 Teach Computing Curriculum resources" from section 2
+  # to section 3 and update the #required_for_completion value on the old grouping
+  def self.move_i_belong_section_from_2_to_3
+    # Perform the move of the activity to the new grouping
+    programme = Programme.find_by(slug: "i-belong")
+    raise "Programme could not be found" if programme.blank?
+
+    potential_groupings = programme.programme_activity_groupings.community
+    raise "There are more than 2 available groupings for the moved activity" unless potential_groupings.size == 2
+
+    activity = programme.activities.find_by(title: "Implement selected key stage 3 Teach Computing Curriculum resources")
+    raise "Activity could not be found" if activity.blank?
+
+    programme_activity = ProgrammeActivity.find_by(activity_id: activity.id)
+    raise "Programme activity could not be found" if programme_activity.blank?
+
+    original_grouping = programme_activity.programme_activity_grouping
+    raise "Current grouping could not be found" if original_grouping.blank?
+
+    new_grouping = potential_groupings.where.not(id: original_grouping.id).first
+    raise "New grouping could not be determined" if new_grouping.blank?
+
+    programme_activity.update!(programme_activity_grouping_id: new_grouping.id)
+
+    # Update the original grouping to only require 2 completed activities
+    original_grouping.update!(required_for_completion: 2)
+  end
+
   protected def fetch_users_achievement_activity_ids(users:)
     Achievement
       .in_state(:complete)

--- a/app/models/programme_activity_grouping.rb
+++ b/app/models/programme_activity_grouping.rb
@@ -65,20 +65,17 @@ class ProgrammeActivityGrouping < ApplicationRecord
     programme = Programme.find_by(slug: "i-belong")
     raise "Programme could not be found" if programme.blank?
 
-    potential_groupings = programme.programme_activity_groupings.community
-    raise "There are more than 2 available groupings for the moved activity" unless potential_groupings.size == 2
-
     activity = programme.activities.find_by(title: "Implement selected key stage 3 Teach Computing Curriculum resources")
     raise "Activity could not be found" if activity.blank?
 
-    programme_activity = ProgrammeActivity.find_by(activity_id: activity.id)
+    programme_activity = programme.programme_activities.find_by(activity_id: activity.id)
     raise "Programme activity could not be found" if programme_activity.blank?
 
-    original_grouping = programme_activity.programme_activity_grouping
+    original_grouping = programme.programme_activity_groupings.find_by(sort_key: 3)
     raise "Current grouping could not be found" if original_grouping.blank?
 
-    new_grouping = potential_groupings.where.not(id: original_grouping.id).first
-    raise "New grouping could not be determined" if new_grouping.blank?
+    new_grouping = programme.programme_activity_groupings.find_by(sort_key: 4)
+    raise "New grouping could not be found" if new_grouping.blank?
 
     programme_activity.update!(programme_activity_grouping_id: new_grouping.id)
 

--- a/db/seeds/programme_activity_groupings/i_belong.rb
+++ b/db/seeds/programme_activity_groupings/i_belong.rb
@@ -26,7 +26,7 @@ end.save!
 i_belong.programme_activity_groupings.find_or_initialize_by(sort_key: 3).tap do |group|
   group.title = "<strong>Access</strong> and <strong>complete all</strong> of the following activities"
   group.sort_key = 3
-  group.required_for_completion = 3
+  group.required_for_completion = 2
   group.programme_id = i_belong.id
   group.progress_bar_title = "<strong>Access</strong> resources to support you"
   group.community = true
@@ -35,8 +35,7 @@ i_belong.programme_activity_groupings.find_or_initialize_by(sort_key: 3).tap do 
 
   activities = [
     {slug: "download-and-use-the-i-belong-handbook", legacy: false},
-    {slug: "request-your-i-belong-in-computer-science-posters", legacy: false},
-    {slug: "implement-selected-key-stage-3-teach-computing-curriculum-resources", legacy: false}
+    {slug: "request-your-i-belong-in-computer-science-posters", legacy: false}
   ]
 
   activities.each_with_index do |activity, index|
@@ -60,7 +59,8 @@ i_belong.programme_activity_groupings.find_or_initialize_by(sort_key: 4).tap do 
     {slug: "start-or-deliver-a-computing-related-club", legacy: true},
     {slug: "host-a-computing-stem-ambassador-activity", legacy: false},
     {slug: "participate-in-a-computing-related-competition", legacy: false},
-    {slug: "any-other-activity-which-aligns-with-recommendations-from-the-handbook", legacy: false}
+    {slug: "any-other-activity-which-aligns-with-recommendations-from-the-handbook", legacy: false},
+    {slug: "implement-selected-key-stage-3-teach-computing-curriculum-resources", legacy: false}
   ]
 
   activities.each_with_index do |activity, index|


### PR DESCRIPTION
## Status

* Current Status: WIP
* Review App link(s): ...
* Closes [#2712](https://github.com/NCCE/teachcomputing.org-issues/issues/2712)

## Review progress:

- [x] Browser tested (although could do with further testing)
- [x] Tech review completed

## What's changed?

Moved the affected activity with title "Implement selected key stage 3 Teach Computing Curriculum resources" from its original programme activity grouping (which places it under section 2 in the UI) to its second programme activity grouping (placing it under 3 in the UI). Script then updates the `required_for_completion` attribute on the original grouping from 3 to 2.

## Steps to perform after deploying to production

- Run the method on `ProgrammeActivityGrouping.move_i_belong_section_from_2_to_3` to perform the above changes
- Remove this method in a separate PR
