### PR TITLE
Tests/improve coverage

### DIFF
--- a/app/models/achievement_transition.rb
+++ b/app/models/achievement_transition.rb
@@ -11,6 +11,6 @@ class AchievementTransition < ApplicationRecord
     last_transition = achievement.achievement_transitions.order(:sort_key).last
     return if last_transition.blank?
 
-    last_transition.update(:most_recent, true)
+    last_transition.update(most_recent: true)
   end
 end

--- a/app/models/assessment_attempt_transition.rb
+++ b/app/models/assessment_attempt_transition.rb
@@ -11,6 +11,6 @@ class AssessmentAttemptTransition < ApplicationRecord
     last_transition = assessment_attempt.assessment_attempt_transitions.order(:sort_key).last
     return if last_transition.blank?
 
-    last_transition.update_column(:most_recent, true)
+    last_transition.update(most_recent: true)
   end
 end

--- a/app/models/assessment_attempt_transition.rb
+++ b/app/models/assessment_attempt_transition.rb
@@ -11,6 +11,6 @@ class AssessmentAttemptTransition < ApplicationRecord
     last_transition = assessment_attempt.assessment_attempt_transitions.order(:sort_key).last
     return if last_transition.blank?
 
-    last_transition.update(:most_recent, true)
+    last_transition.update_column(:most_recent, true)
   end
 end

--- a/app/models/questionnaire_response_transition.rb
+++ b/app/models/questionnaire_response_transition.rb
@@ -11,6 +11,6 @@ class QuestionnaireResponseTransition < ApplicationRecord
     last_transition = questionnaire_response.questionnaire_response_transitions.order(:sort_key).last
     return if last_transition.blank?
 
-    last_transition.update(:most_recent, true)
+    last_transition.update_column(:most_recent, true)
   end
 end

--- a/app/models/questionnaire_response_transition.rb
+++ b/app/models/questionnaire_response_transition.rb
@@ -11,6 +11,6 @@ class QuestionnaireResponseTransition < ApplicationRecord
     last_transition = questionnaire_response.questionnaire_response_transitions.order(:sort_key).last
     return if last_transition.blank?
 
-    last_transition.update_column(:most_recent, true)
+    last_transition.update(most_recent: true)
   end
 end

--- a/app/models/user_programme_enrolment_transition.rb
+++ b/app/models/user_programme_enrolment_transition.rb
@@ -11,6 +11,6 @@ class UserProgrammeEnrolmentTransition < ApplicationRecord
     last_transition = user_programme_enrolment.user_programme_enrolment_transitions.order(:sort_key).last
     return if last_transition.blank?
 
-    last_transition.update_column(:most_recent, true)
+    last_transition.update(most_recent: true)
   end
 end

--- a/spec/factories/assessment_attempt_transition.rb
+++ b/spec/factories/assessment_attempt_transition.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :assessment_attempt_transition do
-    association :assessment_attempt
+    assessment_attempt
     to_state { "commenced" }
     sort_key { 1 }
     most_recent { false }

--- a/spec/factories/assessment_attempt_transition.rb
+++ b/spec/factories/assessment_attempt_transition.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+  factory :assessment_attempt_transition do
+    association :assessment_attempt
+    to_state { "commenced" }
+    sort_key { 1 }
+    most_recent { false }
+
+    trait :most_recent do
+      most_recent { true }
+    end
+
+    trait :passed do
+      to_state { "passed" }
+    end
+
+    trait :failed do
+      to_state { "failed" }
+    end
+  end
+end

--- a/spec/factories/questionnaire_response_transition.rb
+++ b/spec/factories/questionnaire_response_transition.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :questionnaire_response_transition do
-    association :questionnaire_response
+    questionnaire_response
     to_state { "in_progress" }
     sort_key { 1 }
     most_recent { false }

--- a/spec/factories/questionnaire_response_transition.rb
+++ b/spec/factories/questionnaire_response_transition.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :questionnaire_response_transition do
+    association :questionnaire_response
+    to_state { "in_progress" }
+    sort_key { 1 }
+    most_recent { false }
+
+    trait :most_recent do
+      most_recent { true }
+    end
+
+    trait :complete do
+      to_state { "complete" }
+    end
+  end
+end

