### PR TITLE
2783 sticky course filters look wonky on mobile

### DIFF
--- a/app/views/courses/_aside-filters.html.erb
+++ b/app/views/courses/_aside-filters.html.erb
@@ -1,9 +1,9 @@
 <% unless @course_filter.nil? %>
-<div class=" ncce-courses__filters-wrapper__title-desktop">
+<div class="ncce-courses__filters-wrapper__title-desktop">
   <h2 class="govuk-heading-s">Filter courses</h2>
 </div>
 <div class="ncce-aside ncce-aside--filters govuk-!-margin-top-2">
-  <div class=" ncce-courses__filters-wrapper__title-mobile govuk-!-margin-top-1">
+  <div class="ncce-courses__filters-wrapper__title-mobile govuk-!-margin-top-1">
     <h2 class="govuk-heading-s">Filter courses</h2>
   </div>
   <%= label_tag :date_range, 'Have a specific date?', class: 'govuk-body-m ncce-label--s' %>

--- a/app/views/courses/_aside-filters.html.erb
+++ b/app/views/courses/_aside-filters.html.erb
@@ -1,6 +1,11 @@
 <% unless @course_filter.nil? %>
-<h2 class="govuk-heading-s">Filter courses</h2>
+<div class=" ncce-courses__filters-wrapper__title-desktop">
+  <h2 class="govuk-heading-s">Filter courses</h2>
+</div>
 <div class="ncce-aside ncce-aside--filters govuk-!-margin-top-2">
+  <div class=" ncce-courses__filters-wrapper__title-mobile govuk-!-margin-top-1">
+    <h2 class="govuk-heading-s">Filter courses</h2>
+  </div>
   <%= label_tag :date_range, 'Have a specific date?', class: 'govuk-body-m ncce-label--s' %>
   <%= render DatepickerComponent.new(
       "date_range",
@@ -8,7 +13,7 @@
       flatpickr: { mode: "range" },
       options: { data: { action: "changeRange->course-filter#filter changeRange->course-filter#addRangeFilter changeRange->course-filter#dateRangeSearched"} },
       input_options: { placeholder: "Select a date or date range" }
-    ) 
+    )
   %>
 </div>
 
@@ -16,7 +21,7 @@
   <div class="ncce-aside--filters-header">
     <button type="button" class="ncce-courses__filter-form-toggle" data-course-filter-target="filterFormToggle" data-action="click->course-filter#toggleFilterForm">
       <span class="ncce-courses__filter-form-toggle-applied <%= filter_count(@course_filter) == 0 ? 'hidden' : '' %>" data-course-filter-target="filterCount"><%= applied_filters_string(@course_filter) %></span>
-      Filter courses
+      More filters
     </button>
   </div>
   <div class="ncce-courses__filter hidden" id="course-filter" data-course-filter-target="filterForm">
@@ -54,7 +59,7 @@
     <div class="govuk-checkboxes govuk-!-margin-bottom-2">
       <% @course_filter.course_formats.each_with_index do |course_format, index| %>
         <div class='govuk-checkboxes__item ncce-checkboxes__item'>
-          <%= check_box_tag 'course_format[]', course_format[:value], @course_filter&.current_format&.include?(course_format[:value]), class: 'govuk-checkboxes__input ncce-checkboxes__input', 
+          <%= check_box_tag 'course_format[]', course_format[:value], @course_filter&.current_format&.include?(course_format[:value]), class: 'govuk-checkboxes__input ncce-checkboxes__input',
             data: { action: 'change->course-filter#processValueChanges change->course-filter#filter change->course-filter#toggleActiveCheckbox', 'aria-label': 'Filter by format' }, id: "course_format_#{index}" %>
           <%= label_tag "course_format_#{index}", course_format[:label], class: 'govuk-label govuk-checkboxes__label ncce-label ncce-checkboxes__label' %>
         </div>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -54,7 +54,7 @@
     <div class="govuk-width-container ncce-courses__container" data-course-filter-target="resultsContainer" id="results-top">
       <div class="govuk-main-wrapper ncce-courses__results-wrapper">
         <div class="govuk-grid-row">
-          <div class="govuk-grid-column-one-third-from-desktop ncce-courses__filters-wrapper">
+          <div class="govuk-grid-column-one-third-from-desktop ncce-courses__filters-wrapper govuk-!-margin-bottom-3">
             <%= render 'courses/aside-filters' %>
           </div>
           <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/webpacker/stylesheets/components/courses/_courses.scss
+++ b/app/webpacker/stylesheets/components/courses/_courses.scss
@@ -46,7 +46,19 @@
 
   @include govuk-media-query($until: desktop) {
     padding: 0;
-    position: sticky;
     top: 0;
+  }
+
+  /* Move the title inside the filter box on mobile */
+  &__title-desktop {
+    @include govuk-media-query($until: desktop) {
+      display: none;
+    }
+  }
+
+  &__title-mobile {
+    @include govuk-media-query($from: desktop) {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2783

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

*Description of what's been done - bullets are usually best, but you do you.*

- Removed sticky behaviour on the course filter
- Added divs and additional CSS to move the "Filter courses" text outside and inside the box when viewing on desktop or mobile
- Changed "Filter courses" text to "More filters" inline with the mockup from Sam
- A few minor style tweaks