### PR TITLE
Adding in govuk class for numbered lists

### DIFF
--- a/app/components/cms_rich_text_block_component.rb
+++ b/app/components/cms_rich_text_block_component.rb
@@ -116,6 +116,7 @@ class CmsRichTextBlockComponent < ViewComponent::Base
     def classes
       classes = ["govuk-list"]
       classes << "govuk-list--bullet" if tag == :ul
+      classes << "govuk-list--number" if tag == :ol
       classes.join(" ")
     end
   end

--- a/spec/components/cms_rich_text_block_component_spec.rb
+++ b/spec/components/cms_rich_text_block_component_spec.rb
@@ -122,6 +122,7 @@ RSpec.describe CmsRichTextBlockComponent, type: :component do
       }
     ]))
 
+    expect(page).to have_css("ol.govuk-list--number")
     expect(page).to have_css("ol", count: 1)
     expect(page).to have_css("ol li", text: "Item 1")
     expect(page).to have_css("ol li", text: "Item 2")


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2839

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Fixing the problem with number lists not showing the numbers due to missing class
