### PR TITLE
Moving auto-enrolment to after_commit

### DIFF
--- a/app/models/achievement.rb
+++ b/app/models/achievement.rb
@@ -13,7 +13,7 @@ class Achievement < ApplicationRecord
   validates :supporting_evidence, blob: {content_type: :image}
   validates :user_id, uniqueness: {scope: [:activity_id]}
 
-  after_save :queue_auto_enrolment
+  after_commit :queue_auto_enrolment
 
   has_many :achievement_transitions, autosave: false, dependent: :destroy
 

--- a/spec/models/achievement_spec.rb
+++ b/spec/models/achievement_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Achievement, type: :model do
   end
 
   describe "callbacks" do
-    it { is_expected.to callback(:queue_auto_enrolment).after(:save) }
+    it { is_expected.to callback(:queue_auto_enrolment).after(:commit) }
   end
 
   describe "associations" do


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Resolves https://github.com/NCCE/teachcomputing.org-issues/issues/2788

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?
Moving auto-enrol call back to after_commit, as per recommendation from sidekiq to deal with race conditions [sidekiq notes](https://github.com/sidekiq/sidekiq/wiki/FAQ#why-am-i-seeing-a-lot-of-cant-find-modelname-with-id12345-errors-with-sidekiq)

