### PR TITLE
Add full width banner from Strapi

### DIFF
--- a/app/components/cms_full_width_banner_component.rb
+++ b/app/components/cms_full_width_banner_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CmsFullWidthBannerComponent < ViewComponent::Base
+  delegate :cms_image, to: :helpers
+
+  def initialize(text_content:, image:, image_side:, image_link:, background_color: :white, buttons: [])
+    @text_content = text_content
+    @image = image
+    @image_side = image_side
+    @image_link = image_link
+    @background_color = background_color
+    @buttons = buttons
+  end
+
+  def banner_classes
+    ["#{@background_color}-bg"]
+  end
+end

--- a/app/components/cms_full_width_banner_component.rb
+++ b/app/components/cms_full_width_banner_component.rb
@@ -3,16 +3,25 @@
 class CmsFullWidthBannerComponent < ViewComponent::Base
   delegate :cms_image, to: :helpers
 
-  def initialize(text_content:, image:, image_side:, image_link:, background_color: :white, buttons: [])
+  def initialize(text_content:, image:, image_side:, image_link:, title:, background_color: nil, buttons: [])
     @text_content = text_content
     @image = image
     @image_side = image_side
     @image_link = image_link
+    @title = title
     @background_color = background_color
     @buttons = buttons
   end
 
+  def wrapper_classes
+    classes = []
+    classes << "#{@background_color}-bg" if @background_color
+    classes
+  end
+
   def banner_classes
-    ["#{@background_color}-bg"]
+    classes = ["cms-full-width-banner"]
+    classes << "right-align" if @image_side == "right"
+    classes
   end
 end

--- a/app/components/cms_full_width_banner_component.rb
+++ b/app/components/cms_full_width_banner_component.rb
@@ -3,7 +3,7 @@
 class CmsFullWidthBannerComponent < ViewComponent::Base
   delegate :cms_image, to: :helpers
 
-  def initialize(text_content:, image:, image_side:, image_link:, title:, background_color: nil, buttons: [])
+  def initialize(text_content:, image:, image_side:, image_link:, title:, background_color: nil, buttons: [], show_bottom_border: false)
     @text_content = text_content
     @image = image
     @image_side = image_side
@@ -11,11 +11,13 @@ class CmsFullWidthBannerComponent < ViewComponent::Base
     @title = title
     @background_color = background_color
     @buttons = buttons
+    @show_bottom_border = show_bottom_border
   end
 
   def wrapper_classes
-    classes = []
+    classes = ["cms-full-width-banner-row"]
     classes << "#{@background_color}-bg" if @background_color
+    classes << "has-border" if @show_bottom_border
     classes
   end
 

--- a/app/components/cms_full_width_banner_component/cms_full_width_banner_component.html.erb
+++ b/app/components/cms_full_width_banner_component/cms_full_width_banner_component.html.erb
@@ -11,6 +11,14 @@
 
       <div class="cms-full-width-banner__content">
         <%= render CmsRichTextBlockComponent.new(blocks: @text_content, with_wrapper: false) %>
+
+        <% if @buttons %>
+          <div class="cms-full-width-banner__content-buttons">
+            <% @buttons.each do |button| %>
+              <%= render button.render %>
+            <% end %>
+          </div>
+        <% end %>
       </div>
     </div>
   <% end %>

--- a/app/components/cms_full_width_banner_component/cms_full_width_banner_component.html.erb
+++ b/app/components/cms_full_width_banner_component/cms_full_width_banner_component.html.erb
@@ -1,7 +1,11 @@
-<%= render GovGridRowComponent.new(additional_classes: banner_classes) do |row| %>
+<%= render GovGridRowComponent.new(additional_classes: wrapper_classes) do |row| %>
   <%= row.with_column("full") do %>
 
-    <div class="cms-full-width-banner">
+    <% if @title %>
+      <h2 class="govuk-heading-l cms-full-width-banner__heading"><%= @title %></h2>
+    <% end %>
+
+    <%= content_tag :div, class: banner_classes do %>
     
       <% if @image %>
         <div class="cms-full-width-banner__media">
@@ -10,7 +14,7 @@
       <% end %>
 
       <div class="cms-full-width-banner__content">
-        <%= render CmsRichTextBlockComponent.new(blocks: @text_content, with_wrapper: false) %>
+        <%= render @text_content.render %>
 
         <% if @buttons %>
           <div class="cms-full-width-banner__content-buttons">
@@ -20,6 +24,6 @@
           </div>
         <% end %>
       </div>
-    </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/cms_full_width_banner_component/cms_full_width_banner_component.html.erb
+++ b/app/components/cms_full_width_banner_component/cms_full_width_banner_component.html.erb
@@ -9,7 +9,7 @@
     
       <% if @image %>
         <div class="cms-full-width-banner__media">
-          <%= cms_image(@image) %>
+          <%= render CmsImageComponent.new(@image, show_caption: false, link: @image_link) %>
         </div>
       <% end %>
 

--- a/app/components/cms_full_width_banner_component/cms_full_width_banner_component.html.erb
+++ b/app/components/cms_full_width_banner_component/cms_full_width_banner_component.html.erb
@@ -1,0 +1,17 @@
+<%= render GovGridRowComponent.new(additional_classes: banner_classes) do |row| %>
+  <%= row.with_column("full") do %>
+
+    <div class="cms-full-width-banner">
+    
+      <% if @image %>
+        <div class="cms-full-width-banner__media">
+          <%= cms_image(@image) %>
+        </div>
+      <% end %>
+
+      <div class="cms-full-width-banner__content">
+        <%= render CmsRichTextBlockComponent.new(blocks: @text_content, with_wrapper: false) %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/components/cms_full_width_banner_component/cms_full_width_banner_component.scss
+++ b/app/components/cms_full_width_banner_component/cms_full_width_banner_component.scss
@@ -7,7 +7,7 @@
   gap: 15px;
 
   &__media {
-    flex: 0 1 20%;
+    flex: 1;
 
     img {
       width: 100%;
@@ -15,7 +15,8 @@
   }
   
   &__content {
-    flex: 1 1 80%;
+    flex: 2;
+    padding: 20px;
   }
 
 }

--- a/app/components/cms_full_width_banner_component/cms_full_width_banner_component.scss
+++ b/app/components/cms_full_width_banner_component/cms_full_width_banner_component.scss
@@ -1,5 +1,13 @@
 
