### PR TITLE
PIB - Evidence modal character validation and user warning

### DIFF
--- a/app/components/community_activity_component.rb
+++ b/app/components/community_activity_component.rb
@@ -39,6 +39,6 @@ class CommunityActivityComponent < ViewComponent::Base
   end
 
   def minimum_character_requirement
-    @activity.programmes.map(&:minimum_character_required_community_evidence).max
+    @activity.programmes.collect(&:minimum_character_required_community_evidence).max
   end
 end

--- a/app/components/community_activity_component.rb
+++ b/app/components/community_activity_component.rb
@@ -37,4 +37,8 @@ class CommunityActivityComponent < ViewComponent::Base
     return default_option["slug"] == slug if default_option
     false
   end
+
+  def minimum_character_requirement
+    @activity.programmes.map(&:minimum_character_required_community_evidence).max
+  end
 end

--- a/app/components/community_activity_component/community_activity_component.html.erb
+++ b/app/components/community_activity_component/community_activity_component.html.erb
@@ -124,19 +124,24 @@
                             </ul>
                           <% end %>
                         </p>
-                        <textarea class="govuk-textarea govuk-!-margin-bottom-1" placeholder="Please provide us with evidence of the activity you delivered." data-community-activity-component-target="textarea"><%= @achievement&.evidence&.[](index) %></textarea>
-                        <div class="community-activity-component__completion-count">
+                        <textarea class="govuk-textarea govuk-!-margin-bottom-2" placeholder="Please provide us with evidence of the activity you delivered." data-community-activity-component-target="textarea"><%= @achievement&.evidence&.[](index) %></textarea>
+                        <div class="community-activity-component__completion-count govuk-!-margin-bottom-1">
                           <span class="govuk-body-s" data-community-activity-component-target="characterCountMessage"></span>
                         </div>
                       <% end %>
                     <% end %>
+                    <%= progress.with_warning_step do %>
+                      <div>
+                        <span class="govuk-body-m" data-community-activity-component-target="completionWarningMessage"></span>
+                      </div>
+                    <% end %>
 
                     <div class="community-activity-component__footer-actions">
                       <%= progress.with_back do %>
-                        Previous section
+                        Previous
                       <% end %>
                       <%= progress.with_continue do %>
-                        Next section
+                        Next
                       <% end %>
                       <%= render ModalComponent.new(
                         title: "Are you sure you want to submit this evidence?",
@@ -146,11 +151,8 @@
                       ) do |modal| %>
                         <%= modal.with_reopen_button do %>
                           <%= progress.with_submit do %>
-                            <div class="community-activity-component__completion-steps">
-                              <span class="govuk-body-s" data-community-activity-component-target="completionWarningMessage"></span>
-                            </div>
                             <div class="progress-component__submit-button-wrapper">
-                              <button class="govuk-button button save-draft button--inverted govuk-!-margin-bottom-0" data-action="click->community-activity-component#saveAsDraft" data-community-activity-component-target="saveDraftButton">Save as draft</button>
+                              <button class="govuk-button button save-draft button--inverted govuk-!-margin-bottom-0" data-action="click->community-activity-component#saveAsDraft" data-community-activity-component-target="saveDraftButton">Save draft</button>
                               <button class="govuk-button button ncce-modal--reopen govuk-!-margin-bottom-0" data-community-activity-component-target="submitButton" data-action="modal#toggle">Submit</button>
                             </div>
                           <% end %>

--- a/app/components/community_activity_component/community_activity_component.html.erb
+++ b/app/components/community_activity_component/community_activity_component.html.erb
@@ -131,12 +131,10 @@
                       <% end %>
                     <% end %>
 
-                    <% if minimum_character_requirement != 0 %>
-                      <%= progress.with_warning_step do %>
-                        <div class="comminity-activity-component__warning-text">
-                          <span class="govuk-body-m" data-community-activity-component-target="completionWarningMessage"></span>
-                        </div>
-                      <% end %>
+                    <%= progress.with_warning_step do %>
+                      <div class="comminity-activity-component__warning-text">
+                        <span class="govuk-body-m" data-community-activity-component-target="completionWarningMessage"></span>
+                      </div>
                     <% end %>
 
                     <div class="community-activity-component__footer-actions">

--- a/app/components/community_activity_component/community_activity_component.html.erb
+++ b/app/components/community_activity_component/community_activity_component.html.erb
@@ -6,6 +6,7 @@
   data-community-activity-component-achievements-submit-path-value="<%= submit_achievements_path %>"
   data-community-activity-component-achievement-id-value="<%= @achievement&.id %>"
   data-community-activity-component-activity-id-value="<%= @activity.id %>"
+  data-community-activity-component-minimum-evidence-length-value="50"
 >
   <% if achievement_rejected? %>
     <div class="community-activity-component__rejected">