--- a/spec/factories/user_programme_enrolment_transition.rb
+++ b/spec/factories/user_programme_enrolment_transition.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user_programme_enrolment_transition do
-    association :user_programme_enrolment
+    user_programme_enrolment
     to_state { "enrolled" }
     sort_key { 1 }
     most_recent { false }

--- a/spec/factories/user_programme_enrolment_transition.rb
+++ b/spec/factories/user_programme_enrolment_transition.rb
@@ -1,0 +1,24 @@
+FactoryBot.define do
+  factory :user_programme_enrolment_transition do
+    association :user_programme_enrolment
+    to_state { "enrolled" }
+    sort_key { 1 }
+    most_recent { false }
+
+    trait :most_recent do
+      most_recent { true }
+    end
+
+    trait :unenrolled do
+      to_state { "unenrolled" }
+    end
+
+    trait :pending do
+      to_state { "pending" }
+    end
+
+    trait :complete do
+      to_state { "complete" }
+    end
+  end
+end

--- a/spec/factories/user_report_entry.rb
+++ b/spec/factories/user_report_entry.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :user_report_entry do
+    sequence(:programme_slug) { |n| "programme-#{n}" }
+    sequence(:user_stem_user_id) { |n| "user-stem-user-id-#{n}" }
+
+    user_email { "user@example.com" }
+    user_enrolled { true }
+    enrolled_at { Time.zone.now }
+    last_active_at { Time.zone.now - 1.day }
+    completed_cpd_component { false }
+    completed_certificate { false }
+    pending_certificate { false }
+    completed_first_community_component { false }
+    completed_second_community_component { false }
+  end
+end

--- a/spec/models/achievement_spec.rb
+++ b/spec/models/achievement_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Achievement, type: :model do
     it { is_expected.to belong_to(:activity) }
     it { is_expected.to belong_to(:user) }
     it { is_expected.to have_many(:achievement_transitions) }
+    it { is_expected.to have_one_attached(:supporting_evidence) }
   end
 
   describe "validations" do
@@ -149,6 +150,28 @@ RSpec.describe Achievement, type: :model do
 
     it "omits the achievements which don't match the provider" do
       expect(Achievement.with_provider("stem-learning")).not_to include(future_learn_achievement)
+    end
+  end
+
+  describe "#belonging_to_programme?" do
+    context "when programme is nil" do
+      it "returns false" do
+        expect(achievement.belonging_to_programme?(nil)).to be false
+      end
+    end
+
+    context "when programme is provided" do
+      before do
+        programme_activity
+      end
+
+      it "returns true if the activity belongs to the programme" do
+        expect(achievement.belonging_to_programme?(programme)).to be true
+      end
+
+      it "returns false if the activity does not belong to the programme" do
+        expect(achievement2.belonging_to_programme?(programme)).to be false
+      end
     end
   end
 

--- a/spec/models/assessment_attempt_spec.rb
+++ b/spec/models/assessment_attempt_spec.rb
@@ -22,11 +22,36 @@ RSpec.describe AssessmentAttempt do
     end
   end
 
+  describe "state" do
+    it "initializes with the correct initial state" do
+      expect(AssessmentAttempt.in_state(:commenced)).to include(assessment_attempt)
+    end
+
+    it "transitions from commenced to passed" do
+      assessment_attempt.state_machine.transition_to(:passed)
+      expect(AssessmentAttempt.in_state(:passed)).to include(assessment_attempt)
+    end
+
+    it "transitions from commenced to failed" do
+      assessment_attempt.state_machine.transition_to(:failed)
+      expect(AssessmentAttempt.in_state(:failed)).to include(assessment_attempt)
+    end
+  end
+
   describe "delegate methods" do
     it { is_expected.to delegate_method(:can_transition_to?).to(:state_machine).as(:can_transition_to?) }
     it { is_expected.to delegate_method(:current_state).to(:state_machine).as(:current_state) }
     it { is_expected.to delegate_method(:transition_to).to(:state_machine).as(:transition_to) }
     it { is_expected.to delegate_method(:last_transition).to(:state_machine).as(:last_transition) }