+.cms-full-width-banner__heading {
+  margin-bottom: 20px;
+}
+
 .cms-full-width-banner {
+
+  &.right-align {
+    flex-direction: row-reverse;
+  }
 
   display: flex;
 
@@ -7,7 +15,8 @@
   gap: 15px;
 
   &__media {
-    flex: 1;
+    flex: 0 1 calc(100% * 1/3);
+    padding: 10px;
 
     img {
       width: 100%;
@@ -15,8 +24,13 @@
   }
   
   &__content {
-    flex: 2;
-    padding: 20px;
+    flex: 1 1 calc(100% * 2/3);
+    padding: 20px 0px;
+
+    .govuk-button {
+      min-width: 300px;
+    }
+
   }
 
 }

--- a/app/components/cms_full_width_banner_component/cms_full_width_banner_component.scss
+++ b/app/components/cms_full_width_banner_component/cms_full_width_banner_component.scss
@@ -1,0 +1,21 @@
+
+.cms-full-width-banner {
+
+  display: flex;
+
+  flex-direction: row;
+  gap: 15px;
+
+  &__media {
+    flex: 0 1 20%;
+
+    img {
+      width: 100%;
+    }
+  }
+  
+  &__content {
+    flex: 1 1 80%;
+  }
+
+}

--- a/app/components/cms_full_width_banner_component/cms_full_width_banner_component.scss
+++ b/app/components/cms_full_width_banner_component/cms_full_width_banner_component.scss
@@ -1,4 +1,12 @@
 
+.cms-full-width-banner-row {
+  &.has-border {
+    .govuk-main-wrapper {
+      border-bottom: 2px solid $ncce-grey;
+    }
+  }
+}
+
 .cms-full-width-banner__heading {
   margin-bottom: 20px;
 }
@@ -14,8 +22,13 @@
   flex-direction: row;
   gap: 15px;
 
+  @include govuk-media-query($until: tablet) {
+    flex-direction: column;
+    gap: 0px;
+  }
+
   &__media {
-    flex: 0 1 calc(100% * 1/3);
+    flex: 0 0 calc(100% * 1/3);
     padding: 10px;
 
     img {

--- a/app/components/cms_full_width_text_block_component.rb
+++ b/app/components/cms_full_width_text_block_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CmsFullWidthTextBlockComponent < ViewComponent::Base
+  def initialize(blocks:)
+    @blocks = blocks
+  end
+end

--- a/app/components/cms_full_width_text_block_component.rb
+++ b/app/components/cms_full_width_text_block_component.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 class CmsFullWidthTextBlockComponent < ViewComponent::Base
-  def initialize(blocks:)
+  def initialize(blocks:, background_color:)
     @blocks = blocks
+    @background_color = background_color
+  end
+
+  def wrapper_classes
+    classes = ["cms-full-width-text-row"]
+    classes << "#{@background_color}-bg" if @background_color
+    classes
   end
 end

--- a/app/components/cms_full_width_text_block_component/cms_full_width_text_block_component.html.erb
+++ b/app/components/cms_full_width_text_block_component/cms_full_width_text_block_component.html.erb
@@ -1,0 +1,5 @@
+<%= render GovGridRowComponent.new do |row| %>
+  <%= row.with_column("full-width") do %>
+    <%= render @blocks.render %>
+  <% end %>
+<% end %>

--- a/app/components/cms_full_width_text_block_component/cms_full_width_text_block_component.html.erb
+++ b/app/components/cms_full_width_text_block_component/cms_full_width_text_block_component.html.erb
@@ -1,5 +1,5 @@
-<%= render GovGridRowComponent.new do |row| %>
-  <%= row.with_column("full-width") do %>
+<%= render GovGridRowComponent.new(additional_classes: wrapper_classes) do |row| %>
+  <%= row.with_column("full") do %>
     <%= render @blocks.render %>
   <% end %>
 <% end %>

--- a/app/components/cms_ncce_button_component.rb
+++ b/app/components/cms_ncce_button_component.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 class CmsNcceButtonComponent < ViewComponent::Base
-  def initialize(title:, link:, colour: nil)
+  def initialize(title:, link:, color: nil)
     @title = title
     @link = link
-    @colour = colour
+    @color = color
   end
 
   def button_classes
     classes = %i[govuk-button button]
-    classes << "ncce-button--#{@colour}" if @colour
+    classes << "ncce-button--#{@color}" if @color
     classes
   end
 

--- a/app/components/cms_question_and_answer_component/cms_question_and_answer_component.html.erb
+++ b/app/components/cms_question_and_answer_component/cms_question_and_answer_component.html.erb
@@ -1,5 +1,5 @@
 <%= render GovGridRowComponent.new(additional_classes: "question-answer-row") do |row| %>
-  <%= row.with_column("full-width") do %>
+  <%= row.with_column("full") do %>
 
     <div class="tc-row">
     

--- a/app/components/cms_question_and_answer_component/cms_question_and_answer_component.scss
+++ b/app/components/cms_question_and_answer_component/cms_question_and_answer_component.scss
@@ -140,7 +140,12 @@ $avatar_size: 32px;
       }
 
       .cms-image {
-        text-align: center;
+        width: 80%;
+        margin: auto;
+
+        img {
+          width: 100%;
+        }
       }
 
     }

--- a/app/components/gov_grid_row_component.rb
+++ b/app/components/gov_grid_row_component.rb
@@ -28,10 +28,13 @@ class GovGridRowComponent < ViewComponent::Base
     delegate :govuk_padding_classes, :govuk_margin_classes,
       to: :helpers
 
+    VALID_COLUMNS = %w[two-thirds one-third full]
+
     def initialize(column_type, padding: {}, margin: {})
       @column_type = column_type
       @padding = padding
       @margin = margin
+      raise StandardError.new("Invalid column") unless VALID_COLUMNS.include?(@column_type.to_s)
     end
 
     def column_classes

--- a/app/services/cms/dynamic_components/full_width_banner.rb
+++ b/app/services/cms/dynamic_components/full_width_banner.rb
@@ -1,14 +1,15 @@
 module Cms
   module DynamicComponents
     class FullWidthBanner
-      attr_accessor :text_content, :image, :image_side, :buttons, :image_link, :background_color
+      attr_accessor :text_content, :image, :image_side, :buttons, :image_link, :title, :background_color
 
-      def initialize(text_content:, image: nil, image_side: :left, image_link: nil, background_color: :white, buttons: [])
+      def initialize(text_content:, title:, image: nil, image_side: :left, image_link: nil, background_color: :white, buttons: [])
         @text_content = text_content
         @image = image
         @image_side = image_side
         @image_link = image_link
         @background_color = background_color
+        @title = title
         @buttons = buttons
       end
 
@@ -19,7 +20,8 @@ module Cms
           image_side:,
           image_link:,
           background_color:,
-          buttons:
+          buttons:,
+          title:
         )
       end
     end

--- a/app/services/cms/dynamic_components/full_width_banner.rb
+++ b/app/services/cms/dynamic_components/full_width_banner.rb
@@ -1,0 +1,27 @@
+module Cms
+  module DynamicComponents
+    class FullWidthBanner
+      attr_accessor :text_content, :image, :image_side, :buttons, :image_link, :background_color
+
+      def initialize(text_content:, image: nil, image_side: :left, image_link: nil, background_color: :white, buttons: [])
+        @text_content = text_content
+        @image = image
+        @image_side = image_side
+        @image_link = image_link
+        @background_color = background_color
+        @buttons = buttons
+      end
+
+      def render
+        CmsFullWidthBannerComponent.new(
+          text_content:,
+          image:,
+          image_side:,
+          image_link:,
+          background_color:,
+          buttons:
+        )
+      end
+    end
+  end
+end

--- a/app/services/cms/dynamic_components/full_width_banner.rb
+++ b/app/services/cms/dynamic_components/full_width_banner.rb
@@ -1,9 +1,9 @@
 module Cms
   module DynamicComponents
     class FullWidthBanner
-      attr_accessor :text_content, :image, :image_side, :buttons, :image_link, :title, :background_color
+      attr_accessor :text_content, :image, :image_side, :buttons, :image_link, :title, :background_color, :show_bottom_border
 
-      def initialize(text_content:, title:, image: nil, image_side: :left, image_link: nil, background_color: :white, buttons: [])
+      def initialize(text_content:, title:, image: nil, image_side: :left, image_link: nil, background_color: :white, buttons: [], show_bottom_border: false)
         @text_content = text_content
         @image = image
         @image_side = image_side
@@ -11,6 +11,7 @@ module Cms
         @background_color = background_color
         @title = title
         @buttons = buttons
+        @show_bottom_border = show_bottom_border
       end
 
       def render
@@ -21,7 +22,8 @@ module Cms
           image_link:,
           background_color:,
           buttons:,
-          title:
+          title:,
+          show_bottom_border:
         )
       end
     end

--- a/app/services/cms/dynamic_components/full_width_text.rb
+++ b/app/services/cms/dynamic_components/full_width_text.rb
@@ -1,0 +1,15 @@
+module Cms
+  module DynamicComponents
+    class FullWidthText
+      attr_accessor :blocks
+
+      def initialize(blocks:)
+        @blocks = blocks
+      end
+
+      def render
+        CmsFullWidthTextBlockComponent.new(blocks:)
+      end
+    end
+  end
+end

--- a/app/services/cms/dynamic_components/full_width_text.rb
+++ b/app/services/cms/dynamic_components/full_width_text.rb
@@ -1,14 +1,15 @@
 module Cms
   module DynamicComponents
     class FullWidthText
-      attr_accessor :blocks
+      attr_accessor :blocks, :background_color
 
-      def initialize(blocks:)
+      def initialize(blocks:, background_color:)
         @blocks = blocks
+        @background_color = background_color
       end
 
       def render
-        CmsFullWidthTextBlockComponent.new(blocks:)
+        CmsFullWidthTextBlockComponent.new(blocks:, background_color:)
       end
     end
   end

--- a/app/services/cms/dynamic_components/ncce_button.rb
+++ b/app/services/cms/dynamic_components/ncce_button.rb
@@ -1,15 +1,16 @@
 module Cms
   module DynamicComponents
     class NcceButton
-      attr_accessor :title, :link
+      attr_accessor :title, :link, :color
 
-      def initialize(title:, link:)
+      def initialize(title:, link:, color:)
         @title = title
         @link = link
+        @color = color
       end
 
       def render
-        CmsNcceButtonComponent.new(title:, link:, colour: :white)
+        CmsNcceButtonComponent.new(title:, link:, color:)
       end
     end
   end

--- a/app/services/cms/providers/strapi/factories/component_factory.rb
+++ b/app/services/cms/providers/strapi/factories/component_factory.rb
@@ -12,23 +12,18 @@ module Cms
               file_data = strapi_data.dig(:file, :data) ? strapi_data[:file][:data][:attributes] : nil
               to_file(file_data) if file_data
             when "blocks.text-with-asides"
-              asides = if strapi_data.dig(:asideSections, :data)
-                strapi_data[:asideSections][:data].collect { _1[:attributes] }
-              else
-                []
-              end
-              DynamicComponents::TextWithAsides.new(blocks: strapi_data[:textContent], asides:)
+              DynamicComponents::TextWithAsides.new(blocks: strapi_data[:textContent], asides: extract_aside_sections(strapi_data))
             when "blocks.horizontal-card"
               DynamicComponents::HorizontalCard.new(
                 title: strapi_data[:title],
                 body_blocks: strapi_data[:bodyText],
-                image: strapi_data.dig(:image, :data) ? ModelFactory.to_image(strapi_data[:image][:data][:attributes], default_size: :small) : nil,
+                image: ModelFactory.to_image(strapi_data, :image, default_size: :small),
                 image_link: strapi_data[:imageLink],
                 colour_theme: strapi_data.dig(:colourTheme, :data) ? strapi_data[:colourTheme][:data][:attributes][:name] : nil,
                 icon_block: icon_block(strapi_data[:iconBlock])
               )
             when "buttons.ncce-button"
