### PR TITLE
Update interface for assessment attempts on user view in Adminstrate 

### DIFF
--- a/app/dashboards/assessment_attempt_dashboard.rb
+++ b/app/dashboards/assessment_attempt_dashboard.rb
@@ -7,9 +7,9 @@ class AssessmentAttemptDashboard < BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     user: Field::BelongsTo,
-    # assessment: Field::BelongsTo,
     current_state: Field::String.with_options(searchable: false),
     id: Field::String,
+    assessment: AssessmentDetailsField,
     created_at: FORMATTED_DATE_TIME,
     updated_at: FORMATTED_DATE_TIME
   }.freeze
@@ -21,7 +21,9 @@ class AssessmentAttemptDashboard < BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
     id
+    user
     current_state
+    assessment
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -32,6 +34,7 @@ class AssessmentAttemptDashboard < BaseDashboard
     created_at
     updated_at
     current_state
+    assessment
   ].freeze
 
   # FORM_ATTRIBUTES

--- a/app/fields/assessment_details_field.rb
+++ b/app/fields/assessment_details_field.rb
@@ -1,0 +1,38 @@
+require "administrate/field/base"
+
+class AssessmentDetailsField < Administrate::Field::Base
+  def assessment_display
+    "Name: #{assessment.programme.title} assessment (created #{assessment_created_at})"
+  end
+
+  def attempted_at_display
+    "State last changed on: #{state_last_changed_at}"
+  end
+
+  def percentage_score_display
+    "Score: #{percentage_score}"
+  end
+
+  private
+
+  def assessment_attempt
+    @assessment_attempt ||= resource
+  end
+
+  def assessment
+    @assessment ||= assessment_attempt.assessment
+  end
+
+  def assessment_created_at
+    assessment.created_at.strftime("%d/%m/%Y %H:%M")
+  end
+
+  def state_last_changed_at
+    assessment_attempt.last_transition&.created_at&.strftime("%d/%m/%Y %H:%M") || "No changes yet"
+  end
+
+  def percentage_score
+    score_data = assessment_attempt.last_transition&.metadata&.dig("percentage").presence
+    score_data ? "#{score_data}%" : "-"
+  end
+end

--- a/app/views/fields/assessment_details_field/_index.html.erb
+++ b/app/views/fields/assessment_details_field/_index.html.erb
@@ -1,0 +1,5 @@
+<%= field.assessment_display %>
+<br>
+<%= field.attempted_at_display %>
+<br>
+<%= field.percentage_score_display %>

--- a/app/views/fields/assessment_details_field/_show.html.erb
+++ b/app/views/fields/assessment_details_field/_show.html.erb
@@ -1,0 +1,5 @@
+<%= field.assessment_display %>
+<br>
+<%= field.attempted_at_display %>
+<br>
+<%= field.percentage_score_display %>


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2722

## Review progress:

- [x] Browser tested
- [x] Tech review completed

## What's changed?

- Updated the Admin UI for Assessment Attempts to include information on the assessment:
-- Assessment name
-- When assessment was created
-- When attempt state was last transitioned
-- Attempt percentage score