+    it { is_expected.to delegate_method(:in_state?).to(:state_machine).as(:in_state?) }
+  end
+
+  describe "after transition callbacks" do
+    it "enqueues IssueBadgeJob after transitioning to passed" do
+      expect {
+        assessment_attempt.state_machine.transition_to(:passed)
+      }.to have_enqueued_job(IssueBadgeJob).with(assessment_attempt: assessment_attempt)
+    end
   end
 
   describe "#for_user" do

--- a/spec/models/assessment_attempt_transition_spec.rb
+++ b/spec/models/assessment_attempt_transition_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe AssessmentAttemptTransition, type: :model do
+  let(:assessment) { create(:assessment) }
+  let(:assessment_attempt) { create(:assessment_attempt, assessment_id: assessment.id) }
+  let!(:transition1) { create(:assessment_attempt_transition, assessment_attempt: assessment_attempt, sort_key: 1, most_recent: false, to_state: "commenced") }
+  let!(:transition2) { create(:assessment_attempt_transition, assessment_attempt: assessment_attempt, sort_key: 2, most_recent: true, to_state: "passed") }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:assessment_attempt) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_inclusion_of(:to_state).in_array(StateMachines::AssessmentAttemptStateMachine.states) }
+  end
+
+  describe "callbacks" do
+    context "after_destroy" do
+      it "updates the most recent transition if the destroyed transition was the most recent" do
+        transition2.destroy
+
+        transition1.reload
+        expect(transition1.most_recent).to be true
+      end
+
+      it "does not update the most recent transition if the destroyed transition was not the most recent" do
+        transition1.destroy
+
+        transition2.reload
+        expect(transition2.most_recent).to be true
+      end
+    end
+  end
+end

--- a/spec/models/programme_complete_counter_spec.rb
+++ b/spec/models/programme_complete_counter_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe ProgrammeCompleteCounter, type: :model do
       end
 
       it "sets Sentry tags with the programme" do
-        programme_complete_counter.get_next_number rescue nil
+        programme_complete_counter.get_next_number rescue nil # standard:disable Style/RescueModifier
         expect(Sentry).to have_received(:set_tags).with(programme: programme)
       end
 
       it "captures the exception with Sentry" do
-        programme_complete_counter.get_next_number rescue nil
+        programme_complete_counter.get_next_number rescue nil # standard:disable Style/RescueModifier
         expect(Sentry).to have_received(:capture_exception).with(instance_of(ActiveRecord::ActiveRecordError))
       end
     end

--- a/spec/models/questionnaire_response_spec.rb
+++ b/spec/models/questionnaire_response_spec.rb
@@ -43,4 +43,46 @@ RSpec.describe QuestionnaireResponse, type: :model do
       expect(response.score).to eq(57)
     end
   end
+
+  describe "state" do
+    it "initializes with the correct initial state" do
+      expect(QuestionnaireResponse.in_state(:in_progress)).to include(questionnaire_response)
+    end
+
+    it "transitions from in_progress to complete" do
+      questionnaire_response.state_machine.transition_to(:complete)
+      expect(QuestionnaireResponse.in_state(:complete)).to include(questionnaire_response)
+    end
+  end
+
+  describe "delegate methods" do
+    it { is_expected.to delegate_method(:can_transition_to?).to(:state_machine).as(:can_transition_to?) }
+    it { is_expected.to delegate_method(:current_state).to(:state_machine).as(:current_state) }
+    it { is_expected.to delegate_method(:transition_to).to(:state_machine).as(:transition_to) }
+    it { is_expected.to delegate_method(:last_transition).to(:state_machine).as(:last_transition) }
+  end
+
+  describe "#complete!" do
+    it "when state is not complete" do
+      expect { questionnaire_response.complete! }
+        .to change(questionnaire_response, :complete?)
+        .from(false).to(true)
+    end
+
+    it "when state is complete" do
+      questionnaire_response.transition_to(:complete)
+      expect(questionnaire_response.complete!).to be false
+    end
+  end
+
+  describe "#complete?" do
+    it "when state is not complete" do
+      expect(questionnaire_response.complete?).to be false
+    end
+
+    it "when state is complete" do
+      questionnaire_response.transition_to(:complete)
+      expect(questionnaire_response.complete?).to be true
+    end
+  end
 end