-              DynamicComponents::NcceButton.new(title: strapi_data[:title], link: strapi_data[:link])
+              to_ncce_button(strapi_data)
             when "blocks.question-and-answer"
               to_question_and_answer(strapi_data)
             when "blocks.card-section"
@@ -39,15 +34,24 @@ module Cms
                 background_color: strapi_data.dig(:backgroundColour, :data) ? strapi_data[:backgroundColour][:data][:attributes][:name] : nil
               )
             when "blocks.full-width-banner"
-              DynamicComponents::FullWidthBanner.new(
-                text_content: ModelFactory.to_content_block(strapi_data[:textContent]),
-                background_color: strapi_data[:backgroundColor][:name],
-                image: ModelFactory.to_image(strapi_data[:image]),
-                image_side: strapi_data[:image_side],
-                image_link: strapi_data[:imageLink],
-                buttons: [] # TODO pull from Q&A branch,
-              )
+              to_full_width_banner(strapi_data)
             end
+          end
+
+          def self.to_full_width_banner(strapi_data)
+            DynamicComponents::FullWidthBanner.new(
+              text_content: ModelFactory.to_content_block(strapi_data[:textContent], with_wrapper: false),
+              background_color: strapi_data.dig(:backgroundColour, :data) ? strapi_data[:backgroundColour][:data][:attributes][:name] : nil,
+              image: ModelFactory.to_image(strapi_data, :image, default_size: :medium),
+              image_side: strapi_data[:imageSide],
+              image_link: strapi_data[:imageLink],
+              buttons: strapi_data[:buttons] ? strapi_data[:buttons].map { to_ncce_button(_1) } : [],
+              title: strapi_data[:sectionTitle]
+            )
+          end
+
+          def self.to_ncce_button(strapi_data)
+            DynamicComponents::NcceButton.new(title: strapi_data[:title], link: strapi_data[:link], color: strapi_data[:buttonTheme])
           end
 
           def self.to_question_and_answer(strapi_data)
@@ -89,7 +93,7 @@ module Cms
           def self.icon(icon_data)
             DynamicComponents::Icon.new(
               text: icon_data[:iconText],
-              image: ModelFactory.to_image(icon_data[:iconImage][:data][:attributes])
+              image: ModelFactory.to_image(icon_data, :iconImage, default_size: :small)
             )
           end
 

--- a/app/services/cms/providers/strapi/factories/component_factory.rb
+++ b/app/services/cms/providers/strapi/factories/component_factory.rb
@@ -83,7 +83,7 @@ module Cms
             strapi_data.map do |card_data|
               Models::ResourceCard.new(
                 title: card_data[:title],
-                icon: card_data.dig(:icon, :data) ? ModelFactory.to_image(card_data[:icon][:data][:attributes]) : nil,
+                icon: ModelFactory.to_image(card_data, :icon, default_size: :medium),
                 colour_theme: card_data.dig(:colourTheme, :data) ? card_data[:colourTheme][:data][:attributes][:name] : nil,
                 body_text: card_data[:bodyText],
                 button_text: card_data[:buttonText],

--- a/app/services/cms/providers/strapi/factories/component_factory.rb
+++ b/app/services/cms/providers/strapi/factories/component_factory.rb
@@ -92,7 +92,7 @@ module Cms
               Models::ResourceCard.new(
                 title: card_data[:title],
                 icon: ModelFactory.to_image(card_data, :icon, default_size: :medium),
-                colour_theme: extract_color_name(strapi_data, :colourTheme),
+                colour_theme: extract_color_name(card_data, :colourTheme),
                 body_text: card_data[:bodyText],
                 button_text: card_data[:buttonText],
                 button_link: card_data[:buttonLink]

--- a/app/services/cms/providers/strapi/factories/component_factory.rb
+++ b/app/services/cms/providers/strapi/factories/component_factory.rb
@@ -38,6 +38,10 @@ module Cms
                 cards_per_row: strapi_data[:cardsPerRow],
                 background_color: strapi_data.dig(:backgroundColour, :data) ? strapi_data[:backgroundColour][:data][:attributes][:name] : nil
               )
+            when "blocks.full-width-banner"
+              DynamicComponents::FullWidthBanner.new(
+                textContent: ModelFactory.to_content_block(strapi_data[:textContent])
+              )
             end
           end
 

--- a/app/services/cms/providers/strapi/factories/component_factory.rb
+++ b/app/services/cms/providers/strapi/factories/component_factory.rb
@@ -14,14 +14,7 @@ module Cms
             when "blocks.text-with-asides"
               DynamicComponents::TextWithAsides.new(blocks: strapi_data[:textContent], asides: extract_aside_sections(strapi_data))
             when "blocks.horizontal-card"
-              DynamicComponents::HorizontalCard.new(
-                title: strapi_data[:title],
-                body_blocks: strapi_data[:bodyText],
-                image: ModelFactory.to_image(strapi_data, :image, default_size: :small),
-                image_link: strapi_data[:imageLink],
-                colour_theme: strapi_data.dig(:colourTheme, :data) ? strapi_data[:colourTheme][:data][:attributes][:name] : nil,
-                icon_block: icon_block(strapi_data[:iconBlock])
-              )
+              to_horizontal_card(strapi_data)
             when "buttons.ncce-button"
               to_ncce_button(strapi_data)
             when "blocks.question-and-answer"
@@ -35,7 +28,20 @@ module Cms
               )
             when "blocks.full-width-banner"
               to_full_width_banner(strapi_data)
+            when "blocks.full-width-text"
+              DynamicComponents::FullWidthText.new(blocks: ModelFactory.to_content_block(strapi_data[:content], with_wrapper: false))
             end
+          end
+
+          def self.to_horizontal_card(strapi_data)
+            DynamicComponents::HorizontalCard.new(
+              title: strapi_data[:title],
+              body_blocks: strapi_data[:bodyText],
+              image: ModelFactory.to_image(strapi_data, :image, default_size: :small),
+              image_link: strapi_data[:imageLink],
+              colour_theme: strapi_data.dig(:colourTheme, :data) ? strapi_data[:colourTheme][:data][:attributes][:name] : nil,
+              icon_block: icon_block(strapi_data[:iconBlock])
+            )
           end
 
           def self.to_full_width_banner(strapi_data)

--- a/app/services/cms/providers/strapi/factories/component_factory.rb
+++ b/app/services/cms/providers/strapi/factories/component_factory.rb
@@ -40,7 +40,7 @@ module Cms
               )
             when "blocks.full-width-banner"
               DynamicComponents::FullWidthBanner.new(
-                textContent: ModelFactory.to_content_block(strapi_data[:textContent])
+                text_content: ModelFactory.to_content_block(strapi_data[:textContent])
               )
             end
           end

--- a/app/services/cms/providers/strapi/factories/component_factory.rb
+++ b/app/services/cms/providers/strapi/factories/component_factory.rb
@@ -24,12 +24,15 @@ module Cms
                 title: strapi_data[:sectionTitle],
                 cards_block: resource_card_block(strapi_data[:resourceCard]),
                 cards_per_row: strapi_data[:cardsPerRow],
-                background_color: strapi_data.dig(:backgroundColour, :data) ? strapi_data[:backgroundColour][:data][:attributes][:name] : nil
+                background_color: extract_color_name(strapi_data, :backgroundColour)
               )
             when "blocks.full-width-banner"
               to_full_width_banner(strapi_data)
             when "blocks.full-width-text"
-              DynamicComponents::FullWidthText.new(blocks: ModelFactory.to_content_block(strapi_data[:content], with_wrapper: false))
+              DynamicComponents::FullWidthText.new(
+                blocks: ModelFactory.to_content_block(strapi_data[:content], with_wrapper: false),
+                background_color: extract_color_name(strapi_data, :backgroundColour)
+              )
             end
           end
 
@@ -39,7 +42,7 @@ module Cms
               body_blocks: strapi_data[:bodyText],
               image: ModelFactory.to_image(strapi_data, :image, default_size: :small),
               image_link: strapi_data[:imageLink],
-              colour_theme: strapi_data.dig(:colourTheme, :data) ? strapi_data[:colourTheme][:data][:attributes][:name] : nil,
+              colour_theme: extract_color_name(strapi_data, :colourTheme),
               icon_block: icon_block(strapi_data[:iconBlock])
             )
           end
@@ -47,12 +50,13 @@ module Cms
           def self.to_full_width_banner(strapi_data)
             DynamicComponents::FullWidthBanner.new(
               text_content: ModelFactory.to_content_block(strapi_data[:textContent], with_wrapper: false),
-              background_color: strapi_data.dig(:backgroundColour, :data) ? strapi_data[:backgroundColour][:data][:attributes][:name] : nil,
+              background_color: extract_color_name(strapi_data, :backgroundColour),
               image: ModelFactory.to_image(strapi_data, :image, default_size: :medium),
               image_side: strapi_data[:imageSide],
               image_link: strapi_data[:imageLink],
               buttons: strapi_data[:buttons] ? strapi_data[:buttons].map { to_ncce_button(_1) } : [],
-              title: strapi_data[:sectionTitle]
+              title: strapi_data[:sectionTitle],
+              show_bottom_border: strapi_data[:showBottomBorder]
             )
           end
 
