### PR TITLE
Add more than one digital summative assessment url to a unit

### DIFF
--- a/app/components/external_link_card_component.rb
+++ b/app/components/external_link_card_component.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class ExternalLinkCardComponent < ViewComponent::Base
-  def initialize(external_link_card:, title: nil, link: nil)
+  def initialize(external_link_card:, title: nil, link: nil, file_type: nil)
     @title = title || external_link_card[:title]
     @link = link || external_link_card[:link]
+    @file_type = file_type || external_link_card[:file_type]
   end
 
   def render?

--- a/app/components/external_link_card_component/external_link_card_component.html.erb
+++ b/app/components/external_link_card_component/external_link_card_component.html.erb
@@ -2,4 +2,7 @@
   <h3 class="govuk-heading-s external-link-card-component__heading">
     <%= link_to @title, @link, class: 'govuk-link ncce-link' %>
   </h3>
+  <div class='govuk-body-s file-card-component__meta-data'>
+    <%= @file_type %>
+  </div>
 </div>

--- a/app/components/external_link_card_component/external_link_card_component.scss
+++ b/app/components/external_link_card_component/external_link_card_component.scss
@@ -24,7 +24,6 @@
 .external-link-card-component__heading {
   font-weight: 500;
   margin-bottom: 0;
-  white-space: nowrap;
 }
 
 .external-link-card-component__meta-data {

--- a/app/services/curriculum_client/queries/unit.rb
+++ b/app/services/curriculum_client/queries/unit.rb
@@ -58,6 +58,11 @@ module CurriculumClient
           description
           videoUrl
         }
+        urlLinks {
+          label
+          url
+          typeDescriptor
+        }
       GRAPHQL
 
       def self.all(fields = FIELDS)

--- a/app/views/curriculum/units/show.html.erb
+++ b/app/views/curriculum/units/show.html.erb
@@ -40,7 +40,8 @@
             cards = [
               { type: :file, details: @unit.unit_guide },
             ] + (@unit.learning_graphs + @unit.rubrics + @unit.summative_assessments + @unit.summative_answers).map{ { type: :file, details: _1 } } +
-            [{ type: :external_link, details: { title: 'Digital Summative <br /> Assesment'.html_safe, link: @unit.digital_summative_assessment_url } }]
+            [{ type: :external_link, details: { title: 'Digital Summative <br /> Assesment'.html_safe, link: @unit.digital_summative_assessment_url } }] +
+            @unit.url_links.map { |link| { type: :external_link, details: { title: link.label, link: link.url, file_type: link.type_descriptor } } }
           %>
           <%= render MixedCardsComponent.new(cards: cards) %>
 

--- a/spec/components/external_link_card_component_spec.rb
+++ b/spec/components/external_link_card_component_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe ExternalLinkCardComponent, type: :component do
   let(:link_card) do
     {
       title: "Testing",
-      link: "https://www.example.com"
+      link: "https://www.example.com",
+      file_type: "Google Doc"
     }
   end
 
@@ -12,6 +13,13 @@ RSpec.describe ExternalLinkCardComponent, type: :component do
     {
       title: "Missing Link",
       link: nil
+    }
+  end
+
+  let(:link_card_missing_file_type) do
+    {
+      title: "Missing File Type",
+      file_type: nil
     }
   end
 
@@ -32,6 +40,16 @@ RSpec.describe ExternalLinkCardComponent, type: :component do
 
     it "renders with expected link" do
       expect(page).to have_link("Testing", href: "https://www.example.com")
+    end
+  end
+
+  describe "with no file type defined" do
+    before do
+      render_inline(described_class.new(external_link_card: link_card_missing_file_type))
+    end
+
+    it "renders with expected link" do
+      expect(page).not_to have_text("Google Doc")
     end
   end
 end

--- a/spec/components/mixed_cards_component_spec.rb
+++ b/spec/components/mixed_cards_component_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe MixedCardsComponent, type: :component do
   let(:link_card) do
     {
       title: "Testing",
-      link: "https://www.example.com"
+      link: "https://www.example.com",
+      file_type: "Google Doc"
     }
   end
 