--- a/spec/models/questionnaire_response_transition_spec.rb
+++ b/spec/models/questionnaire_response_transition_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe QuestionnaireResponseTransition, type: :model do
+  let(:questionnaire_response) { create(:questionnaire_response) }
+  let!(:transition1) { create(:questionnaire_response_transition, questionnaire_response: questionnaire_response, sort_key: 1, most_recent: false, to_state: "in_progress") }
+  let!(:transition2) { create(:questionnaire_response_transition, questionnaire_response: questionnaire_response, sort_key: 2, most_recent: true, to_state: "complete") }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:questionnaire_response) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_inclusion_of(:to_state).in_array(StateMachines::QuestionnaireResponseStateMachine.states) }
+  end
+
+  describe "callbacks" do
+    context "after_destroy" do
+      it "updates the most recent transition if the destroyed transition was the most recent" do
+        transition2.destroy
+
+        transition1.reload
+        expect(transition1.most_recent).to be true
+      end
+
+      it "does not update the most recent transition if the destroyed transition was not the most recent" do
+        transition1.destroy
+
+        transition2.reload
+        expect(transition2.most_recent).to be true
+      end
+    end
+  end
+end

--- a/spec/models/support_audits_spec.rb
+++ b/spec/models/support_audits_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe SupportAudit, type: :model do
+  let(:default_user) { create(:user, email: "admin@example.com") }
+  let(:user) { create(:user) }
+  let(:affected_user) { create(:user) }
+  let(:authoriser) { create(:authoriser) }
+  let(:support_audit) { build(:support_audit, user: nil, affected_user: nil, authoriser: authoriser) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:user).optional }
+    it { is_expected.to belong_to(:affected_user).class_name("User").with_foreign_key(:affected_user_id).optional }
+    it { is_expected.to belong_to(:authoriser).optional }
+  end
+
+  describe "validations" do
+    context "on update" do
+      before { support_audit.save! }
+
+      it "validates presence of authoriser_id" do
+        expect(support_audit).to validate_presence_of(:authoriser_id).on(:update)
+      end
+
+      it "validates presence of comment" do
+        expect(support_audit).to validate_presence_of(:comment).on(:update)
+      end
+    end
+  end
+
+  describe "callbacks" do
+    before do
+      allow(User).to receive(:find_by_email).and_return(default_user)
+    end
+    
+    context "before_create" do
+      it "adds actuating user details" do
+        support_audit.save!
+        expect(support_audit.user_id).to eq(default_user.id)
+        expect(support_audit.username).to eq(default_user.email)
+        expect(support_audit.user_type).to eq("teachcomputing")
+      end
+
+      it "adds affected user details" do
+        support_audit.auditable = user
+        support_audit.save!
+        expect(support_audit.affected_user_id).to eq(user.id)
+      end
+    end
+  end
+end

--- a/spec/models/support_audits_spec.rb
+++ b/spec/models/support_audits_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe SupportAudit, type: :model do
     before do
       allow(User).to receive(:find_by_email).and_return(default_user)
     end
-    
+
     context "before_create" do
       it "adds actuating user details" do
         support_audit.save!