@@ -79,12 +83,16 @@ module Cms
             end
           end
 
+          def self.extract_color_name(strapi_data, key)
+            strapi_data[key][:data][:attributes][:name] if strapi_data.dig(key, :data)
+          end
+
           def self.resource_card_block(strapi_data)
             strapi_data.map do |card_data|
               Models::ResourceCard.new(
                 title: card_data[:title],
                 icon: ModelFactory.to_image(card_data, :icon, default_size: :medium),
-                colour_theme: card_data.dig(:colourTheme, :data) ? card_data[:colourTheme][:data][:attributes][:name] : nil,
+                colour_theme: extract_color_name(strapi_data, :colourTheme),
                 body_text: card_data[:bodyText],
                 button_text: card_data[:buttonText],
                 button_link: card_data[:buttonLink]

--- a/app/services/cms/providers/strapi/factories/component_factory.rb
+++ b/app/services/cms/providers/strapi/factories/component_factory.rb
@@ -10,7 +10,7 @@ module Cms
               ModelFactory.to_content_block(strapi_data[:content], with_wrapper: false)
             when "content-blocks.file-link"
               file_data = strapi_data.dig(:file, :data) ? strapi_data[:file][:data][:attributes] : nil
-              ModelFactory.to_file(file_data) if file_data
+              to_file(file_data) if file_data
             when "blocks.text-with-asides"
               asides = if strapi_data.dig(:asideSections, :data)
                 strapi_data[:asideSections][:data].collect { _1[:attributes] }
@@ -40,7 +40,12 @@ module Cms
               )
             when "blocks.full-width-banner"
               DynamicComponents::FullWidthBanner.new(
-                text_content: ModelFactory.to_content_block(strapi_data[:textContent])
+                text_content: ModelFactory.to_content_block(strapi_data[:textContent]),
+                background_color: strapi_data[:backgroundColor][:name],
+                image: ModelFactory.to_image(strapi_data[:image]),
+                image_side: strapi_data[:image_side],
+                image_link: strapi_data[:imageLink],
+                buttons: [] # TODO pull from Q&A branch,
               )
             end
           end
@@ -85,6 +90,15 @@ module Cms
             DynamicComponents::Icon.new(
               text: icon_data[:iconText],
               image: ModelFactory.to_image(icon_data[:iconImage][:data][:attributes])
+            )
+          end
+
+          def self.to_file(data)
+            Models::File.new(
+              url: data[:url],
+              filename: data[:name],
+              size: data[:size],
+              updated_at: DateTime.parse(data[:updatedAt])
             )
           end
         end

--- a/app/services/cms/providers/strapi/factories/component_parameter_factory.rb
+++ b/app/services/cms/providers/strapi/factories/component_parameter_factory.rb
@@ -38,6 +38,16 @@ module Cms
             }
           end
 
+          def self.full_width_banner_parameters
+            {
+              populate: {
+                image: {populate: [:alternativeText]},
+                backgroundColour: {populate: [:name]},
+                buttons: {populate: [:title, :link]}
+              }
+            }
+          end
+
           def self.icon_block_parameters
             {populate: {iconImage: "alternativeText"}}
           end

--- a/app/services/cms/providers/strapi/factories/component_parameter_factory.rb
+++ b/app/services/cms/providers/strapi/factories/component_parameter_factory.rb
@@ -24,7 +24,10 @@ module Cms
 
           def self.text_block_parameters
             {
-              populate: {fields: "content"}
+              populate: {
+                fields: "content",
+                backgroundColour: {populate: {fields: "name"}}
+              }
             }
           end
 

--- a/app/services/cms/providers/strapi/factories/model_factory.rb
+++ b/app/services/cms/providers/strapi/factories/model_factory.rb
@@ -65,15 +65,6 @@ module Cms
             end
           end
 
-          def self.to_file(data)
-            Models::File.new(
-              url: data[:url],
-              filename: data[:name],
-              size: data[:size],
-              updated_at: DateTime.parse(data[:updatedAt])
-            )
-          end
-
           def self.to_enrichment(strapi_data)
             return nil if strapi_data[:publishedAt].nil? && Rails.env.production?
             type_data = strapi_data[:type][:data][:attributes]

--- a/app/services/cms/providers/strapi/factories/model_factory.rb
+++ b/app/services/cms/providers/strapi/factories/model_factory.rb
@@ -16,14 +16,12 @@ module Cms
               model_class.new(
                 title: strapi_data[:title],
                 description: strapi_data[:description],
-                featured_image: strapi_data.dig(:featuredImage, :data) ? to_image(strapi_data[:featuredImage][:data][:attributes]) : nil
+                featured_image: to_image(strapi_data, :featuredImage)
               )
             elsif model_class == Models::FeaturedImage
               to_featured_image(strapi_data[:data][:attributes])
             elsif model_class == Models::ContentBlock
               to_content_block(strapi_data)
-            elsif model_class == Models::RichHeader
-              model_class.new(blocks: strapi_data)
             elsif model_class == Models::SimpleTitle
               model_class.new(title: strapi_data)
             elsif model_class == Models::Aside
@@ -76,17 +74,17 @@ module Cms
               i_belong: strapi_data[:i_belong],
               terms: strapi_data.dig(:terms, :data).map { _1[:attributes][:name] },
               age_groups: strapi_data.dig(:age_groups, :data).map { _1[:attributes][:name] },
-              partner_icon: strapi_data[:partner_icon][:data].nil? ? nil : to_image(strapi_data[:partner_icon][:data][:attributes]),
+              partner_icon: to_image(strapi_data, :partner_icon, default_size: :small),
               type: Models::EnrichmentType.new(
                 name: type_data[:name],
-                icon: type_data[:icon][:data].nil? ? nil : to_image(type_data[:icon][:data][:attributes])
+                icon: to_image(type_data, :icon, default_size: :small)
               )
             )
           end
 
           def self.to_content_block(data, with_wrapper: true)
             data.map! do |block|
-              block[:image] = to_image(block[:image]) if block[:type] == "image"
+              block[:image] = as_image(block[:image], :medium) if block[:type] == "image"
               block
             end
             Models::ContentBlock.new(blocks: data, with_wrapper:)
@@ -102,7 +100,14 @@ module Cms
             )
           end
 
-          def self.to_image(image_data, default_size: :medium)
+          def self.to_image(strapi_data, image_key, default_size: :medium)
+            if strapi_data.dig(image_key, :data)
+              image_data = strapi_data[image_key][:data][:attributes]
+              as_image(image_data, default_size)
+            end
+          end
+
+          def self.as_image(image_data, default_size = :medium)
             Models::Image.new(
               url: image_data[:url],
               alt: image_data[:alternativeText],

--- a/app/services/cms/providers/strapi/factories/parameter_factory.rb
+++ b/app/services/cms/providers/strapi/factories/parameter_factory.rb
@@ -43,7 +43,7 @@ module Cms
                   "blocks.horizontal-card": ComponentParameterFactory.horizontal_card_parameters,
                   "blocks.question-and-answer": ComponentParameterFactory.question_and_answer_parameters,
                   "blocks.full-width-banner": ComponentParameterFactory.full_width_banner_parameters,
-                  "content-blocks.text-block": ComponentParameterFactory.text_block_parameters
+                  "blocks.full-width-text": ComponentParameterFactory.text_block_parameters
                 }
               }
             end

--- a/app/services/cms/providers/strapi/factories/parameter_factory.rb
+++ b/app/services/cms/providers/strapi/factories/parameter_factory.rb
@@ -42,6 +42,7 @@ module Cms
                   "blocks.card-section": ComponentParameterFactory.card_wrapper_parameters,
                   "blocks.horizontal-card": ComponentParameterFactory.horizontal_card_parameters,
                   "blocks.question-and-answer": ComponentParameterFactory.question_and_answer_parameters,
+                  "blocks.full-width-banner": ComponentParameterFactory.full_width_banner_parameters,
                   "content-blocks.text-block": ComponentParameterFactory.text_block_parameters
                 }
               }