@@ -129,10 +130,10 @@
 
                     <div class="community-activity-component__footer-actions">
                       <%= progress.with_back do %>
-                        Back
+                        Previous section
                       <% end %>
                       <%= progress.with_continue do %>
-                        Continue
+                        Next section
                       <% end %>
                       <%= render ModalComponent.new(
                         title: "Are you sure you want to submit this evidence?",
@@ -142,6 +143,7 @@
                       ) do |modal| %>
                         <%= modal.with_reopen_button do %>
                           <%= progress.with_submit do %>
+                            <span data-community-activity-component-target="completionWarningMessage"></span>
                             <div class="progress-component__submit-button-wrapper">
                               <button class="govuk-button button save-draft button--inverted govuk-!-margin-bottom-0" data-action="click->community-activity-component#saveAsDraft" data-community-activity-component-target="saveDraftButton">Save as draft</button>
                               <button class="govuk-button button ncce-modal--reopen govuk-!-margin-bottom-0" data-community-activity-component-target="submitButton" data-action="modal#toggle">Submit</button>

--- a/app/components/community_activity_component/community_activity_component.html.erb
+++ b/app/components/community_activity_component/community_activity_component.html.erb
@@ -47,15 +47,15 @@
                   <div class='community-activity-component__completed-badge'><%= t('.complete') %></div>
                 </div>
                 <% if option["redownload"] %>
-                  <a href="<%= option["redirect"] %>" rel="noopener" 
+                  <a href="<%= option["redirect"] %>" rel="noopener"
                     class="govuk-body-s" target="_blank">Re-download <%= option["title"].downcase %></a>
                 <% end %>
               <% else %>
                 <% if @achievement&.complete? %>
-                  <a href="<%= option["redirect"] %>" rel="noopener" 
+                  <a href="<%= option["redirect"] %>" rel="noopener"
                     class="govuk-button button <%= @button_class %>" target="_blank"><%= option["title"] %></a>
                 <% else %>
-                  <button class="govuk-button button <%= @button_class %>" 
+                  <button class="govuk-button button <%= @button_class %>"
                     data-action="click->community-activity-component#submit"
                     data-community-activity-component-slug-param="<%= option["slug"] %>"
                     data-community-activity-component-redirect-param="<%= option["redirect"] %>"
@@ -133,7 +133,7 @@
 
                     <% if minimum_character_requirement != 0 %>
                       <%= progress.with_warning_step do %>
-                        <div>
+                        <div class="comminity-activity-component__warning-text">
                           <span class="govuk-body-m" data-community-activity-component-target="completionWarningMessage"></span>
                         </div>
                       <% end %>

--- a/app/components/community_activity_component/community_activity_component.html.erb
+++ b/app/components/community_activity_component/community_activity_component.html.erb
@@ -6,7 +6,7 @@
   data-community-activity-component-achievements-submit-path-value="<%= submit_achievements_path %>"
   data-community-activity-component-achievement-id-value="<%= @achievement&.id %>"
   data-community-activity-component-activity-id-value="<%= @activity.id %>"
-  data-community-activity-component-minimum-evidence-length-value="50"
+  data-community-activity-component-minimum-evidence-length-value="<%= minimum_character_requirement %>"
 >
   <% if achievement_rejected? %>
     <div class="community-activity-component__rejected">
@@ -130,10 +130,13 @@
                         </div>
                       <% end %>
                     <% end %>
-                    <%= progress.with_warning_step do %>
-                      <div>
-                        <span class="govuk-body-m" data-community-activity-component-target="completionWarningMessage"></span>
-                      </div>
+
+                    <% if minimum_character_requirement != 0 %>
+                      <%= progress.with_warning_step do %>
+                        <div>
+                          <span class="govuk-body-m" data-community-activity-component-target="completionWarningMessage"></span>
+                        </div>
+                      <% end %>
                     <% end %>
 
                     <div class="community-activity-component__footer-actions">

--- a/app/components/community_activity_component/community_activity_component.html.erb
+++ b/app/components/community_activity_component/community_activity_component.html.erb
@@ -123,8 +123,11 @@
                               <% end %>
                             </ul>
                           <% end %>
-                          <textarea class="govuk-textarea" placeholder="Please provide us with evidence of the activity you delivered." data-community-activity-component-target="textarea"><%= @achievement&.evidence&.[](index) %></textarea>
                         </p>
+                        <textarea class="govuk-textarea govuk-!-margin-bottom-1" placeholder="Please provide us with evidence of the activity you delivered." data-community-activity-component-target="textarea"><%= @achievement&.evidence&.[](index) %></textarea>
+                        <div class="community-activity-component__completion-count">
+                          <span class="govuk-body-s" data-community-activity-component-target="characterCountMessage"></span>
+                        </div>
                       <% end %>
                     <% end %>
 