--- a/spec/models/user_programme_enrolment_transition_spec.rb
+++ b/spec/models/user_programme_enrolment_transition_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe UserProgrammeEnrolmentTransition, type: :model do
+  let(:user) { create(:user) }
+  let(:cs_accelerator) { create(:cs_accelerator) }
+  let(:cs_accelerator_enrolment) { create(:user_programme_enrolment, user: user, programme: cs_accelerator) }
+  let!(:transition1) { create(:user_programme_enrolment_transition, user_programme_enrolment: cs_accelerator_enrolment, sort_key: 1, most_recent: false, to_state: "enrolled") }
+  let!(:transition2) { create(:user_programme_enrolment_transition, user_programme_enrolment: cs_accelerator_enrolment, sort_key: 2, most_recent: true, to_state: "complete") }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:user_programme_enrolment) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_inclusion_of(:to_state).in_array(StateMachines::UserProgrammeEnrolmentStateMachine.states) }
+  end
+
+  describe "callbacks" do
+    context "after_destroy" do
+      it "updates the most recent transition if the destroyed transition was the most recent" do
+        transition2.destroy
+
+        transition1.reload
+        expect(transition1.most_recent).to be true
+      end
+
+      it "does not update the most recent transition if the destroyed transition was not the most recent" do
+        transition1.destroy
+
+        transition2.reload
+        expect(transition2.most_recent).to be true
+      end
+    end
+  end
+end

--- a/spec/models/user_report_entry_spec.rb
+++ b/spec/models/user_report_entry_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe UserReportEntry, type: :model do
+  describe "factory" do
+    it "has a valid factory" do
+      expect(build(:user_report_entry)).to be_valid
+    end
+  end
+end

--- a/spec/requests/admin/root_spec.rb
+++ b/spec/requests/admin/root_spec.rb
@@ -1,29 +1,55 @@
 require "rails_helper"
 
-RSpec.describe "Admin root request spec" do
-  context "when authenticated with CF access" do
-    it "redirects to the pathway index route" do
-      allow_any_instance_of(Admin::ApplicationController).to receive(:authenticate_admin).and_return("user@example.com")
+RSpec.describe "Admin Root Request Spec" do
+  let(:jwt_payload) { {"email" => "admin@example.com"} }
+  let(:jwt_token) { JWT.encode(jwt_payload, nil, "none") }
 
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with("BYPASS_ADMINISTRATE_CF_AUTH", anything).and_return("false")
+  end
+
+  context "when BYPASS_ADMINISTRATE_CF_AUTH is true and not in production" do
+    before do
+      allow(ENV).to receive(:fetch).with("BYPASS_ADMINISTRATE_CF_AUTH", anything).and_return("true")
+      allow(Rails.env).to receive(:production?).and_return(false)
+    end
+
+    it "allows access to admin root path" do
       get admin_root_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
 
+  context "when authenticated with CF access" do
+    let(:headers) { {"Cookie" => "CF_Authorization=#{jwt_token}"} }
+
+    it "returns OK status for admin root path" do
+      get admin_root_path, headers: headers
       expect(response).to have_http_status(:ok)
     end
 
     it "asks client not to cache potentially sensitive pages" do
-      allow_any_instance_of(Admin::ApplicationController).to receive(:authenticate_admin).and_return("user@example.com")
+      get admin_root_path, headers: headers
+      expect(response.headers["Cache-Control"]).to eq("no-store")
+    end
 
-      get admin_root_path
-
-      expect(response.headers["cache-control"]).to eq("no-store")
+    it "decodes the cookie and sets @admin_email" do
+      get admin_root_path, headers: headers
+      controller = response.request.env["action_controller.instance"]
+      expect(controller.instance_variable_get(:@admin_email)).to eq("admin@example.com")
     end
   end
 
   context "without CF access authentication" do
     it "redirects to the root of the application" do
       get admin_root_path
-
       expect(response).to redirect_to(root_path)
+    end
+
+    it "sets a flash error message" do
+      get admin_root_path
+      expect(flash[:error]).to eq("Whoops something went wrong")
     end
   end
 end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Admin::UsersController do
       allow(User).to receive(:find_by_email).and_return(admin_user)
       allow(Support::UserUtilities).to receive(:reset_tests).and_return([])
     end
