### PR TITLE
Add traffic light icons to administrate for objectives

### DIFF
--- a/app/assets/stylesheets/administrate/application.scss
+++ b/app/assets/stylesheets/administrate/application.scss
@@ -27,6 +27,7 @@
 
 @import "administrate/fields/audited_json_viewer";
 @import "administrate/fields/achievement_list";
+@import "administrate/fields/state_picker";
 
 @import "administrate/utilities/text-color";
 @import "administrate/utilities/margin";

--- a/app/assets/stylesheets/administrate/fields/state_picker.scss
+++ b/app/assets/stylesheets/administrate/fields/state_picker.scss
@@ -1,0 +1,32 @@
+.administrate_objectives-row {
+  display: flex;
+  gap: 6px;
+  margin-top: 3px;
+}
+
+.administrate_objective-circle {
+  display: inline-block;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  position: relative;
+  cursor: pointer;
+  border: 1px solid #333;
+}
+
+.administrate_objective-circle:hover::after {
+  content: attr(title);
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #333;
+  color: #fff;
+  padding: 5px;
+  border-radius: 3px;
+  min-width: 200px;
+  max-width: 300px;
+  white-space: normal;
+  word-wrap: break-word;
+  z-index: 1;
+}

--- a/app/fields/state_picker_field.rb
+++ b/app/fields/state_picker_field.rb
@@ -12,4 +12,8 @@ class StatePickerField < Administrate::Field::Base
   def to_s
     data.to_s
   end
+
+  def objectives
+    @objectives ||= resource.programme.programme_objectives
+  end
 end

--- a/app/lib/programme_objectives/assessment_pass_required.rb
+++ b/app/lib/programme_objectives/assessment_pass_required.rb
@@ -9,6 +9,10 @@ class ProgrammeObjectives::AssessmentPassRequired
     assessment.latest_attempt_for(user:)&.in_state?(:passed) || false
   end
 
+  def progress_bar_title
+    "Programme Assessment"
+  end
+
   def objective_displayed_in_progress_bar?
     false
   end

--- a/app/views/fields/state_picker_field/_index.html.erb
+++ b/app/views/fields/state_picker_field/_index.html.erb
@@ -1,1 +1,11 @@
 <%= field.to_s %>
+
+<% user = field.resource.user %>
+<div class="administrate_objectives-row">
+  <% field.objectives.each_with_index do |objective, idx| %>
+    <% color = objective&.user_complete?(user) ? 'green' : 'red' %>
+    <% label = strip_tags(objective.progress_bar_title.upcase_first) %>
+
+    <span class="administrate_objective-circle" style="background-color: <%= color %>;" title="<%= label %>"></span>
+  <% end %>
+</div>


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App link(s): ...
* Closes [#2670](https://github.com/NCCE/teachcomputing.org-issues/issues/2670)

## Review progress:

- [x] Browser tested
- [ ] Front-end review completed
- [x] Tech review completed

## What's changed?

- Addition of traffic light system for objective completion (albeit only where objectives are tracked / used to indicate progress) to the administrate interface (/admin)
![Pasted Graphic 1](https://github.com/NCCE/teachcomputing.org/assets/105515730/0d3b8e1e-4c82-499f-8a92-683ed1c9f555)

