### PR TITLE
Comms fixes for Strapi ECT pages

### DIFF
--- a/app/components/cms_dynamic_zone_component.rb
+++ b/app/components/cms_dynamic_zone_component.rb
@@ -1,19 +1,12 @@
 # frozen_string_literal: true
 
 class CmsDynamicZoneComponent < ViewComponent::Base
-  def initialize(cms_models:, with_spacing: true)
+  def initialize(cms_models:)
     @cms_models = cms_models
-    @with_spacing = with_spacing
-  end
-
-  def wrapper_classes
-    classes = ["cms-dynamic-zone"]
-    classes += ["govuk-!-margin-bottom-7", "govuk-!-margin-top-7"] if @with_spacing
-    classes.join(" ")
   end
 
   erb_template <<~ERB
-    <div class="<%= wrapper_classes %>">
+    <div class="cms-dynamic-zone">
       <% @cms_models.each do |model| %>
         <%= render model.render %>
       <% end %>

--- a/app/components/cms_picture_card_component/cms_picture_card_component.html.erb
+++ b/app/components/cms_picture_card_component/cms_picture_card_component.html.erb
@@ -3,7 +3,7 @@
     <%= render CmsImageComponent.new(@image, show_caption: false, link: @link) %>
   <% end %>
   <div class="cms-picture-card__title">
-    <h2 class="govuk-heading-m"><%= link_to_if @link, @title, @link %></h2>
+    <h2 class="govuk-heading-m"><%= link_to_if @link, @title, @link, class: "cms-picture-card__link" %></h2>
   </div>
   <div class="cms-picture-card__text">
     <%= render @body_text.render %>

--- a/app/components/cms_question_and_answer_component/cms_question_and_answer_component.html.erb
+++ b/app/components/cms_question_and_answer_component/cms_question_and_answer_component.html.erb
@@ -6,7 +6,7 @@
       <div class="tc-row-two-thirds">
 
         <div class="question-answer__question">
-          <div class="question-answer__question-content">
+          <div class="question-answer__question-content govuk-heading-m">
             <%= @question %>
           </div>
         </div>

--- a/app/components/cms_question_and_answer_component/cms_question_and_answer_component.scss
+++ b/app/components/cms_question_and_answer_component/cms_question_and_answer_component.scss
@@ -39,7 +39,6 @@ $avatar_size: 32px;
     }
 
     &-content {
-      @include govuk-font($size: 24, $weight: bold);
       padding: 20px 25px;
       box-shadow: 0px 0px 8px 0px #0000004D;
       border-radius: 5px;

--- a/app/components/cms_rich_text_block_component/cms_rich_text_block_component.scss
+++ b/app/components/cms_rich_text_block_component/cms_rich_text_block_component.scss
@@ -18,6 +18,12 @@
   text-decoration: line-through;
 }
 