--- a/app/services/cms/providers/strapi/mocks/aside_sections.rb
+++ b/app/services/cms/providers/strapi/mocks/aside_sections.rb
@@ -1,0 +1,24 @@
+module Cms
+  module Providers
+    module Strapi
+      module Mocks
+        class AsideSections
+          def self.generate_data(slugs: [])
+            slugs.map do |slug|
+              {
+                id: Faker::Number.number,
+                slug:
+              }
+            end
+          end
+
+          def self.generate_raw_data(slugs: [])
+            {
+              data: generate_data(slugs:).map { {attributes: _1} }
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/cms/providers/strapi/mocks/full_width_banner.rb
+++ b/app/services/cms/providers/strapi/mocks/full_width_banner.rb
@@ -1,0 +1,27 @@
+module Cms
+  module Providers
+    module Strapi
+      module Mocks
+        class FullWidthBanner
+          def self.as_model
+            Factories::ComponentFactory.process_component(generate_data)
+          end
+
+          def self.generate_data(aside_sections: [])
+            {
+              textContent: RichBlocks.generate,
+              image: nil
+            }
+          end
+
+          def self.generate_raw_data
+            {
+              __component: "blocks.full-width-banner",
+              id: 1
+            }.merge(generate_data)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/cms/providers/strapi/mocks/full_width_banner.rb
+++ b/app/services/cms/providers/strapi/mocks/full_width_banner.rb
@@ -7,10 +7,16 @@ module Cms
             Factories::ComponentFactory.process_component(generate_data)
           end
 
-          def self.generate_data(aside_sections: [])
+          def self.generate_data
             {
               textContent: RichBlocks.generate,
-              image: nil
+              image: Mocks::Image.generate_data,
+              imageLink: Faker::Internet.url,
+              backgroundColor: {
+                name: "white"
+              },
+              imageSide: "right",
+              buttons: nil
             }
           end
 

--- a/app/services/cms/providers/strapi/mocks/full_width_text.rb
+++ b/app/services/cms/providers/strapi/mocks/full_width_text.rb
@@ -2,27 +2,20 @@ module Cms
   module Providers
     module Strapi
       module Mocks
-        class FullWidthBanner
+        class FullWidthText
           def self.as_model
             Factories::ComponentFactory.process_component(generate_data)
           end
 
           def self.generate_data
             {
-              textContent: RichBlocks.generate_data,
-              image: Mocks::Image.generate_data,
-              imageLink: Faker::Internet.url,
-              backgroundColor: {
-                name: "white"
-              },
-              imageSide: "right",
-              buttons: nil
+              content: RichBlocks.generate_data
             }
           end
 
           def self.generate_raw_data
             {
-              __component: "blocks.full-width-banner",
+              __component: "blocks.full-width-text",
               id: 1
             }.merge(generate_data)
           end

--- a/app/services/cms/providers/strapi/mocks/horizontal_card.rb
+++ b/app/services/cms/providers/strapi/mocks/horizontal_card.rb
@@ -1,0 +1,31 @@
+module Cms
+  module Providers
+    module Strapi
+      module Mocks
+        class HorizontalCard
+          def self.as_model
+            Factories::ComponentFactory.to_horizontal_card(generate_data)
+          end
+
+          def self.generate_data
+            {
+              title: Faker::Lorem.words(number: 5),
+              bodyText: RichBlocks.generate_data,
+              image: Image.generate_data,
+              imageLink: nil,
+              colourTheme: nil,
+              iconBlock: IconBlocks.generate_data
+            }
+          end
+
+          def self.generate_raw_data
+            {
+              __component: "blocks.horizontal-card",
+              id: 1
+            }.merge(generate_data)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/cms/providers/strapi/mocks/image.rb
+++ b/app/services/cms/providers/strapi/mocks/image.rb
@@ -10,7 +10,7 @@ module Cms
           }
 
           def self.as_model
-            Factories::ModelFactory.to_image(generate_data)
+            Factories::ModelFactory.as_image(generate_data)
           end
 
           def self.generate_raw_data(caption: nil)

--- a/app/services/cms/providers/strapi/mocks/question_and_answer.rb
+++ b/app/services/cms/providers/strapi/mocks/question_and_answer.rb
@@ -7,11 +7,11 @@ module Cms
             Factories::ComponentFactory.to_question_and_answer(generate_data)
           end
 
-          def self.generate_data(aside_sections: {})
+          def self.generate_data(aside_slugs: [])
             {
               question: Faker::Lorem.sentence,
-              answer: RichBlocks.generate,
-              asideSections: aside_sections,
+              answer: RichBlocks.generate_data,
+              asideSections: AsideSections.generate_raw_data(slugs: aside_slugs),
               answerIcons: {},
               asideAlignment: :top,
               showBackgroundTriangle: false

--- a/app/services/cms/providers/strapi/mocks/resource_card.rb
+++ b/app/services/cms/providers/strapi/mocks/resource_card.rb
@@ -16,7 +16,7 @@ module Cms
                 title: title,
                 icon: icon,
                 colour_theme: colour_theme,
-                body_text: Cms::Mocks::RichBlocks.generate,
+                body_text: Cms::Mocks::RichBlocks.generate_data,
                 button_text: button_text,
                 button_link: button_link
               )

--- a/app/services/cms/providers/strapi/mocks/rich_blocks.rb
+++ b/app/services/cms/providers/strapi/mocks/rich_blocks.rb
@@ -4,10 +4,10 @@ module Cms
       module Mocks
         class RichBlocks
           def self.as_model
-            Factories::ModelFactory.to_content_block(generate)
+            Factories::ModelFactory.to_content_block(generate_data)
           end
 
-          def self.generate
+          def self.generate_data
             [paragraph(2)]
           end
 

--- a/app/services/cms/providers/strapi/mocks/rich_blocks.rb
+++ b/app/services/cms/providers/strapi/mocks/rich_blocks.rb
@@ -3,12 +3,12 @@ module Cms
     module Strapi
       module Mocks
         class RichBlocks
-          def self.as_model
-            Factories::ModelFactory.to_content_block(generate_data)
+          def self.as_model(with_wrapper: false)
+            Factories::ModelFactory.to_content_block(generate_data, with_wrapper:)
           end
 
           def self.generate_data
-            [paragraph(2)]
+            [paragraph(6)]
           end
 
           def self.paragraph(sentences)

--- a/app/webpacker/stylesheets/components/_button.scss
+++ b/app/webpacker/stylesheets/components/_button.scss
@@ -51,6 +51,11 @@
   @include ncce_button($blue);
 }
 