-    
+
     context "when reset tests result is empty" do
       it "calls the reset service and redirects back with a notice" do
         get admin_user_perform_reset_path(user_id: user.id)

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe Admin::UsersController do
+  let(:user) { create(:user) }
+  let(:admin_user) { create(:user, email: "admin@example.com") }
+
+  describe "GET #perform_sync" do
+    before do
+      allow_any_instance_of(Admin::ApplicationController).to receive(:authenticate_admin).and_return("admin@example.com")
+      allow(Support::UserUtilities).to receive(:sync).and_return("success")
+    end
+
+    it "calls the sync service and redirects back with a notice" do
+      get admin_user_perform_sync_path(user_id: user.id)
+
+      expect(response).to redirect_to(admin_users_path(user_id: user.id))
+      expect(flash[:notice]).to eq("Sync complete")
+    end
+  end
+
+  describe "GET #perform_reset_tests" do
+    before do
+      allow_any_instance_of(Admin::ApplicationController).to receive(:authenticate_admin).and_return("admin@example.com")
+      allow(User).to receive(:find_by_email).and_return(admin_user)
+      allow(Support::UserUtilities).to receive(:reset_tests).and_return([])
+    end
+    
+    context "when reset tests result is empty" do
+      it "calls the reset service and redirects back with a notice" do
+        get admin_user_perform_reset_path(user_id: user.id)
+
+        expect(response).to redirect_to(admin_users_path(user.id))
+        expect(flash[:notice]).to eq("Nothing to do!")
+      end
+    end
+
+    context "when reset tests result is not empty" do
+      let(:support_audit) { create(:support_audit, user: admin_user) }
+
+      before do
+        allow(Support::UserUtilities).to receive(:reset_tests).and_return(["result"])
+        allow(SupportAudit).to receive(:where).with(user_id: admin_user.id).and_return([support_audit])
+      end
+
+      it "calls the reset service and redirects to edit the last support audit" do
+        get admin_user_perform_reset_path(user_id: user.id)
+
+        expect(response).to redirect_to(edit_admin_support_audit_path(id: support_audit.id))
+      end
+    end
+  end
+end

--- a/spec/requests/curriculum/file_redirect/redirect_to_file_spec.rb
+++ b/spec/requests/curriculum/file_redirect/redirect_to_file_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Curriculum::FileRedirectController do
+  describe "GET #redirect_to_file" do
+    let(:slug) { "primary-journey-progress-icon" }
+    let(:file_url) { "http://curriculum.teachcomputing.org/rails/active_storage/blobs/redirect/test_icon.jpeg" }
+    let(:file_upload) { OpenStruct.new(file: file_url) }
+
+    context "when the file exists" do
+      before do
+        allow(CurriculumClient::Queries::FileUpload).to receive(:one).and_return(OpenStruct.new(file_upload: file_upload))
+      end
+
+      it "redirects to the file URL" do
+        get curriculum_file_redirect_path(slug: slug)
+
+        expect(response).to redirect_to(file_url)
+      end
+    end
+
+    context "when the file does not exist" do
+      before do
+        allow(CurriculumClient::Queries::FileUpload).to receive(:one).and_return(OpenStruct.new(file_upload: nil))
+      end
+
+      it "returns a 404 status with a 'File not found' message" do
+        get curriculum_file_redirect_path(slug: slug)
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.body).to include("File not found")
+      end
+    end
+  end
+end

--- a/spec/requests/feedback/create_spec.rb
+++ b/spec/requests/feedback/create_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe FeedbackController do
+  let(:user) { create(:user) }
+  let(:feedback_params) { { area: "Test area", comment: "Test feedback comment" } }
+
+  before do
+    allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
+  end
+
+  describe "POST #create" do
+    context "when feedback is successfully submitted" do
+      it "saves the feedback and redirects back with a success notice" do        
+        post feedback_path(feedback_comment: feedback_params), headers: { "HTTP_REFERER" => root_path }
+
+        expect(FeedbackComment.last.comment).to eq("Test feedback comment")
+        expect(flash[:notice]).to eq("Your feedback was successfully submitted")
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when feedback submission fails" do
+      before do
+        allow_any_instance_of(FeedbackComment).to receive(:save).and_return(false)
+      end
+
+      it "does not save the feedback and redirects back with an error notice" do
+        post feedback_path(feedback_comment: feedback_params), headers: { "HTTP_REFERER" => root_path }
+
+        expect(FeedbackComment.last).to be_nil
+        expect(flash[:error]).to eq("There was a problem submitting feedback please try again")
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/requests/feedback/create_spec.rb
+++ b/spec/requests/feedback/create_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe FeedbackController do
   let(:user) { create(:user) }
