### PR TITLE
Bug Fix: Page subtext missing after strapi rename

### DIFF
--- a/app/components/cms_page_title_component.rb
+++ b/app/components/cms_page_title_component.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class CmsPageTitleComponent < ViewComponent::Base
-  def initialize(title:, intro_text: nil)
+  def initialize(title:, sub_text: nil)
     @title = title
-    @intro_text = intro_text
+    @sub_text = sub_text
   end
 end

--- a/app/components/cms_page_title_component/cms_page_title_component.html.erb
+++ b/app/components/cms_page_title_component/cms_page_title_component.html.erb
@@ -4,9 +4,9 @@
       <h1 class="govuk-heading-l page-title__title-text">
         <%= @title %>
       </h1>
-      <% if @intro_text %>
-        <p class="govuk-body page-title__intro-text">
-          <%= @intro_text %>
+      <% if @sub_text %>
+        <p class="govuk-body page-title__sub-text">
+          <%= @sub_text %>
         </p>
       <% end %>
     </div>

--- a/app/components/cms_page_title_component/cms_page_title_component.scss
+++ b/app/components/cms_page_title_component/cms_page_title_component.scss
@@ -8,7 +8,7 @@
     margin-bottom: 0;
   }
 
-  &__intro-text {
+  &__sub-text {
     color: $mid-gray;
     margin-top: 10px;
     margin-bottom: 0;

--- a/app/services/cms/models/page_title.rb
+++ b/app/services/cms/models/page_title.rb
@@ -1,15 +1,15 @@
 module Cms
   module Models
     class PageTitle
-      attr_accessor :title, :intro_text
+      attr_accessor :title, :sub_text
 
-      def initialize(title:, intro_text:)
+      def initialize(title:, sub_text:)
         @title = title
-        @intro_text = intro_text
+        @sub_text = sub_text
       end
 
       def render
-        CmsPageTitleComponent.new(title:, intro_text:)
+        CmsPageTitleComponent.new(title:, sub_text:)
       end
     end
   end

--- a/app/services/cms/providers/strapi/factories/model_factory.rb
+++ b/app/services/cms/providers/strapi/factories/model_factory.rb
@@ -36,7 +36,7 @@ module Cms
             elsif model_class == Models::PageTitle
               model_class.new(
                 title: strapi_data[:title],
-                intro_text: strapi_data[:introText]
+                sub_text: strapi_data[:subText]
               )
             elsif model_class == Models::BlogPreview
               model_class.new(

--- a/spec/components/cms_page_title_component_spec.rb
+++ b/spec/components/cms_page_title_component_spec.rb
@@ -4,14 +4,14 @@ require "rails_helper"
 
 RSpec.describe CmsPageTitleComponent, type: :component do
   before do
-    render_inline(described_class.new(title: "Page title", intro_text: "Intro text for the page"))
+    render_inline(described_class.new(title: "Page title", sub_text: "Sub text for the page"))
   end
 
   it "renders the title" do
     expect(page).to have_text("Page title")
   end
 
-  it "renders the intro text" do
-    expect(page).to have_text("Intro text for the page")
+  it "renders the sub text" do
+    expect(page).to have_text("Sub text for the page")
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for front-end / tech review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2886

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Fixing the broken reference to intro-text in page titles, after strapi rename
This has taken the subtitle off the enrichment pages, this quick fix should put them back in as will be a few days before the strapi pages go live

