### PR TITLE
Remove reference to ActiveModel boolean cast in initializer

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -32,7 +32,7 @@ module OmniAuth::Strategies
     end
 
     def callback_url
-      return super if ActiveRecord::Type::Boolean.new.cast(ENV["BYPASS_OAUTH"])
+      return super if ENV.fetch("BYPASS_OAUTH", false) == "true"
 
       full_host + script_name + callback_path
     end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -58,7 +58,7 @@ end
 
 OmniAuth.config.logger = Rails.logger if Rails.env.development?
 
-if ActiveModel::Type::Boolean.new.cast(ENV.fetch("BYPASS_OAUTH", false))
+if ENV.fetch("BYPASS_OAUTH", false) == "true"
   puts "Bypassing OAuth login"
   OmniAuth.config.test_mode = true
   OmniAuth.config.mock_auth[:stem] = OmniAuth::AuthHash.new(


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2778

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Removed the use of the Rails Boolean casting method, instead we will just do a simple string comparison for the word true (lowercase) otherwise we will assume no bypass exists
- This is due to the call to this (outside of class in the omniauth initialiser) seems to intermittently cause the app to crash out, my guess is that sometimes it takes longer to boot rails and the initialiser is being run before the library code is loaded
- I have modified the second reference (inside the class) to keep consistency in the check methods, but that one doesnt appear to cause us an issue