### PR TITLE
Fix to ensure title label can handle nil in admin

### DIFF
--- a/app/views/fields/state_picker_field/_index.html.erb
+++ b/app/views/fields/state_picker_field/_index.html.erb
@@ -3,6 +3,8 @@
 <% user = field.resource.user %>
 <div class="administrate_objectives-row">
   <% field.objectives.each_with_index do |objective, idx| %>
+    <% next if objective.progress_bar_title.blank? %>
+
     <% color = objective&.user_complete?(user) ? 'green' : 'red' %>
     <% label = strip_tags(objective.progress_bar_title.upcase_first) %>
 


### PR DESCRIPTION
## What's changed?

Fix to ensure that title label can handle nil in admin interface for user programme enrolments
