### PR TITLE
Fixing I Belong activities list after migration to new config

### DIFF
--- a/app/models/programme_activity_grouping.rb
+++ b/app/models/programme_activity_grouping.rb
@@ -58,31 +58,6 @@ class ProgrammeActivityGrouping < ApplicationRecord
     end.to_h
   end
 
-  # Move "Implement selected key stage 3 Teach Computing Curriculum resources" from section 2
-  # to section 3 and update the #required_for_completion value on the old grouping
-  def self.move_i_belong_section_from_2_to_3
-    # Perform the move of the activity to the new grouping
-    programme = Programme.find_by(slug: "i-belong")
-    raise "Programme could not be found" if programme.blank?
-
-    activity = programme.activities.find_by(title: "Implement selected key stage 3 Teach Computing Curriculum resources")
-    raise "Activity could not be found" if activity.blank?
-
-    programme_activity = programme.programme_activities.find_by(activity_id: activity.id)
-    raise "Programme activity could not be found" if programme_activity.blank?
-
-    original_grouping = programme.programme_activity_groupings.find_by(sort_key: 3)
-    raise "Current grouping could not be found" if original_grouping.blank?
-
-    new_grouping = programme.programme_activity_groupings.find_by(sort_key: 4)
-    raise "New grouping could not be found" if new_grouping.blank?
-
-    programme_activity.update!(programme_activity_grouping_id: new_grouping.id)
-
-    # Update the original grouping to only require 2 completed activities
-    original_grouping.update!(required_for_completion: 2)
-  end
-
   protected def fetch_users_achievement_activity_ids(users:)
     Achievement
       .in_state(:complete)

--- a/app/views/certificates/i_belong/_achievement_list.html.erb
+++ b/app/views/certificates/i_belong/_achievement_list.html.erb
@@ -33,6 +33,6 @@
     programme_activity_grouping: group,
     community_achievements: @community_achievements,
     tracking_category:,
-    number_to_show: 7
+    number_to_show: 6
   ) %>
 <% end %>

--- a/app/views/certificates/i_belong/_achievement_list.html.erb
+++ b/app/views/certificates/i_belong/_achievement_list.html.erb
@@ -33,6 +33,6 @@
     programme_activity_grouping: group,
     community_achievements: @community_achievements,
     tracking_category:,
-    number_to_show: 5
+    number_to_show: 7
   ) %>
 <% end %>

--- a/db/seeds/programme_activity_groupings/i_belong.rb
+++ b/db/seeds/programme_activity_groupings/i_belong.rb
@@ -54,13 +54,14 @@ i_belong.programme_activity_groupings.find_or_initialize_by(sort_key: 4).tap do 
   group.save!
 
   activities = [
-    {slug: "implement-selected-key-stage-3-teach-computing-curiculum-resources", legacy: false},
+    {slug: "implement-selected-key-stage-3-teach-computing-curriculum-resources", legacy: false},
     {slug: "participate-in-a-ncce-student-enrichment-activity", legacy: false},
     {slug: "provide-access-to-a-computing-related-extracurricular-club", legacy: false},
-    {slug: "start-or-deliver-a-computing-related-club", legacy: true},
     {slug: "host-a-computing-stem-ambassador-activity", legacy: false},
     {slug: "participate-in-a-computing-related-competition", legacy: false},
-    {slug: "any-other-activity-which-aligns-with-recommendations-from-the-handbook", legacy: false}
+    {slug: "any-other-activity-which-aligns-with-recommendations-from-the-handbook", legacy: false},
+
+    {slug: "start-or-deliver-a-computing-related-club", legacy: true}
   ]
 
   activities.each_with_index do |activity, index|

--- a/db/seeds/programme_activity_groupings/i_belong.rb
+++ b/db/seeds/programme_activity_groupings/i_belong.rb
@@ -54,13 +54,13 @@ i_belong.programme_activity_groupings.find_or_initialize_by(sort_key: 4).tap do 
   group.save!
 
   activities = [
+    {slug: "implement-selected-key-stage-3-teach-computing-curiculum-resources", legacy: false},
     {slug: "participate-in-a-ncce-student-enrichment-activity", legacy: false},
     {slug: "provide-access-to-a-computing-related-extracurricular-club", legacy: false},
     {slug: "start-or-deliver-a-computing-related-club", legacy: true},
     {slug: "host-a-computing-stem-ambassador-activity", legacy: false},
     {slug: "participate-in-a-computing-related-competition", legacy: false},
-    {slug: "any-other-activity-which-aligns-with-recommendations-from-the-handbook", legacy: false},
-    {slug: "implement-selected-key-stage-3-teach-computing-curriculum-resources", legacy: false}
+    {slug: "any-other-activity-which-aligns-with-recommendations-from-the-handbook", legacy: false}
   ]
 
   activities.each_with_index do |activity, index|

--- a/db/seeds/programme_activity_groupings/i_belong.rb
+++ b/db/seeds/programme_activity_groupings/i_belong.rb
@@ -61,6 +61,8 @@ i_belong.programme_activity_groupings.find_or_initialize_by(sort_key: 4).tap do 
     {slug: "participate-in-a-computing-related-competition", legacy: false},
     {slug: "any-other-activity-which-aligns-with-recommendations-from-the-handbook", legacy: false},
 
+    # Legacy
+
     {slug: "start-or-deliver-a-computing-related-club", legacy: true}
   ]
 


### PR DESCRIPTION
## Status

* Current Status: Ready for front-end / tech review
* Review App link(s): https://teachcomputing-pr-2074.herokuapp.com/
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2730

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Curriculum activity should now be at the top of the list
No activities should be in the drop down
Removed code needed to complete the migration as no longer needed