-  let(:feedback_params) { { area: "Test area", comment: "Test feedback comment" } }
+  let(:feedback_params) { {area: "Test area", comment: "Test feedback comment"} }
 
   before do
     allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
@@ -10,8 +10,8 @@ RSpec.describe FeedbackController do
 
   describe "POST #create" do
     context "when feedback is successfully submitted" do
-      it "saves the feedback and redirects back with a success notice" do        
-        post feedback_path(feedback_comment: feedback_params), headers: { "HTTP_REFERER" => root_path }
+      it "saves the feedback and redirects back with a success notice" do
+        post feedback_path(feedback_comment: feedback_params), headers: {"HTTP_REFERER" => root_path}
 
         expect(FeedbackComment.last.comment).to eq("Test feedback comment")
         expect(flash[:notice]).to eq("Your feedback was successfully submitted")
@@ -25,7 +25,7 @@ RSpec.describe FeedbackController do
       end
 
       it "does not save the feedback and redirects back with an error notice" do
-        post feedback_path(feedback_comment: feedback_params), headers: { "HTTP_REFERER" => root_path }
+        post feedback_path(feedback_comment: feedback_params), headers: {"HTTP_REFERER" => root_path}
 
         expect(FeedbackComment.last).to be_nil
         expect(flash[:error]).to eq("There was a problem submitting feedback please try again")

--- a/spec/requests/pages/i_belong_spec.rb
+++ b/spec/requests/pages/i_belong_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe PagesController do
+  include ApplicationHelper
+
+  let(:user) { create(:user) }
+  let(:programme) { create(:i_belong) }
+  let!(:enrolment) { create(:user_programme_enrolment, user: user, programme: programme) }
+
+  before do
+    allow(Programme).to receive(:i_belong).and_return(programme)
+  end
+
+  describe "GET #i_belong" do
+    context "when user is enrolled" do
+      before do
+        allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
+        allow(programme).to receive(:user_enrolled?).with(user).and_return(true)
+        get about_i_belong_path
+      end
+
+      it "renders the enrolled template with correct locals" do
+        expect(response).to render_template("pages/enrolment/i_belong")
+        expect(response.body).to include("https://forms.office.com/e/x1FMMzjxhg")
+        expect(response.body).to include("Request your posters")
+        expect(response.body).to include("Download your handbook")
+      end
+    end
+
+    context "when user is unenrolled" do
+      before do
+        allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
+        allow(programme).to receive(:user_enrolled?).with(user).and_return(false)
+        allow(programme).to receive(:enrol_path).and_return("/enrol_path")
+        get about_i_belong_path
+      end
+
+      it "renders the unenrolled template with correct locals" do
+        expect(response).to render_template("pages/enrolment/i_belong")
+        expect(response.body).to include("/enrol_path")
+        expect(response.body).to include("Enrol to request")
+        expect(response.body).to include("Enrol to download")
+      end
+    end
+
+    context "when user is a guest" do
+      before do
+        get about_i_belong_path
+      end
+
+      it "renders the guest template with correct locals" do
+        expect(response).to render_template("pages/enrolment/i_belong")
+        expect(response.body).to include(auth_url)
+        expect(response.body).to include("Log in to request")
+        expect(response.body).to include("Log in to download")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Status

* Current Status: Ready for Review
* Closes [#2719](https://github.com/NCCE/teachcomputing.org-issues/issues/2719)

## Review progress:

- [ ] Tech review completed

## What's changed?

- Additional tests added to improve coverage and focussing primarily on transitions
- Fixes for apparent issue with the `#update_most_recent` callbacks on two of the transition models
- [x] Model coverage at least orange
- [x] - Controller coverage at least orange (1 controller remains however...)
--- `Admin::AssessmentAttemptsController` - I don't think the controller `after_resource_updated_path` *can* be called because only the `#show` and `#index` actions appear to be implemented but wouldn't mind getting this confirmed