@@ -143,7 +146,9 @@
                       ) do |modal| %>
                         <%= modal.with_reopen_button do %>
                           <%= progress.with_submit do %>
-                            <span data-community-activity-component-target="completionWarningMessage"></span>
+                            <div class="community-activity-component__completion-steps">
+                              <span class="govuk-body-s" data-community-activity-component-target="completionWarningMessage"></span>
+                            </div>
                             <div class="progress-component__submit-button-wrapper">
                               <button class="govuk-button button save-draft button--inverted govuk-!-margin-bottom-0" data-action="click->community-activity-component#saveAsDraft" data-community-activity-component-target="saveDraftButton">Save as draft</button>
                               <button class="govuk-button button ncce-modal--reopen govuk-!-margin-bottom-0" data-community-activity-component-target="submitButton" data-action="modal#toggle">Submit</button>

--- a/app/components/community_activity_component/community_activity_component.scss
+++ b/app/components/community_activity_component/community_activity_component.scss
@@ -176,8 +176,8 @@
 
           .save-draft {
             grid-column: 1;
-            padding-left: 4px;
-            padding-right: 4px;
+            padding-left: 10px;
+            padding-right: 10px;
           }
 
           .ncce-modal--reopen {

--- a/app/components/community_activity_component/community_activity_component.scss
+++ b/app/components/community_activity_component/community_activity_component.scss
@@ -150,11 +150,12 @@
         font-size: 1rem;
       }
     }
