### PR TITLE
Remove global spacing incorrectly applied to Asides

### DIFF
--- a/app/components/cms_dynamic_zone_component.rb
+++ b/app/components/cms_dynamic_zone_component.rb
@@ -1,12 +1,19 @@
 # frozen_string_literal: true
 
 class CmsDynamicZoneComponent < ViewComponent::Base
-  def initialize(cms_models)
+  def initialize(cms_models:, with_spacing: true)
     @cms_models = cms_models
+    @with_spacing = with_spacing
+  end
+
+  def wrapper_classes
+    classes = ["cms-dynamic-zone"]
+    classes += ["govuk-!-margin-bottom-7", "govuk-!-margin-top-7"] if @with_spacing
+    classes.join(" ")
   end
 
   erb_template <<~ERB
-    <div class="cms-dynamic-zone govuk-!-margin-bottom-7 govuk-!-margin-top-7">
+    <div class="<%= wrapper_classes %>">
       <% @cms_models.each do |model| %>
         <%= render model.render %>
       <% end %>

--- a/app/services/cms/models/dynamic_zone.rb
+++ b/app/services/cms/models/dynamic_zone.rb
@@ -1,12 +1,15 @@
 module Cms
   module Models
     class DynamicZone
-      def initialize(cms_models)
+      attr_accessor :cms_models, :with_spacing
+
+      def initialize(cms_models:, with_spacing: true)
         @cms_models = cms_models
+        @with_spacing = with_spacing
       end
 
       def render
-        CmsDynamicZoneComponent.new(@cms_models)
+        CmsDynamicZoneComponent.new(cms_models:, with_spacing:)
       end
     end
   end

--- a/app/services/cms/providers/strapi/factories/model_factory.rb
+++ b/app/services/cms/providers/strapi/factories/model_factory.rb
@@ -27,7 +27,10 @@ module Cms
             elsif model_class == Models::Aside
               model_class.new(
                 title: strapi_data[:title],
-                dynamic_content: Models::DynamicZone.new(strapi_data[:content].map { ComponentFactory.process_component(_1) }.compact),
+                dynamic_content: Models::DynamicZone.new(
+                  cms_models: strapi_data[:content].map { ComponentFactory.process_component(_1) }.compact,
+                  with_spacing: false
+                ),
                 show_heading_line: strapi_data[:showHeadingLine],
                 aside_icons: ComponentFactory.icon_block(strapi_data[:asideIcons])
               )
@@ -45,7 +48,7 @@ module Cms
                 slug: strapi_data[:slug]
               )
             elsif model_class == Models::DynamicZone
-              model_class.new(strapi_data.map { ComponentFactory.process_component(_1) }.compact)
+              model_class.new(cms_models: strapi_data.map { ComponentFactory.process_component(_1) }.compact)
             elsif model_class == Models::EnrichmentList
               model_class.new(
                 enrichments: strapi_data[:data].map { to_enrichment(_1[:attributes]) }.compact,

--- a/spec/components/cms_dynamic_zone_component_spec.rb
+++ b/spec/components/cms_dynamic_zone_component_spec.rb
@@ -3,30 +3,66 @@
 require "rails_helper"
 
 RSpec.describe CmsDynamicZoneComponent, type: :component do
-  before do
-    render_inline(described_class.new(
-      [
-        Cms::Models::TextBlock.new(blocks: [
-          type: "paragraph",
-          children: [
-            {type: "text", text: "Hello world!"}
-          ]
-        ]),
-        Cms::Models::TextBlock.new(blocks: [
-          type: "paragraph",
-          children: [
-            {type: "text", text: "Hello world! Number 2"}
-          ]
-        ])
-      ]
-    ))
+  context "with spacing" do
+    before do
+      render_inline(described_class.new(
+        cms_models: [
+          Cms::Models::TextBlock.new(blocks: [
+            type: "paragraph",
+            children: [
+              {type: "text", text: "Hello world!"}
+            ]
+          ]),
+          Cms::Models::TextBlock.new(blocks: [
+            type: "paragraph",
+            children: [
+              {type: "text", text: "Hello world! Number 2"}
+            ]
+          ])
+        ]
+      ))
+    end
+
+    it "should render wrapper" do
+      expect(page).to have_css(".cms-dynamic-zone.govuk-\\!-margin-bottom-7.govuk-\\!-margin-top-7")
+    end
+
+    it "should render content blocks" do
+      expect(page).to have_css(".cms-rich-text-block-component", count: 2)
+    end
   end
 
-  it "should render wrapper" do
-    expect(page).to have_css(".cms-dynamic-zone")
-  end
+  context "without spacing" do
+    before do
+      render_inline(described_class.new(
+        cms_models: [
+          Cms::Models::TextBlock.new(blocks: [
+            type: "paragraph",
+            children: [
+              {type: "text", text: "Hello world!"}
+            ]
+          ]),
+          Cms::Models::TextBlock.new(blocks: [
+            type: "paragraph",
+            children: [
+              {type: "text", text: "Hello world! Number 2"}
+            ]
+          ])
+        ],
+        with_spacing: false
+      ))
+    end
 
-  it "should render content blocks" do
-    expect(page).to have_css(".cms-rich-text-block-component", count: 2)
+    it "should render wrapper" do
+      expect(page).to have_css(".cms-dynamic-zone")
+    end
+
+    it "should render wrapper without spacing" do
+      expect(page).to_not have_css(".cms-dynamic-zone.govuk-\\!-margin-bottom-7")
+    end
+
+    it "should render content blocks" do
+      expect(page).to have_css(".cms-rich-text-block-component", count: 2)
+    end
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2887

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Optional flag to remove the default spacing on dynamic zones, on by default

