### PR TITLE
Adding top margin for spacing on icon row

### DIFF
--- a/app/components/cms_icon_block_component/cms_icon_block_component.scss
+++ b/app/components/cms_icon_block_component/cms_icon_block_component.scss
@@ -2,6 +2,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  margin-top: 20px;
 
   @include govuk-media-query($until: desktop) {
     margin-bottom: 15px;

--- a/app/components/icon_row_component/icon_row_component.scss
+++ b/app/components/icon_row_component/icon_row_component.scss
@@ -2,7 +2,6 @@
 div.icon-row-component {
   display: flex;
   justify-content: space-between;
-  margin-top: 20px;
 
   div.icon-row-component_icon {
     display: flex;

--- a/app/components/icon_row_component/icon_row_component.scss
+++ b/app/components/icon_row_component/icon_row_component.scss
@@ -2,6 +2,7 @@
 div.icon-row-component {
   display: flex;
   justify-content: space-between;
+  margin-top: 20px;
 
   div.icon-row-component_icon {
     display: flex;


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2892


## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Adding bit or margin to top of icon-row

Think this was caused by removing the margin of the bottom of the last paragraph to solve the other spacing complaint

