### PR TITLE
Removing news tag from footer link

### DIFF
--- a/app/views/components/_footer.html.erb
+++ b/app/views/components/_footer.html.erb
@@ -30,7 +30,7 @@
       </ul>
       <ul class="ncce-footer__list">
         <li class="ncce-footer__list-item">
-          <%= link_to 'News', news_url, class: 'govuk-footer__link ncce-link ncce-link--on-dark', data: { event_action: 'click', event_category: 'Site Navigation: Footer', event_label: 'News' } %>
+          <%= link_to 'News', cms_posts_path, class: 'govuk-footer__link ncce-link ncce-link--on-dark', data: { event_action: 'click', event_category: 'Site Navigation: Footer', event_label: 'News' } %>
         </li>
         <li class="ncce-footer__list-item">
           <%= link_to 'Get involved', get_involved_path, class: 'govuk-footer__link ncce-link ncce-link--on-dark', data: { event_action: 'click', event_category: 'Site Navigation: Footer', event_label: 'Get involved' } %>


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2847
## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Remove news tag from footer, just go to blog page instead