+.ncce-button--green {
+  @include ncce_button($lime-green);
+  color: $govuk-text-colour;
+}
+
 .button {
   @include ncce_button($lime-green);
   color: $govuk-text-colour;

--- a/app/webpacker/stylesheets/components/cms/_shared.scss
+++ b/app/webpacker/stylesheets/components/cms/_shared.scss
@@ -38,7 +38,6 @@
 .tc-row {
   display: flex;
   flex-direction: row;
-  padding: 0 15px;
   gap: 20px;
 
   @include govuk-media-query($until: desktop) {

--- a/previews/components/cms_full_width_banner_component_preview.rb
+++ b/previews/components/cms_full_width_banner_component_preview.rb
@@ -19,7 +19,7 @@ class CmsFullWidthBannerComponentPreview < ViewComponent::Preview
       image: Cms::Mocks::Image.as_model,
       image_side: :left,
       image_link: nil,
-      buttons: [] # TODO after merge
+      buttons: [Cms::Mocks::NcceButton.as_model]
     ))
   end
 end

--- a/previews/components/cms_full_width_banner_component_preview.rb
+++ b/previews/components/cms_full_width_banner_component_preview.rb
@@ -3,12 +3,23 @@
 class CmsFullWidthBannerComponentPreview < ViewComponent::Preview
   def default
     render(CmsFullWidthBannerComponent.new(
-      text_content: [], # Cms::Mocks::RichBlocks.generate,
+      text_content: Cms::Mocks::RichBlocks.generate,
       background_color: :white,
-      image: nil,  # Cms::Mocks::Image.as_model,
+      image: Cms::Mocks::Image.as_model,
       image_side: :left,
       image_link: nil,
       buttons: []
+    ))
+  end
+
+  def with_button
+    render(CmsFullWidthBannerComponent.new(
+      text_content: Cms::Mocks::RichBlocks.generate,
+      background_color: :white,
+      image: Cms::Mocks::Image.as_model,
+      image_side: :left,
+      image_link: nil,
+      buttons: [] # TODO after merge
     ))
   end
 end

--- a/previews/components/cms_full_width_banner_component_preview.rb
+++ b/previews/components/cms_full_width_banner_component_preview.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CmsFullWidthBannerComponentPreview < ViewComponent::Preview
+  def default
+    render(CmsFullWidthBannerComponent.new(
+      text_content: [], # Cms::Mocks::RichBlocks.generate,
+      background_color: :white,
+      image: nil,  # Cms::Mocks::Image.as_model,
+      image_side: :left,
+      image_link: nil,
+      buttons: []
+    ))
+  end
+end

--- a/previews/components/cms_full_width_text_block_component_preview.rb
+++ b/previews/components/cms_full_width_text_block_component_preview.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CmsFullWidthTextBlockComponentPreview < ViewComponent::Preview
+  def default
+    render(CmsFullWidthTextBlockComponent.new)
+  end
+end

--- a/previews/components/cms_full_width_text_block_component_preview.rb
+++ b/previews/components/cms_full_width_text_block_component_preview.rb
@@ -2,6 +2,8 @@
 
 class CmsFullWidthTextBlockComponentPreview < ViewComponent::Preview
   def default
-    render(CmsFullWidthTextBlockComponent.new)
+    render(CmsFullWidthTextBlockComponent.new(
+      blocks: Cms::Mocks::RichBlocks.as_model
+    ))
   end
 end

--- a/spec/components/cms_enrichment_component_spec.rb
+++ b/spec/components/cms_enrichment_component_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe CmsEnrichmentComponent, type: :component do
   before do
     render_inline(CmsEnrichmentComponent.new(
-      title: Cms::Models::RichHeader.new(blocks: Cms::Mocks::RichBlocks.generate),
-      details: Cms::Mocks::RichBlocks.generate,
+      title: Cms::Models::RichHeader.new(blocks: Cms::Mocks::RichBlocks.generate_data),
+      details: Cms::Mocks::RichBlocks.generate_data,
       link: "https:://www.teachcomputing.org/test-enrichment",
       i_belong: false,
       type: Cms::Models::EnrichmentType.new(

--- a/spec/components/cms_full_width_banner_component_spec.rb
+++ b/spec/components/cms_full_width_banner_component_spec.rb
@@ -3,16 +3,41 @@
 require "rails_helper"
 
 RSpec.describe CmsFullWidthBannerComponent, type: :component do
-  before do
-    render_inline(described_class.new(
-      text_content: [], # Cms::Mocks::RichBlocks.generate,
-      image: nil, # Cms::Mocks::Image.as_model,
-      image_side: :left,
-      image_link: nil
-    ))
+  context "standard layout" do
+    before do
+      render_inline(described_class.new(
+        text_content: Cms::Mocks::RichBlocks.as_model,
+        image: Cms::Mocks::Image.as_model,
+        image_side: :left,
+        image_link: nil,
+        title: nil
+      ))
+    end
+
+    it "renders the intro text" do
+      expect(page).to have_css(".cms-rich-text-block-component")
+    end
+
+    it "should have image" do
+      expect(page).to have_css("img")
+    end
   end
 
-  it "renders the intro text" do
-    expect(page).to have_css(".cms-rich-text-block-component")
+  context "with heading" do
+    let(:title) { Faker::Lorem.sentence }
+
+    before do
+      render_inline(described_class.new(
+        text_content: Cms::Mocks::RichBlocks.as_model,
+        image: Cms::Mocks::Image.as_model,
+        image_side: :left,
+        image_link: nil,
+        title:
+      ))
+    end
+
+    it "show render heading" do
+      expect(page).to have_css(".govuk-heading-l.cms-full-width-banner__heading", text: title)
+    end
   end
 end

--- a/spec/components/cms_full_width_banner_component_spec.rb
+++ b/spec/components/cms_full_width_banner_component_spec.rb
@@ -9,9 +9,14 @@ RSpec.describe CmsFullWidthBannerComponent, type: :component do
         text_content: Cms::Mocks::RichBlocks.as_model,
         image: Cms::Mocks::Image.as_model,
         image_side: :left,
-        image_link: nil,
-        title: nil
+        image_link: "https://www.teachcomputing.test/test-page",
+        title: nil,
+        background_color: "light-grey"
       ))
+    end
+
+    it "renders background color" do
+      expect(page).to have_css(".cms-full-width-banner-row.light-grey-bg")
     end
 
     it "renders the intro text" do
@@ -20,6 +25,10 @@ RSpec.describe CmsFullWidthBannerComponent, type: :component do
 
     it "should have image" do
       expect(page).to have_css("img")
+    end
+
+    it "should have link" do
+      expect(page).to have_link(href: "https://www.teachcomputing.test/test-page")
     end
   end
 
@@ -38,6 +47,23 @@ RSpec.describe CmsFullWidthBannerComponent, type: :component do
 
     it "show render heading" do
       expect(page).to have_css(".govuk-heading-l.cms-full-width-banner__heading", text: title)
+    end
+  end
+
+  context "with border" do
+    before do
+      render_inline(described_class.new(
+        text_content: Cms::Mocks::RichBlocks.as_model,
+        image: Cms::Mocks::Image.as_model,
+        image_side: :left,
+        image_link: nil,
+        title: nil,
+        show_bottom_border: true
+      ))
+    end
+
+    it "show render heading" do
+      expect(page).to have_css(".cms-full-width-banner-row.has-border")
     end
   end
 end

--- a/spec/components/cms_full_width_banner_component_spec.rb
+++ b/spec/components/cms_full_width_banner_component_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CmsFullWidthBannerComponent, type: :component do
+  before do
+    render_inline(described_class.new(
+      text_content: [], # Cms::Mocks::RichBlocks.generate,
+      image: nil, # Cms::Mocks::Image.as_model,
+      image_side: :left,
+      image_link: nil
+    ))
+  end
+
+  it "renders the intro text" do
+    expect(page).to have_css(".cms-rich-text-block-component")
+  end
+end

--- a/spec/components/cms_full_width_text_block_component_spec.rb
+++ b/spec/components/cms_full_width_text_block_component_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CmsFullWidthTextBlockComponent, type: :component do
+  before do
+    render_inline(described_class.new(blocks: Cms::Mocks::RichBlocks.as_model))
+  end
+
+  it "renders govuk grid row" do
+    expect(page).to have_css(".tc-gov-grid-wrapper")
+  end
+
+  it "has two full width column" do
+    expect(page).to have_css(".govuk-grid-column-full-width")
+  end
+end

--- a/spec/components/cms_full_width_text_block_component_spec.rb
+++ b/spec/components/cms_full_width_text_block_component_spec.rb
@@ -3,15 +3,34 @@
 require "rails_helper"
 
 RSpec.describe CmsFullWidthTextBlockComponent, type: :component do
-  before do
-    render_inline(described_class.new(blocks: Cms::Mocks::RichBlocks.as_model))
+  context "without background color" do
+    before do
+      render_inline(described_class.new(blocks: Cms::Mocks::RichBlocks.as_model, background_color: nil))
+    end
+
+    it "renders govuk grid row" do
+      expect(page).to have_css(".tc-gov-grid-wrapper")
+    end
+
+    it "has two full width column" do
+      expect(page).to have_css(".govuk-grid-column-full")
+    end
   end
 
-  it "renders govuk grid row" do
-    expect(page).to have_css(".tc-gov-grid-wrapper")
-  end
+  context "with background color" do
+    before do
+      render_inline(described_class.new(
+        blocks: Cms::Mocks::RichBlocks.as_model,
+        background_color: "light-grey"
+      ))
+    end
 
-  it "has two full width column" do
-    expect(page).to have_css(".govuk-grid-column-full-width")
+    it "renders govuk grid row" do
+      expect(page).to have_css(".tc-gov-grid-wrapper.light-grey-bg")
+    end
+
+    it "has two full width column" do
+      expect(page).to have_css(".govuk-grid-column-full")
+    end
   end
 end

--- a/spec/components/cms_horizontal_card_component_spec.rb
+++ b/spec/components/cms_horizontal_card_component_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe CmsHorizontalCardComponent, type: :component do
   context "with only a title and body block" do
-    let(:content_block) { Cms::Mocks::RichBlocks.generate }
+    let(:content_block) { Cms::Mocks::RichBlocks.generate_data }
 
     before do
       render_inline(described_class.new(
@@ -42,7 +42,7 @@ RSpec.describe CmsHorizontalCardComponent, type: :component do
     before do
       render_inline(described_class.new(
         title: "Page title",
-        body_blocks: Cms::Mocks::RichBlocks.generate,
+        body_blocks: Cms::Mocks::RichBlocks.generate_data,
         image: Cms::Mocks::Image.as_model,
         image_link: nil,
         colour_theme: nil,
@@ -59,7 +59,7 @@ RSpec.describe CmsHorizontalCardComponent, type: :component do
     before do
       render_inline(described_class.new(
         title: "Page title",
-        body_blocks: Cms::Mocks::RichBlocks.generate,
+        body_blocks: Cms::Mocks::RichBlocks.generate_data,
         image: Cms::Mocks::Image.as_model,
         image_link: "https://www.example.com",
         colour_theme: nil,
@@ -80,7 +80,7 @@ RSpec.describe CmsHorizontalCardComponent, type: :component do
     before do
       render_inline(described_class.new(
         title: "Page title",
-        body_blocks: Cms::Mocks::RichBlocks.generate,
+        body_blocks: Cms::Mocks::RichBlocks.generate_data,
         image: Cms::Mocks::Image.as_model,
         image_link: nil,
         colour_theme: nil,
@@ -101,7 +101,7 @@ RSpec.describe CmsHorizontalCardComponent, type: :component do
     before do
       render_inline(described_class.new(
         title: "Page title",
-        body_blocks: Cms::Mocks::RichBlocks.generate,
+        body_blocks: Cms::Mocks::RichBlocks.generate_data,
         image: nil,
         image_link: nil,
         colour_theme: "standard",
@@ -118,7 +118,7 @@ RSpec.describe CmsHorizontalCardComponent, type: :component do
     before do
       render_inline(described_class.new(
         title: "Page title",
-        body_blocks: Cms::Mocks::RichBlocks.generate,
+        body_blocks: Cms::Mocks::RichBlocks.generate_data,
         image: nil,
         image_link: nil,
         colour_theme: nil,

--- a/spec/components/cms_ncce_button_component_spec.rb
+++ b/spec/components/cms_ncce_button_component_spec.rb
@@ -3,30 +3,15 @@
 require "rails_helper"
 
 RSpec.describe CmsNcceButtonComponent, type: :component do
-  describe "without colour" do
-    before do
-      render_inline(described_class.new(
-        title: "Click me",
-        link: "https://www.teachcomputing.test/click-me"
-      ))
-    end
-
-    it "should render the link with correct classes" do
-      expect(page).to have_link("Click me", href: "https://www.teachcomputing.test/click-me", class: ["button", "govuk-button"])
-    end
+  before do
+    render_inline(described_class.new(
+      title: "Click me",
+      link: "https://www.teachcomputing.test/click-me",
+      color: :white
+    ))
   end
 
-  describe "with colour" do
-    before do
-      render_inline(described_class.new(
-        title: "Click me",
-        link: "https://www.teachcomputing.test/click-me",
-        colour: :white
-      ))
-    end
-
-    it "should render the link with the correct classes" do
-      expect(page).to have_link("Click me", href: "https://www.teachcomputing.test/click-me", class: ["button", "govuk-button", "ncce-button--white"])
-    end
+  it "should render the link with the correct classes" do
+    expect(page).to have_link("Click me", href: "https://www.teachcomputing.test/click-me", class: ["button", "govuk-button", "ncce-button--white"])
   end
 end

--- a/spec/components/cms_question_and_answer_component_spec.rb
+++ b/spec/components/cms_question_and_answer_component_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe CmsQuestionAndAnswerComponent, type: :component do
   before do
-    stub_strapi_aside_section
+    stub_strapi_aside_section("test-aside")
   end
 
   context "standard layout" do

--- a/spec/components/cms_resource_card_component_spec.rb
+++ b/spec/components/cms_resource_card_component_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe CmsResourceCardComponent, type: :component do
-  let(:body_text) { Cms::Mocks::RichBlocks.generate }
+  let(:body_text) { Cms::Mocks::RichBlocks.generate_data }
 
   context "has all the values defined" do
     before do

--- a/spec/components/cms_text_with_asides_component_spec.rb
+++ b/spec/components/cms_text_with_asides_component_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe CmsTextWithAsidesComponent, type: :component do
   before do
-    stub_strapi_aside_section
+    stub_strapi_aside_section("test-aside")
     render_inline(described_class.new(blocks: [], asides: [{slug: "test-aside"}]))
   end
 

--- a/spec/components/cms_text_with_asides_component_spec.rb
+++ b/spec/components/cms_text_with_asides_component_spec.rb
@@ -3,24 +3,45 @@
 require "rails_helper"
 
 RSpec.describe CmsTextWithAsidesComponent, type: :component do
-  before do
-    stub_strapi_aside_section("test-aside")
-    render_inline(described_class.new(blocks: [], asides: [{slug: "test-aside"}]))
+  context "with valid aside" do
+    before do
+      stub_strapi_aside_section("test-aside")
+      render_inline(described_class.new(blocks: [], asides: [{slug: "test-aside"}]))
+    end
+
+    it "renders govuk grid row" do
+      expect(page).to have_css(".tc-gov-grid-wrapper")
+    end
+
+    it "has two thirds column" do
+      expect(page).to have_css(".govuk-grid-column-two-thirds")
+    end
+
+    it "has one third column" do
+      expect(page).to have_css(".govuk-grid-column-one-third")
+    end
+
+    it "should display aside section" do
+      expect(page).to have_css(".aside-component")
+    end
   end
 
-  it "renders govuk grid row" do
-    expect(page).to have_css(".tc-gov-grid-wrapper")
-  end
+  context "with missing aside" do
+    before do
+      stub_strapi_aside_section_missing("missing-aside")
+      render_inline(described_class.new(blocks: [], asides: [{slug: "missing-aside"}]))
+    end
 
-  it "has two thirds column" do
-    expect(page).to have_css(".govuk-grid-column-two-thirds")
-  end
+    it "renders govuk grid row" do
+      expect(page).to have_css(".tc-gov-grid-wrapper")
+    end
 
-  it "has one third column" do
-    expect(page).to have_css(".govuk-grid-column-one-third")
-  end
+    it "has two thirds column" do
+      expect(page).to have_css(".govuk-grid-column-two-thirds")
+    end
 
-  it "should display aside section" do
-    expect(page).to have_css(".aside-component")
+    it "has one third column" do
+      expect(page).to have_css(".govuk-grid-column-one-third")
+    end
   end
 end

--- a/spec/components/cms_with_asides_component_spec.rb
+++ b/spec/components/cms_with_asides_component_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe CmsWithAsidesComponent, type: :component do
   context "missing aside" do
     before do
       stub_strapi_aside_section_missing("missing-aside")
-      puts "Im here"
       render_inline(described_class.new(aside_sections: [{slug: "missing-aside"}]))
     end
 

--- a/spec/components/cms_with_asides_component_spec.rb
+++ b/spec/components/cms_with_asides_component_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe CmsWithAsidesComponent, type: :component do
+  context "with valid aside" do
+    before do
+      stub_strapi_aside_section
+      render_inline(described_class.new(aside_sections: [{slug: "test-aside"}]))
+    end
+
+    it "should display aside section" do
+      expect(page).to have_css(".aside-component")
+    end
+  end
+
+  context "with multiple asides" do
+    before do
+      stub_strapi_aside_section
+      render_inline(described_class.new(aside_sections: [{slug: "test-aside"}, {slug: "test-aside-2"}]))
+    end
+
+    it "should display aside section" do
+      expect(page).to have_css(".aside-component", count: 2)
+    end
+  end
+
+  context "missing aside" do
+    before do
+      stub_strapi_aside_section_missing("missing-aside")
+      render_inline(described_class.new(aside_sections: [{slug: "missing-aside"}]))
+    end
+
+    it "should display aside section" do
+      expect(page).not_to have_css(".aside-component")
+    end
+  end
+end

--- a/spec/components/cms_with_asides_component_spec.rb
+++ b/spec/components/cms_with_asides_component_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe CmsWithAsidesComponent, type: :component do
   context "with valid aside" do
     before do
-      stub_strapi_aside_section
+      stub_strapi_aside_section("test-aside")
       render_inline(described_class.new(aside_sections: [{slug: "test-aside"}]))
     end
 
@@ -14,7 +14,7 @@ RSpec.describe CmsWithAsidesComponent, type: :component do
 
   context "with multiple asides" do
     before do
-      stub_strapi_aside_section
+      stub_strapi_aside_section("test-aside")
       render_inline(described_class.new(aside_sections: [{slug: "test-aside"}, {slug: "test-aside-2"}]))
     end
 
@@ -26,6 +26,7 @@ RSpec.describe CmsWithAsidesComponent, type: :component do
   context "missing aside" do
     before do
       stub_strapi_aside_section_missing("missing-aside")
+      puts "Im here"
       render_inline(described_class.new(aside_sections: [{slug: "missing-aside"}]))
     end
 

--- a/spec/components/dashboard_programme_activity_group_section_component_spec.rb
+++ b/spec/components/dashboard_programme_activity_group_section_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DashboardProgrammeActivityGroupSectionComponent, type: :component
   context "with aside slug" do
     context "when cms returns aside" do
       before do
-        stub_strapi_aside_section
+        stub_strapi_aside_section("testing-with-aside")
         render_inline(described_class.new(
           anchor_id: "test-id",
           title: "With Aside",

--- a/spec/components/gov_grid_row_component_spec.rb
+++ b/spec/components/gov_grid_row_component_spec.rb
@@ -60,4 +60,19 @@ RSpec.describe GovGridRowComponent, type: :component do
       expect(page).to have_css("div.govuk-grid-column-full[class*='margin-left-1']")
     end
   end
+
+  context "with non valid column" do
+    it "should raise an error" do
+      expect do
+        described_class.new(
+          padding: {right: 5},
+          margin: {bottom: 4}
+        ).tap do |c|
+          c.with_column("full-width", padding: {top: 2}, margin: {left: 1}) do
+            "Some text"
+          end
+        end
+      end.to raise_error(StandardError)
+    end
+  end
 end

--- a/spec/requests/certificates/i_belong_dashboard_spec.rb
+++ b/spec/requests/certificates/i_belong_dashboard_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Certificates::IBelongController do
     before do
       stub_attendance_sets
       stub_delegate
-      stub_strapi_aside_section
+      stub_strapi_aside_section("i-belong-dashboard-help-section")
+      stub_strapi_aside_section("i-belong-community-help")
     end
 
     describe "while unenrolled" do

--- a/spec/requests/cms/cms_enrichment_spec.rb
+++ b/spec/requests/cms/cms_enrichment_spec.rb
@@ -26,4 +26,21 @@ RSpec.describe CmsController do
       end
     end
   end
+
+  describe "cache clearing" do
+    before do
+      allow(Cms::Collections::EnrichmentPage).to receive(:clear_cache).and_return(nil)
+      get "/primary-enrichment/refresh"
+    end
+
+    context "with a cms page" do
+      it "redirects to page" do
+        expect(response).to redirect_to("/primary-enrichment")
+      end
+
+      it "calls cache clear method" do
+        expect(Cms::Collections::EnrichmentPage).to have_received(:clear_cache).with("primary-enrichment")
+      end
+    end
+  end
 end

--- a/spec/services/cms/collections/web_page_spec.rb
+++ b/spec/services/cms/collections/web_page_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Cms::Collections::WebPage do
+  let(:required_models) {
+    [Cms::Models::PageTitle, Cms::Models::Seo, Cms::Models::DynamicZone]
+  }
+
   before do
   end
 
@@ -10,5 +14,10 @@ RSpec.describe Cms::Collections::WebPage do
 
   it "should have 15 minute cache expiry" do
     expect(described_class.cache_expiry).to eq(4.hours)
+  end
+
+  it "should have the correct models" do
+    models = described_class.resource_attribute_mappings.collect { _1[:model] }
+    expect(models).to eq(required_models)
   end
 end

--- a/spec/services/cms/dynamic_components/full_width_banner_spec.rb
+++ b/spec/services/cms/dynamic_components/full_width_banner_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.describe Cms::DynamicComponents::FullWidthBanner do
   before do
-    @button = Cms::Providers::Strapi::Factories::ComponentFactory.to_full_width_banner(Cms::Mocks::FullWidthBanner.generate_data)
+    @banner = Cms::Providers::Strapi::Factories::ComponentFactory.to_full_width_banner(Cms::Mocks::FullWidthBanner.generate_data)
   end
 
   it "should render as CmsFullWidthBannerComponent" do
-    expect(@button.render).to be_a(CmsFullWidthBannerComponent)
+    expect(@banner.render).to be_a(CmsFullWidthBannerComponent)
   end
 end

--- a/spec/services/cms/dynamic_components/full_width_banner_spec.rb
+++ b/spec/services/cms/dynamic_components/full_width_banner_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Cms::DynamicComponents::FullWidthBanner do
+  before do
+    @button = Cms::Providers::Strapi::Factories::ComponentFactory.to_full_width_banner(Cms::Mocks::FullWidthBanner.generate_data)
+  end
+
+  it "should render as CmsFullWidthBannerComponent" do
+    expect(@button.render).to be_a(CmsFullWidthBannerComponent)
+  end
+end

--- a/spec/services/cms/dynamic_components/full_width_text_spec.rb
+++ b/spec/services/cms/dynamic_components/full_width_text_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Cms::DynamicComponents::FullWidthText do
+  before do
+    @text = Cms::Providers::Strapi::Factories::ComponentFactory.process_component(Cms::Mocks::FullWidthText.generate_raw_data)
+  end
+
+  it "should render as CmsFullWidthBannerComponent" do
+    expect(@text.render).to be_a(CmsFullWidthTextBlockComponent)
+  end
+end

--- a/spec/services/cms/dynamic_components/horizontal_card_spec.rb
+++ b/spec/services/cms/dynamic_components/horizontal_card_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Cms::DynamicComponents::HorizontalCard do
+  before do
+    @card = Cms::Providers::Strapi::Factories::ComponentFactory.to_horizontal_card(Cms::Mocks::HorizontalCard.generate_data)
+  end
+
+  it "should render as CmsHorizontalCardComponent" do
+    expect(@card.render).to be_a(CmsHorizontalCardComponent)
+  end
+end

--- a/spec/services/cms/dynamic_components/ncce_button_spec.rb
+++ b/spec/services/cms/dynamic_components/ncce_button_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Cms::DynamicComponents::NcceButton do
+  before do
+    @button = Cms::Providers::Strapi::Factories::ComponentFactory.to_ncce_button(Cms::Mocks::NcceButton.generate_data)
+  end
+
+  it "should render as CmsNcceButtonComponent" do
+    expect(@button.render).to be_a(CmsNcceButtonComponent)
+  end
+end

--- a/spec/services/cms/dynamic_components/question_and_answer_spec.rb
+++ b/spec/services/cms/dynamic_components/question_and_answer_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Cms::DynamicComponents::QuestionAndAnswer do
+  before do
+    @button = Cms::Providers::Strapi::Factories::ComponentFactory.to_question_and_answer(Cms::Mocks::QuestionAndAnswer.generate_data)
+  end
+
+  it "should render as CmsQuestionAndAnswerComponent" do
+    expect(@button.render).to be_a(CmsQuestionAndAnswerComponent)
+  end
+end

--- a/spec/services/cms/dynamic_components/question_and_answer_spec.rb
+++ b/spec/services/cms/dynamic_components/question_and_answer_spec.rb
@@ -2,10 +2,12 @@ require "rails_helper"
 
 RSpec.describe Cms::DynamicComponents::QuestionAndAnswer do
   before do
-    @button = Cms::Providers::Strapi::Factories::ComponentFactory.to_question_and_answer(Cms::Mocks::QuestionAndAnswer.generate_data)
+    stub_strapi_aside_section("test-aside")
+    data = Cms::Mocks::QuestionAndAnswer.generate_data(aside_slugs: ["test-aside"])
+    @qa_component = Cms::Providers::Strapi::Factories::ComponentFactory.to_question_and_answer(data)
   end
 
   it "should render as CmsQuestionAndAnswerComponent" do
-    expect(@button.render).to be_a(CmsQuestionAndAnswerComponent)
+    expect(@qa_component.render).to be_a(CmsQuestionAndAnswerComponent)
   end
 end

--- a/spec/services/cms/providers/strapi/component_factory_spec.rb
+++ b/spec/services/cms/providers/strapi/component_factory_spec.rb
@@ -24,4 +24,20 @@ RSpec.describe Cms::Providers::Strapi::Factories::ComponentFactory do
       expect(model).to be_a Cms::DynamicComponents::FullWidthBanner
     end
   end
+
+  context "HorizontalCard" do
+    it "should be created" do
+      strapi_data = Cms::Providers::Strapi::Mocks::HorizontalCard.generate_raw_data
+      model = described_class.process_component(strapi_data)
+      expect(model).to be_a Cms::DynamicComponents::HorizontalCard
+    end
+  end
+
+  context "FullWidthText" do
+    it "should be created" do
+      strapi_data = Cms::Providers::Strapi::Mocks::FullWidthText.generate_raw_data
+      model = described_class.process_component(strapi_data)
+      expect(model).to be_a Cms::DynamicComponents::FullWidthText
+    end
+  end
 end

--- a/spec/services/cms/providers/strapi/component_factory_spec.rb
+++ b/spec/services/cms/providers/strapi/component_factory_spec.rb
@@ -16,4 +16,12 @@ RSpec.describe Cms::Providers::Strapi::Factories::ComponentFactory do
       expect(model).to be_a Cms::DynamicComponents::NcceButton
     end
   end
+
+  context "FullWidthBanner" do
+    it "should be created" do
+      strapi_data = Cms::Providers::Strapi::Mocks::FullWidthBanner.generate_raw_data
+      model = described_class.process_component(strapi_data)
+      expect(model).to be_a Cms::DynamicComponents::FullWidthBanner
+    end
+  end
 end

--- a/spec/support/cms/providers/strapi/aside_section_response.json
+++ b/spec/support/cms/providers/strapi/aside_section_response.json
@@ -7,6 +7,7 @@
             "createdAt": "2024-08-13T12:41:36.015Z",
             "updatedAt": "2024-08-13T15:02:12.914Z",
             "publishedAt": "2024-08-13T12:41:37.767Z",
+            "showHeadingLine": false,
             "content": [
                 {
                     "id": 1,

--- a/spec/support/cms/providers/strapi/strapi_stubs.rb
+++ b/spec/support/cms/providers/strapi/strapi_stubs.rb
@@ -91,9 +91,9 @@ module StrapiStubs
     stub_request(:get, /^https:\/\/strapi.teachcomputing.org\/api\/blogs\?.*(filters\[blog_tags\]\[slug\]\[\$eq\]=#{tag}).*/).to_return(body: json_response)
   end
 
-  def stub_strapi_aside_section
+  def stub_strapi_aside_section(key)
     json_response = File.new("spec/support/cms/providers/strapi/aside_section_response.json")
-    stub_request(:get, /^https:\/\/strapi.teachcomputing.org\/api\/aside-sections/).to_return(body: json_response)
+    stub_request(:get, /^https:\/\/strapi.teachcomputing.org\/api\/aside-sections\/#{key}/).to_return(body: json_response)
   end
 
   def stub_strapi_aside_section_missing(key)

--- a/spec/views/certificates/i_belong/show_spec.rb
+++ b/spec/views/certificates/i_belong/show_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe("certificates/i_belong/show", type: :view) do
   before do
     stub_course_templates
     stub_duration_units
-    stub_strapi_aside_section
+    stub_strapi_aside_section("i-belong-dashboard-help-section")
+    stub_strapi_aside_section("i-belong-community-help")
 
     groups = professional_development_groups
 


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Review App link(s): https://teachcomputing-pr-2167.herokuapp.com/
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2834

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Increasing test coverage across some of the strapi components
- Created new full width banner component
- Created new full width text component

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
