### PR TITLE
Broken link on careers support page

### DIFF
--- a/app/views/pages/careers-support.html.erb
+++ b/app/views/pages/careers-support.html.erb
@@ -112,7 +112,7 @@
       <li><%= t(".careers-website.content.point_2_html",
         link: link_to("career guidance", "https://www.ucas.com/careers-advice")) %></li>
       <li><%= t(".careers-website.content.point_3_html",
-        link: link_to("Kudos", "https://www.cascaid.co.uk/kudos/")) %></li>
+        link: link_to("Kudos", "https://kudos.cascaid.co.uk/")) %></li>
       <li><%= t(".careers-website.content.point_4_html",
         link: link_to("Tech Jobs Quiz", "https://www.bcs.org/it-careers/tech-job-quiz/in-demand-tech-jobs/")) %></li>
       <li><%= t(".careers-website.content.point_5_html",


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2805

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?
- Updated link on the careers support page as it was going to a 404 page