+.cms-rich-text-block-component {
+  p:last-child {
+    margin-bottom: 0px;
+  }
+}
+
 
 .cms-rich-text-block-component__text--code {
   p {

--- a/app/services/cms/dynamic_components/linked_picture.rb
+++ b/app/services/cms/dynamic_components/linked_picture.rb
@@ -1,0 +1,16 @@
+module Cms
+  module DynamicComponents
+    class LinkedPicture
+      attr_accessor :image, :link
+
+      def initialize(image:, link:)
+        @image = image
+        @link = link
+      end
+
+      def render
+        CmsImageComponent.new(image, show_caption: false, link:)
+      end
+    end
+  end
+end

--- a/app/services/cms/models/dynamic_zone.rb
+++ b/app/services/cms/models/dynamic_zone.rb
@@ -1,15 +1,14 @@
 module Cms
   module Models
     class DynamicZone
-      attr_accessor :cms_models, :with_spacing
+      attr_accessor :cms_models
 
-      def initialize(cms_models:, with_spacing: true)
+      def initialize(cms_models:)
         @cms_models = cms_models
-        @with_spacing = with_spacing
       end
 
       def render
-        CmsDynamicZoneComponent.new(cms_models:, with_spacing:)
+        CmsDynamicZoneComponent.new(cms_models:)
       end
     end
   end

--- a/app/services/cms/providers/strapi/factories/component_factory.rb
+++ b/app/services/cms/providers/strapi/factories/component_factory.rb
@@ -11,6 +11,8 @@ module Cms
             when "content-blocks.file-link"
               file_data = strapi_data.dig(:file, :data) ? strapi_data[:file][:data][:attributes] : nil
               to_file(file_data) if file_data
+            when "content-blocks.linked-picture"
+              DynamicComponents::LinkedPicture.new(image: ModelFactory.to_image(strapi_data, :image), link: strapi_data[:link])
             when "blocks.text-with-asides"
               DynamicComponents::TextWithAsides.new(blocks: strapi_data[:textContent], asides: extract_aside_sections(strapi_data))
             when "blocks.horizontal-card"

--- a/app/services/cms/providers/strapi/factories/model_factory.rb
+++ b/app/services/cms/providers/strapi/factories/model_factory.rb
@@ -28,8 +28,7 @@ module Cms
               model_class.new(
                 title: strapi_data[:title],
                 dynamic_content: Models::DynamicZone.new(
-                  cms_models: strapi_data[:content].map { ComponentFactory.process_component(_1) }.compact,
-                  with_spacing: false
+                  cms_models: strapi_data[:content].map { ComponentFactory.process_component(_1) }.compact
                 ),
                 show_heading_line: strapi_data[:showHeadingLine],
                 aside_icons: ComponentFactory.icon_block(strapi_data[:asideIcons])

--- a/app/services/cms/providers/strapi/mocks/linked_picture.rb
+++ b/app/services/cms/providers/strapi/mocks/linked_picture.rb
@@ -1,0 +1,14 @@
+module Cms
+  module Providers
+    module Strapi
+      module Mocks
+        class LinkedPicture < StrapiMock
+          strapi_component "content-blocks.linked-picture"
+
+          attribute(:image) { Mocks::Image.generate_raw_data }
+          attribute(:link) { Faker::Internet.url }
+        end
+      end
+    end
+  end
+end

--- a/spec/components/cms_dynamic_zone_component_spec.rb
+++ b/spec/components/cms_dynamic_zone_component_spec.rb
@@ -3,66 +3,30 @@
 require "rails_helper"
 
 RSpec.describe CmsDynamicZoneComponent, type: :component do
-  context "with spacing" do
-    before do
-      render_inline(described_class.new(
-        cms_models: [
-          Cms::Models::TextBlock.new(blocks: [
-            type: "paragraph",
-            children: [
-              {type: "text", text: "Hello world!"}
-            ]
-          ]),
-          Cms::Models::TextBlock.new(blocks: [
-            type: "paragraph",
-            children: [
-              {type: "text", text: "Hello world! Number 2"}
-            ]
-          ])
-        ]
-      ))
-    end
-
-    it "should render wrapper" do
-      expect(page).to have_css(".cms-dynamic-zone.govuk-\\!-margin-bottom-7.govuk-\\!-margin-top-7")
-    end
-
-    it "should render content blocks" do
-      expect(page).to have_css(".cms-rich-text-block-component", count: 2)
-    end
+  before do
+    render_inline(described_class.new(
+      cms_models: [
+        Cms::Models::TextBlock.new(blocks: [
+          type: "paragraph",
+          children: [
+            {type: "text", text: "Hello world!"}
+          ]
+        ]),
+        Cms::Models::TextBlock.new(blocks: [
+          type: "paragraph",
+          children: [
+            {type: "text", text: "Hello world! Number 2"}
+          ]
+        ])
+      ]
+    ))
   end
 
-  context "without spacing" do
-    before do
-      render_inline(described_class.new(
-        cms_models: [
-          Cms::Models::TextBlock.new(blocks: [
-            type: "paragraph",
-            children: [
-              {type: "text", text: "Hello world!"}
-            ]
-          ]),
-          Cms::Models::TextBlock.new(blocks: [
-            type: "paragraph",
-            children: [
-              {type: "text", text: "Hello world! Number 2"}
-            ]
-          ])
-        ],
-        with_spacing: false
-      ))
-    end
+  it "should render wrapper" do
+    expect(page).to have_css(".cms-dynamic-zone")
+  end
 
-    it "should render wrapper" do
-      expect(page).to have_css(".cms-dynamic-zone")
-    end
-
-    it "should render wrapper without spacing" do
-      expect(page).to_not have_css(".cms-dynamic-zone.govuk-\\!-margin-bottom-7")
-    end
-
-    it "should render content blocks" do
-      expect(page).to have_css(".cms-rich-text-block-component", count: 2)
-    end
+  it "should render content blocks" do
+    expect(page).to have_css(".cms-rich-text-block-component", count: 2)
   end
 end

--- a/spec/services/cms/dynamic_components/linked_picture_spec.rb
+++ b/spec/services/cms/dynamic_components/linked_picture_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Cms::DynamicComponents::LinkedPicture do
+  before do
+    @linked_picture = Cms::Providers::Strapi::Factories::ComponentFactory.process_component(Cms::Mocks::LinkedPicture.generate_raw_data)
+  end
+
+  it "should render as CmsNcceButtonComponent" do
+    expect(@linked_picture.render).to be_a(CmsImageComponent)
+  end
+end

--- a/spec/services/cms/providers/strapi/component_factory_spec.rb
+++ b/spec/services/cms/providers/strapi/component_factory_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe Cms::Providers::Strapi::Factories::ComponentFactory do
     end
   end
 
+  context "LinkedPicture" do
+    it "should be created" do
+      strapi_data = Cms::Providers::Strapi::Mocks::LinkedPicture.generate_raw_data
+      model = described_class.process_component(strapi_data)
+      expect(model).to be_a Cms::DynamicComponents::LinkedPicture
+    end
+  end
+
   context "FullWidthBanner" do
     it "should be created" do
       strapi_data = Cms::Providers::Strapi::Mocks::FullWidthBanner.generate_raw_data


### PR DESCRIPTION
## Status

* Current Status: Ready for front-end / tech review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2888

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Adding linked pictures content block for dynamics zones (only currentlly used in asides)
- Fixing font in q&a and picutre cards
- Removing margin off the last P in the rich-text-block
- Removing the spacing off the dynamic zone as it was creating issues elsewhere, and giving excessive spacing