@@ -27,6 +28,10 @@ RSpec.describe MixedCardsComponent, type: :component do
 
     it "renders with the expected link" do
       expect(page).to have_link("Testing", href: "https://www.example.com")
+    end
+
+    it "renders the file type text" do
+      expect(page).to have_text("Google Doc")
     end
   end
 

--- a/spec/support/curriculum/curriculum_schema.json
+++ b/spec/support/curriculum/curriculum_schema.json
@@ -2509,6 +2509,28 @@
               "deprecationReason": null
             },
             {
+              "name": "urlLinks",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "UrlLink",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "video",
               "description": null,
               "args": [
@@ -2534,6 +2556,87 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "YearGroup",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "UrlLink",
+          "description": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "label",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "typeDescriptor",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },

--- a/spec/support/curriculum/responses/unit.json
+++ b/spec/support/curriculum/responses/unit.json
@@ -11,6 +11,18 @@
         "created": "5 Nov 2016"
       },
       "summativeAssessments": [],
+      "urlLinks": [
+        {
+          "label": "Digital summative assessment",
+          "url": "https://www.example.com",
+          "typeDescriptor": "Google Doc"
+        },
+        {
+          "label": "Digital summative assessment",
+          "url": "https://www.example.com",
+          "typeDescriptor": "Google Doc"
+        }
+      ],
       "summativeAnswers": [],
       "digitalSummativeAssessmentUrl": "https://www.stem.org.uk/resources/elibrary/resource/522344/year-3-computer-systems-and-networks-connecting-computers",
       "learningGraphs": [

--- a/spec/support/curriculum/views/unit.json
+++ b/spec/support/curriculum/views/unit.json
@@ -14,6 +14,13 @@
       },
       "digitalSummativeAssessmentUrl": "https://www.stem.org.uk/resources/elibrary/resource/522344/year-3-computer-systems-and-networks-connecting-computers",
       "summative_assessments": [],
+      "url_links": [
+        {
+          "label": "Digtial Summative Assessment",
+          "url": "https://www.google.com",
+          "typeDescriptor": "Microsoft Form"
+        }
+      ],
       "summative_answers": [],
       "learning_graphs": [],
       "rubrics": [],

--- a/spec/support/curriculum/views/unit_alt.json
+++ b/spec/support/curriculum/views/unit_alt.json
@@ -14,6 +14,7 @@
         "type": "PDF"
       },
       "summative_assessments": [],
+      "url_links": [],
       "summative_answers": [],
       "learning_graphs": [],
       "rubrics": [],

--- a/spec/support/curriculum/views/unit_with_video.json
+++ b/spec/support/curriculum/views/unit_with_video.json
@@ -20,6 +20,7 @@
         "layout": "row"
       },
       "digitalSummativeAssessmentUrl": "https://www.stem.org.uk/resources/elibrary/resource/522344/year-3-computer-systems-and-networks-connecting-computers",
+      "url_links": [],
       "summative_assessments": [],
       "summative_answers": [],
       "learning_graphs": [],

--- a/spec/views/curriculum/units/show_spec.rb
+++ b/spec/views/curriculum/units/show_spec.rb
@@ -104,4 +104,26 @@ RSpec.describe("curriculum/units/show", type: :view) do
       expect(rendered).not_to have_css(".gcse-revision__link")
     end
   end
+
+  context "when a url link is present" do
+    before do
+      setup_view
+      render
+    end
+
+    it "renders the external link component" do
+      expect(rendered).to have_css(".external-link-card-component")
+    end
+  end
+
+  context "when a url link is not present" do
+    before do
+      setup_view_with_video
+      render
+    end
+
+    it "renders the external link component" do
+      expect(rendered).to_not have_css(".external-link-card-component")
+    end
+  end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2846

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?
- Added url links into graphql definitions
- Updated unit show page to render url links via existing components

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