-    
+
     .community-activity-component__footer-actions {
       display: grid;
-      grid-template-columns: 1fr 1fr;
+      grid-template-columns: 0.25fr 1fr;
       align-items: center;
+      margin-top: 10px;
 
       .progress-component__back {
         grid-column: 1;
@@ -169,9 +170,9 @@
       .progress-component__submit{
         &-button-wrapper {
           display: grid;
-          grid-template-columns: 1fr 1fr;
+          grid-template-columns: 1.25fr 1fr;
           align-items: center;
-          grid-gap: 10px;
+          grid-gap: 0 10px;
 
           .save-draft {
             grid-column: 1;
@@ -182,7 +183,15 @@
           }
         }
       }
+    }
 
+    .community-activity-component__section-link {
+    color: $hyper-link-blue;
+
+      &:hover {
+        color: $grey-dark-x;
+        cursor: pointer;
+      }
     }
 
     > .ncce-modal--body {

--- a/app/components/community_activity_component/community_activity_component.scss
+++ b/app/components/community_activity_component/community_activity_component.scss
@@ -176,6 +176,8 @@
 
           .save-draft {
             grid-column: 1;
+            padding-left: 4px;
+            padding-right: 4px;
           }
 
           .ncce-modal--reopen {

--- a/app/components/community_activity_component/community_activity_component.scss
+++ b/app/components/community_activity_component/community_activity_component.scss
@@ -185,6 +185,10 @@
       }
     }
 
+    .comminity-activity-component__warning-text .govuk-body-m {
+      color: $red;
+    }
+
     .community-activity-component__section-link {
     color: $hyper-link-blue;
 

--- a/app/components/community_activity_component/community_activity_component.scss
+++ b/app/components/community_activity_component/community_activity_component.scss
@@ -170,7 +170,7 @@
       .progress-component__submit{
         &-button-wrapper {
           display: grid;
-          grid-template-columns: 1.25fr 1fr;
+          grid-template-columns: 1fr 1fr;
           align-items: center;
           grid-gap: 0 10px;
 

--- a/app/components/progress_component.rb
+++ b/app/components/progress_component.rb
@@ -8,6 +8,7 @@ class ProgressComponent < ViewComponent::Base
   renders_one :back, "Back"
   renders_one :continue, "Continue"
   renders_one :submit, "Submit"
+  renders_one :warning_step, "Warning"
   renders_many :steps, "Step"
 
   erb_template <<~ERB
@@ -58,6 +59,14 @@ class ProgressComponent < ViewComponent::Base
   # Submit is a dumb wrapper to allow forms to weird stuff like pop a modal instead
   # of just submitting the form. We only control it's visibility
   class Submit < TargetWrapper
+    erb_template <<~ERB
+      <div class="<%= css_class %>" data-progress-component-target="<%= target %>">
+        <%= content %>
+      </div>
+    ERB
+  end
+
+  class Warning < TargetWrapper
     erb_template <<~ERB
       <div class="<%= css_class %>" data-progress-component-target="<%= target %>">
         <%= content %>

--- a/app/components/progress_component/progress_component.scss
+++ b/app/components/progress_component/progress_component.scss
@@ -2,7 +2,8 @@
   .progress-component__back,
   .progress-component__continue,
   .progress-component__submit,
-  .progress-component__step {
+  .progress-component__step,
+  .progress-component__warning {
     &:not(.active) {
       display: none;
     }

--- a/app/components/progress_component/progress_component_controller.js
+++ b/app/components/progress_component/progress_component_controller.js
@@ -6,10 +6,7 @@ export default class ProgressComponentController extends ApplicationController {
   connect() {
     if (this.stepTargets.length == 0) throw new Error("Must have at least one step")
     this.currentStep = 0
-    this.updateCounter()
-    this.updateButtonVisibility()
-    this.updateStepsVisibility()
-    this.updateWarningStepVisibility()
+    this.updateSection()
   }
 
   updateCounter() {

--- a/app/components/progress_component/progress_component_controller.js
+++ b/app/components/progress_component/progress_component_controller.js
@@ -27,21 +27,30 @@ export default class ProgressComponentController extends ApplicationController {
     })
   }
 
+  updateSection() {
+    this.updateCounter()
+    this.updateButtonVisibility()
+    this.updateStepsVisibility()
+  }
+
   back() {
     if (this.currentStep == 0) return
 
     this.currentStep -= 1
-    this.updateCounter()
-    this.updateButtonVisibility()
-    this.updateStepsVisibility()
+    this.updateSection()
   }
 
   continue() {
     if (this.currentStep == this.stepTargets.length - 1) return
 
     this.currentStep += 1
-    this.updateCounter()
-    this.updateButtonVisibility()
-    this.updateStepsVisibility()
+    this.updateSection()
+  }
+
+  jumpToSection(event) {
+    const targetStep = event.params.targetStep
+
+    this.currentStep = targetStep
+    this.updateSection()
   }
 }

--- a/app/components/progress_component/progress_component_controller.js
+++ b/app/components/progress_component/progress_component_controller.js
@@ -1,7 +1,7 @@
 import ApplicationController from "../../webpacker/javascript/controllers/application_controller"
 
 export default class ProgressComponentController extends ApplicationController {
-  static targets = ["counter", "back", "continue", "submit", "step"]
+  static targets = ["counter", "back", "continue", "submit", "step", "warning"]
 
   connect() {
     if (this.stepTargets.length == 0) throw new Error("Must have at least one step")
@@ -9,6 +9,7 @@ export default class ProgressComponentController extends ApplicationController {
     this.updateCounter()
     this.updateButtonVisibility()
     this.updateStepsVisibility()
+    this.updateWarningStepVisibility()
   }
 
   updateCounter() {
@@ -27,10 +28,15 @@ export default class ProgressComponentController extends ApplicationController {
     })
   }
 
+  updateWarningStepVisibility() {
+    this.warningTarget.classList.toggle("active", this.currentStep == this.stepTargets.length - 1)
+  }
+
   updateSection() {
     this.updateCounter()
     this.updateButtonVisibility()
     this.updateStepsVisibility()
+    this.updateWarningStepVisibility()
   }
 
   back() {

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -187,4 +187,8 @@ class Programme < ApplicationRecord
   def notification_link
     root_path
   end
+
+  def minimum_character_required_community_evidence
+    0
+  end
 end

--- a/app/models/programmes/i_belong.rb
+++ b/app/models/programmes/i_belong.rb
@@ -46,5 +46,9 @@ module Programmes
     def auto_enrollment_ignored_activity_codes
       ["FD022"]
     end
+
+    def minimum_character_required_community_evidence
+      50
+    end
   end
 end

--- a/app/webpacker/javascript/controllers/community_activity_component_controller.js
+++ b/app/webpacker/javascript/controllers/community_activity_component_controller.js
@@ -103,6 +103,7 @@ export default class extends ApplicationController {
     this.textareaTargets.forEach(element => {
       element.removeEventListener("input", this.toggleConfirmationEnabled)
       element.removeEventListener("input", this.hasEvidence)
+      element.removeEventListener("input", this.updateCharacterCount)
     })
   }
 

--- a/app/webpacker/javascript/controllers/community_activity_component_controller.js
+++ b/app/webpacker/javascript/controllers/community_activity_component_controller.js
@@ -59,6 +59,7 @@ export default class extends ApplicationController {
 
   checkForEvidence() {
     this.hasEvidence = () => {
+      const hasAnyValue = this.textareaTargets.some(element => element.value !== "")
       const missingValues = []
       this.textareaTargets.forEach((element, index) => {
         if(element.value.length < this.minimumEvidenceLengthValue){
@@ -73,7 +74,7 @@ export default class extends ApplicationController {
         }
       }
       if(this.hasSaveDraftButtonTarget) {
-        if(missingValues.length == 0){
+        if(hasAnyValue){
           this.saveDraftButtonTarget.removeAttribute('disabled')
         } else {
           this.saveDraftButtonTarget.setAttribute('disabled', '')

--- a/app/webpacker/javascript/controllers/community_activity_component_controller.js
+++ b/app/webpacker/javascript/controllers/community_activity_component_controller.js
@@ -41,9 +41,9 @@ export default class extends ApplicationController {
       const remainingCharacters = this.minimumEvidenceLengthValue - element.value.length
 
       if(element.value.length > 0 && element.value.length < this.minimumEvidenceLengthValue) {
-        this.characterCountMessageTargets[index].innerHTML = `Provide at least ${remainingCharacters} more characters`
+        this.characterCountMessageTargets[index].textContent = `Provide at least ${remainingCharacters} more characters`
       } else {
-        this.characterCountMessageTargets[index].innerHTML = ""
+        this.characterCountMessageTargets[index].textContent = ""
       }
 
     };
@@ -81,9 +81,9 @@ export default class extends ApplicationController {
       }
       if(this.hasCompletionWarningMessageTarget) {
         if(missingValues.length > 0) {
-          this.completionWarningMessageTarget.innerHTML = 'You are missing some evidence in ' + missingValues.map(index => {
+          this.completionWarningMessageTarget.innerHTML = 'You are missing some evidence in section ' + missingValues.map(index => {
             const sectionNumber = index + 1
-            return `<button data-action='progress-component#jumpToSection' data-progress-component-target-step-param='${index}'> ${sectionNumber} </button>`
+            return `<a class='community-activity-component__section-link' data-action='progress-component#jumpToSection' data-progress-component-target-step-param='${index}'> ${sectionNumber}</a>`
           }).join(', ')
         } else {
           this.completionWarningMessageTarget.innerHTML = ''

--- a/app/webpacker/javascript/controllers/community_activity_component_controller.js
+++ b/app/webpacker/javascript/controllers/community_activity_component_controller.js
@@ -9,7 +9,7 @@ export default class extends ApplicationController {
     activityId: String,
     minimumEvidenceLength: { type: Number, default: 0 }
   }
-  static targets = ["textarea", "submitButton", "saveDraftButton", "completionWarningMessage"]
+  static targets = ["textarea", "submitButton", "saveDraftButton", "completionWarningMessage", "characterCountMessage"]
 
   trackUnsavedChanges() {
     this.initialValues = new Map()
@@ -33,6 +33,28 @@ export default class extends ApplicationController {
   connect() {
     this.trackUnsavedChanges()
     this.checkForEvidence();
+    this.trackCharacterCount()
+  }
+
+  trackCharacterCount() {
+    this.updateCharacterCount = (element, index) => {
+      const remainingCharacters = this.minimumEvidenceLengthValue - element.value.length
+
+      if(element.value.length > 0 && element.value.length < this.minimumEvidenceLengthValue) {
+        this.characterCountMessageTargets[index].innerHTML = `Provide at least ${remainingCharacters} more characters`
+      } else {
+        this.characterCountMessageTargets[index].innerHTML = ""
+      }
+
+    };
+
+    this.textareaTargets.forEach((input, index) => {
+      input.addEventListener("input", () => this.updateCharacterCount(input, index))
+    });
+
+    this.textareaTargets.forEach((input, index) => {
+      this.updateCharacterCount(input, index)
+    });
   }
 
   checkForEvidence() {

--- a/db/seeds/activities/community.rb
+++ b/db/seeds/activities/community.rb
@@ -426,7 +426,7 @@ Activity.find_or_initialize_by(slug: "request-your-i-belong-in-computer-science-
 end.save!
 
 Activity.find_or_initialize_by(slug: "implement-selected-key-stage-3-teach-computing-curriculum-resources").tap do |activity|
-  activity.title = "Implement selected key stage 3 Teach Computing Curriculum resources"
+  activity.title = "Implement selected Teach Computing Curriculum resources"
   activity.credit = 10
   activity.slug = "implement-selected-key-stage-3-teach-computing-curriculum-resources"
   activity.category = "community"
@@ -439,14 +439,20 @@ Activity.find_or_initialize_by(slug: "implement-selected-key-stage-3-teach-compu
       brief: "Tell us which units you’ve been teaching, to which year group, and when."
     },
     {
-      brief: "Tell us how you added approaches from the 'Encouraging Girls' course into your teaching. Examples may include increasing students’ sense of ‘belonging’ with different ways of working together; using near-peer and relatable role models to link careers into the computing curriculum; or boosting girls’ self-efficacy when teaching units such as programming."
+      brief: "Tell us how you added approaches from the 'Encouraging Girls' or ‘Empowering girls’ course into your teaching. Examples may include:",
+      bullets: [
+        "Increasing pupils’ sense of ‘belonging’ with different ways of working together",
+        "Using near-peer and relatable role models to link careers into the computing curriculum",
+        "Boosting girls’ self-efficacy when teaching units such as programming by implementing effective pedagogies such as pair programming"
+      ]
     },
     {
       brief: "Tell us the impact of what you did. Share your reflections and add examples of evidence, such as:",
       bullets: [
-        "documenting changes in girls’ participation levels after implementing the resources (may include student voice).",
-        "examples where collaborative working or team-based activities have increased girls’ participation.",
-        "sharing programming units as a link from your school website and reflect on strategies to boost girls' self-efficacy, such as targeted feedback, peer collaboration, showcasing successful projects by female students, or family engagement."
+        "Documenting changes in girls’ participation levels after implementing the resources (may include student voice)",
+        "Examples where collaborative working or project-based activities have increased girls’ participation",
+        "Reflect on the use of strategies to boost girls' self-efficacy, such as targeted feedback, peer collaboration",
+        "Showcase successful projects by female pupils, on the school website and share them with family to support family engagement"
       ]
     }
   ]
@@ -463,23 +469,23 @@ Activity.find_or_initialize_by(slug: "participate-in-a-ncce-student-enrichment-a
   activity.self_verification_info = "Please provide us with evidence of participation"
   activity.public_copy_evidence = [
     {
-      brief: "Tell us which event your students participated in. Describe the activity including when it took place. Include the age range of students involved, the total number and the proportion of female and male students. "
+      brief: "Tell us which event your students participated in. Describe the activity including when it took place. Include the age range of students involved, the total number and the proportion of female and male pupils."
     },
     {
-      brief: "Tell us which approaches from the 'Encouraging Girls' course were used. Examples might include:",
+      brief: "Tell us which approaches from the 'Encouraging Girls' or ‘Empowering girls’ course were used. Examples might include:",
       bullets: [
-        "Being part of a supportive team at the event – increasing the proportion of girls participating.",
-        "Using near-peer mentors, such as older students - increasing identity.",
-        "Family engagement – increasing social capital.",
-        "Considering prior experiences and access to computing at home – advancing equity."
+        "Being part of a supportive team at the event – increasing the proportion of girls participating",
+        "Using near-peer mentors, such as older pupils - increasing identity",
+        "Family engagement – increasing social capital",
+        "Considering prior experiences and access to computing at home – advancing equity"
       ]
     },
     {
       brief: "What was the impact of the event? Share your reflections and add examples of evidence, such as:",
       bullets: [
-        "Positive feedback from students or a blogpost from the school website.",
-        "A link to an online news story or social media post from your school’s account to summarise the event.",
-        "Option data showing an increase in the proportion of girls considering GCSE Computer Science in KS4."
+        "Positive feedback from pupils, a link to a newsletter covering the event or a blogpost from the school website",
+        "A link to an online news story or social media post from your school’s account to summarise the event",
+        "Option data showing an increase in the proportion of girls considering GCSE Computer Science in KS4"
       ]
     }
   ]
@@ -495,23 +501,24 @@ Activity.find_or_initialize_by(slug: "provide-access-to-a-computing-related-extr
   activity.description = %(Provide access to a computing related STEM lunchtime or after school club. Consider involving older female students to support. Resources to help you get started are available via the <a href="#{i_belong_secondary_handbook_url}">handbook</a>.)
   activity.self_verification_info = "Please provide us with evidence of delivery"
   activity.public_copy_evidence = [{
-    brief: "Tell us what you did and when. Describe your computing club in school and include timescales, particularly if you’ve run the club for longer than a year. Include the age range of students involved, and the proportion of female and male students. How do you promote a higher proportion of girls participating? Finally, reflect and tell us why you chose this activity."
+    brief: "Tell us what you did and when. Describe your computing club in school and include timescales, particularly if you’ve run the club for longer than a year. Include the age range of pupils involved, and the proportion of female and male pupils. How do you promote a higher proportion of girls participating? Finally, reflect and tell us why you chose this activity."
   },
     {
-      brief: "Which approaches from the 'Encouraging Girls' course have you considered or used? Examples might include:",
+      brief: "Which approaches from the 'Encouraging Girls' or ‘Empowering girls’ course have you considered or used? Examples might include:",
       bullets: [
-        "Inviting students during lessons or family events to increase the proportion of girls taking part.",
-        "Having a choice of activities including physical computing or themed projects such as climate challenges or creating music.",
-        "Including competitive activities in a supportive setting such as the CyberFirst Girls or CanSat challenges.",
-        "Using near-peer mentors (such as older students or computing ambassadors)."
+        "Inviting female pupils during lessons or family events to increase the proportion of girls taking part",
+        "Having a choice of activities including physical computing or themed projects such as climate challenges or creating music",
+        "Setting up girls-only clubs to empower them to question, experiment and lead",
+        "Including competitive activities in a supportive setting such as the CyberFirst Girls or CanSat challenges",
+        "Using near-peer mentors (such as older pupils or computing ambassadors)"
       ]
     },
     {
       brief: "What is the impact of the club? Write your reflections and add examples of evidence, which might include:",
       bullets: [
-        "Positive feedback from students or sharing a blogpost from the school website.",
-        "Sharing a link to an online news story or social media post from your school’s account about a success in a competition or club activities.",
-        "Option data showing an increase in the proportion of girls considering GCSE Computer Science in KS4."
+        "Positive feedback from pupils, a link to a newsletter covering the event or a blogpost from the school website",
+        "Sharing a link to an online news story or social media post from your school’s account about a success in a competition or club activities",
+        "Option data showing an increase in the proportion of girls considering GCSE Computer Science in KS4"
       ]
     }]
 end.save!
@@ -526,21 +533,22 @@ Activity.find_or_initialize_by(slug: "host-a-computing-stem-ambassador-activity"
   activity.description = "Host a Computing Ambassador in your school to support raising gender and career aspirations and to help students understand the real-world applications of their learning. Evidence must showcase the <a href=\"#{stem_request_ambassador_url}\">Computing Ambassador</a> visit to your school from April 2023 onwards."
   activity.self_verification_info = "Please provide us with evidence of delivery"
   activity.public_copy_evidence = [{
-    brief: "Tell us what you did and when. Was it a one-off visit from a computing ambassador or part of a series of events you’ve organised in school? Include the age range of students involved, and the proportion of female and male students. How did you promote a higher proportion of girls participating?"
+    brief: "Tell us what you did and when. Was it a one-off visit from a computing ambassador or part of a series of events you’ve organised in school? Include the age range of students involved, and the proportion of female and male pupils. How did you promote a higher proportion of girls participating?"
   },
     {
-      brief: "Which approaches from the 'Encouraging Girls' course can you share in how you planned the activity? Examples might include:",
+      brief: "Which approaches from the 'Encouraging Girls' or ‘Empowering girls’ course can you share in how you planned the activity? Examples might include:",
       bullets: [
-        "Inviting near-peer and relatable role models to link careers into the computing curriculum.",
-        "Bringing in relevance such as AI, health or environmental themes for activities that are about ‘people not things’."
+        "Linking the visit to the curriculum to add real world contexts",
+        "Inviting relatable role models to link careers into the computing curriculum",
+        "Choosing a topic such as AI, health or environmental themes for activities that are about ‘people not things’"
       ]
     },
     {
       brief: "What was the impact? What have you observed following the interventions you’ve put in place? Examples might include:",
       bullets: [
-        "Positive feedback from students or sharing a blogpost from the school website.",
-        "A link to an online news story or social media post from your school’s account summarising the activity.",
-        "Option data showing an increase in the proportion of girls considering GCSE Computer Science in KS4."
+        "Positive feedback from pupils, a link to a newsletter covering the event or a blogpost from the school website",
+        "A link to an online news story or social media post from your school’s account summarising the activity",
+        "Option data showing an increase in the proportion of girls considering GCSE Computer Science in KS4"
       ]
     }]
 end.save!
@@ -556,22 +564,23 @@ Activity.find_or_initialize_by(slug: "participate-in-a-computing-related-competi
   activity.self_verification_info = "Please provide us with evidence of delivery"
   activity.public_copy_evidence = [
     {
-      brief: "Tell us which competition your students entered into and when. Include the age range of students involved, and the proportion of girls taking part."
+      brief: "Tell us which competition your students entered into and when. Include the age range of pupils involved, and the proportion of girls taking part."
     },
     {
-      brief: "Which approaches from the 'Encouraging Girls' course helped to increase the proportion of girls participating in the competition? Examples might include:",
+      brief: "Which approaches from the 'Encouraging Girls' or ‘Empowering girls’ course helped to increase the proportion of girls participating in the competition? Examples might include:",
       bullets: [
-        "Inviting students during lessons or family engagement events to promote self-efficacy and participation.",
-        "Building a supportive team with competitions in a club setting.",
-        "Involving near-peer mentors such as older students or computing ambassadors."
+        "Inviting female pupils during lessons or family engagement events to promote self-efficacy and participation",
+        "Building a supportive team with competitions in a club setting",
+        "Setting up girls-only teams to empower them to question, experiment and lead",
+        "Involving near-peer mentors such as older pupils or computing ambassadors"
       ]
     },
     {
       brief: "What was the impact? What have you observed following the interventions you’ve put in place? Examples might include:",
       bullets: [
-        "Positive feedback from students or a blogpost from the school website.",
-        "A link to an online news story or school social media post about a success in a competition or club activity.",
-        "Option data showing an increase in the proportion of girls considering GCSE Computer Science in KS4."
+        "Positive feedback from pupils, a link to a newsletter covering the event or a blogpost from the school website",
+        "A link to an online news story or school social media post about a success in a competition or club activity",
+        "Option data showing an increase in the proportion of girls considering GCSE Computer Science in KS4"
       ]
     }
   ]
@@ -588,21 +597,23 @@ Activity.find_or_initialize_by(slug: "any-other-activity-which-aligns-with-recom
   activity.self_verification_info = "Please provide us with evidence of delivery"
   activity.public_copy_evidence = [
     {
-      brief: "Tell us which activity your students have got involved with and when it took place. Include the age range of all the students involved, the total number and the proportion of girls and boys."
+      brief: "Tell us which activity your students have got involved with and when it took place. Include the age range of all the pupils involved, the total number and the proportion of girls and boys."
     },
     {
-      brief: "Which approaches from the 'Encouraging Girls' course can you share in the way you planned the activity? Examples might include:",
+      brief: "Which approaches from the 'Encouraging Girls' or ‘Empowering girls’ course can you share in the way you planned the activity? Examples might include:",
       bullets: [
-        "Inviting near-peer and relatable role models to link careers into the computing curriculum.",
-        "Bringing in relevance such as AI, health or environmental themes for activities that are about ‘people not things’."
+        "Creating opportunities for family engagement",
+        "Setting up girls-only opportunities to empower them to question, experiment and lead",
+        "Inviting near-peer and relatable role models to link careers into the computing curriculum",
+        "Bringing in relevance such as AI, health or environmental themes for activities that are about ‘people not things’"
       ]
     },
     {
       brief: "What was the impact? What have you observed following the interventions you’ve put in place? Examples might include:",
       bullets: [
-        "Positive feedback from students or a blogpost from the school website.",
-        "A link to an online news story or school social media post about a success in a competition or club activities.",
-        "Option data showing an increase in the proportion of girls considering GCSE Computer Science in KS4."
+        "Positive feedback from pupils, a link to a newsletter covering the event or a blogpost from the school website",
+        "A link to an online news story or school social media post about a success in a competition or club activities",
+        "Option data showing an increase in the proportion of girls considering GCSE Computer Science in KS4"
       ]
     }
   ]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@babel/core": "^7.14.0",
     "@babel/eslint-parser": "^7.13.14",
-    "@hotwired/stimulus": "^3.0",
+    "@hotwired/stimulus": "^3.2.2",
     "@hotwired/stimulus-webpack-helpers": "^1.0.1",
     "@rails/actiontext": "^6.1.3",
     "@rails/activestorage": "^6.1.3",

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -425,4 +425,12 @@ RSpec.describe Programme, type: :model do
       expect(programme.auto_enrollment_ignored_activity_codes).to eq []
     end
   end
+
+  describe "#minimum_character_required_community_evidence" do
+    it "should default to zero" do
+      programme = create(:programme)
+
+      expect(programme.minimum_character_required_community_evidence).to eq(0)
+    end
+  end
 end

--- a/spec/models/programmes/i_belong_spec.rb
+++ b/spec/models/programmes/i_belong_spec.rb
@@ -52,4 +52,10 @@ RSpec.describe Programmes::IBelong do
       expect(programme.auto_enrollment_ignored_activity_codes).to eq ["FD022"]
     end
   end
+
+  describe "#minimum_character_required_community_evidence" do
+    it "should return 50" do
+      expect(programme.minimum_character_required_community_evidence).to eq(50)
+    end
+  end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1478,7 +1478,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hotwired/stimulus@npm:^3.0":
+"@hotwired/stimulus@npm:^3.2.2":
   version: 3.2.2
   resolution: "@hotwired/stimulus@npm:3.2.2"
   checksum: e0c13469df89f760f35cce0fd7af5f7eeabd4ff79c4ad2b05fe7d8d7b845818c6736c3cd515c1906e144aa27529d5a60377647937b756950b4f709be329c9046
@@ -7595,7 +7595,7 @@ __metadata:
   dependencies:
     "@babel/core": ^7.14.0
     "@babel/eslint-parser": ^7.13.14
-    "@hotwired/stimulus": ^3.0
+    "@hotwired/stimulus": ^3.2.2
     "@hotwired/stimulus-webpack-helpers": ^1.0.1
     "@rails/actiontext": ^6.1.3
     "@rails/activestorage": ^6.1.3


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2809

Fixes the bug in this ticket:
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2801

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?
- Additional javascript in community activity component added to check textareas for evidence and warns the user on the last section if they are missing evidence in one of the sections
 - Alongside this, added links to take the user back to that missing section
 - Some javascript added into the progress component so the warning only appears on the last section
- Added minimum character requirement to the evidence boxes - set to 50. When a user starts entering their evidence a text prompt will appear to show the user how many more characters are required to be a valid submission
- Small tweaks to the CSS on the modal for better layout on mobile view
