### PR TITLE
Implement primary certificate enrolment confirmation

### DIFF
--- a/app/components/enrolment_confirmation_component.rb
+++ b/app/components/enrolment_confirmation_component.rb
@@ -2,8 +2,9 @@
 
 class EnrolmentConfirmationComponent < ViewComponent::Base
   delegate :auth_url, to: :helpers
+  attr_reader :button_text
 
-  def initialize(programme:, current_user:, full_width: true, button_text: nil)
+  def initialize(programme:, current_user:, full_width: true, button_text: "Enrol")
     @current_user = current_user
     @programme = programme
     @full_width = full_width
@@ -14,9 +15,5 @@ class EnrolmentConfirmationComponent < ViewComponent::Base
     classes = ["govuk-button button"]
     classes << "button--full-width" if @full_width
     classes
-  end
-
-  def button_text
-    @button_text || "Enrol"
   end
 end

--- a/app/components/enrolment_confirmation_component.rb
+++ b/app/components/enrolment_confirmation_component.rb
@@ -3,9 +3,16 @@
 class EnrolmentConfirmationComponent < ViewComponent::Base
   delegate :auth_url, to: :helpers
 
-  def initialize(programme:, current_user:, enrol_text: nil)
+  def initialize(programme:, current_user:, full_width: true, enrol_button_text: nil)
     @current_user = current_user
     @programme = programme
-    @enrol_text = enrol_text
+    @full_width = full_width
+    @enrol_button_text = enrol_button_text
+  end
+
+  def button_classes
+    classes = ["govuk-button button"]
+    classes << "button--full-width" if @full_width
+    classes
   end
 end

--- a/app/components/enrolment_confirmation_component.rb
+++ b/app/components/enrolment_confirmation_component.rb
@@ -15,4 +15,8 @@ class EnrolmentConfirmationComponent < ViewComponent::Base
     classes << "button--full-width" if @full_width
     classes
   end
+
+  def button_text
+    @button_text || "Enrol"
+  end
 end

--- a/app/components/enrolment_confirmation_component.rb
+++ b/app/components/enrolment_confirmation_component.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class EnrolmentConfirmationComponent < ViewComponent::Base
-  delegate :auth_url, to: :helpers
   attr_reader :button_text
+
+  delegate :auth_url, to: :helpers
 
   def initialize(programme:, current_user:, full_width: true, button_text: "Enrol")
     @current_user = current_user

--- a/app/components/enrolment_confirmation_component.rb
+++ b/app/components/enrolment_confirmation_component.rb
@@ -5,11 +5,12 @@ class EnrolmentConfirmationComponent < ViewComponent::Base
 
   delegate :auth_url, to: :helpers
 
-  def initialize(programme:, current_user:, full_width: true, button_text: "Enrol")
+  def initialize(programme:, current_user:, full_width: true, button_text: "Enrol", pathway: nil)
     @current_user = current_user
     @programme = programme
     @full_width = full_width
     @button_text = button_text
+    @pathway = pathway
   end
 
   def button_classes

--- a/app/components/enrolment_confirmation_component.rb
+++ b/app/components/enrolment_confirmation_component.rb
@@ -3,11 +3,11 @@
 class EnrolmentConfirmationComponent < ViewComponent::Base
   delegate :auth_url, to: :helpers
 
-  def initialize(programme:, current_user:, full_width: true, enrol_button_text: nil)
+  def initialize(programme:, current_user:, full_width: true, button_text: nil)
     @current_user = current_user
     @programme = programme
     @full_width = full_width
-    @enrol_button_text = enrol_button_text
+    @button_text = button_text
   end
 
   def button_classes

--- a/app/components/enrolment_confirmation_component.rb
+++ b/app/components/enrolment_confirmation_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class EnrolmentConfirmationComponent < ViewComponent::Base
+  delegate :auth_url, to: :helpers
+
+  def initialize(programme:, current_user:, enrol_text: nil)
+    @current_user = current_user
+    @programme = programme
+    @enrol_text = enrol_text
+  end
+end

--- a/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
+++ b/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
@@ -1,25 +1,29 @@
 <% if @current_user %>
-  <div class="enrolment-confirmation-component">
-    <%= render ModalComponent.new(
-      title: "Enrol on the #{@programme.certificate_name}",
-      reopen_button_text: (@enrol_button_text || "Enrol"),
-      show_corner_decoration: false,
-      reopen_button_class: ("enrolment-confirmation-component-button--full-width" if @full_width)
-      ) do |component| %>
+  <% if @programme.enrolment_confirmation_required? %>
+    <div class="enrolment-confirmation-component">
+      <%= render ModalComponent.new(
+        title: "Enrol on the #{@programme.certificate_name}",
+        reopen_button_text: (@enrol_button_text || "Enrol"),
+        show_corner_decoration: false,
+        reopen_button_class: ("enrolment-confirmation-component-button--full-width" if @full_width)
+        ) do |component| %>
 
-      <% component.with_body do %>
-        <div class="enrolment-confirmation-model--wrapper">
-          <div>
-            <h2 class="govuk-heading-s">Ready to enrol?</h2>
-            <p class="govuk-body">Comfirm your enrolment on the certificate, and then let"s find you the perfect training course to get started with.</p>
+        <% component.with_body do %>
+          <div class="enrolment-confirmation-model--wrapper">
+            <div>
+              <h2 class="govuk-heading-s">Ready to enrol?</h2>
+              <p class="govuk-body">Comfirm your enrolment on the certificate, and then let"s find you the perfect training course to get started with.</p>
+            </div>
+            <div>
+              <%= link_to "Comfirm my enrolment", @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: "govuk-button button", role: "button", draggable: "false" %>
+            </div>
           </div>
-          <div>
-            <%= link_to "Comfirm my enrolment", @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: "govuk-button button", role: "button", draggable: "false" %>
-          </div>
-        </div>
+        <% end %>
       <% end %>
-    <% end %>
-  </div>
+    </div>
+  <% else %>
+    <%= link_to (@enrol_button_text || "Enrol"), @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: button_classes, role: "button", draggable: "false" %>
+  <% end %>
 <% else %>
   <%= link_to "Log in", auth_url, method: :post, class: button_classes, role: "button", draggable: "false" %>
 <% end %>

--- a/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
+++ b/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
@@ -16,14 +16,14 @@
               <p class="govuk-body">Confirm your enrolment on the certificate, and then let's find you the perfect training course to get started with.</p>
             </div>
             <div>
-              <%= link_to "Confirm my enrolment", @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: "govuk-button button", role: "button" %>
+              <%= link_to "Confirm my enrolment", @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id, pathway_slug: @pathway.slug }), method: :post, class: "govuk-button button", role: "button" %>
             </div>
           </div>
         <% end %>
       <% end %>
     </div>
   <% else %>
-    <%= link_to button_text, @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: button_classes, role: "button" %>
+    <%= link_to button_text, @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id, pathway_slug: @pathway.slug }), method: :post, class: button_classes, role: "button" %>
   <% end %>
 <% else %>
   <%= link_to "Log in", auth_url, method: :post, class: button_classes, role: "button" %>

--- a/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
+++ b/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
@@ -1,34 +1,25 @@
 <% if @current_user %>
-  <% if @programme.primary_certificate? || @programme.secondary_certificate? %>
-    <%= link_to 'Choose a pathway', @programme.public_path, class: 'govuk-button button button--full-width', role: 'button', draggable: 'false' %>
-  <% else %>
-    <div class="enrolment-confirmation-component">
-      <%= render ModalComponent.new(
-        title: "Enrol on the #{@programme.certificate_name}#{@programme == Programme.i_belong ? ' certificate' : ''}",
-        reopen_button_text: (@enrol_text || 'Enrol'),
-        show_corner_decoration: false) do |component| %>
+  <div class="enrolment-confirmation-component">
+    <%= render ModalComponent.new(
+      title: "Enrol on the #{@programme.certificate_name}",
+      reopen_button_text: (@enrol_button_text || "Enrol"),
+      show_corner_decoration: false,
+      reopen_button_class: ("enrolment-confirmation-component-button--full-width" if @full_width)
+      ) do |component| %>
 
-        <% component.with_body do %>
-          <div class="enrolment-confirmation-model--wrapper">
-            <div>
-              <h2 class="govuk-heading-s">
-                Ready to enrol?
-              </h2>
-              <p class="govuk-body">
-                Confirm your enrolment on the certificate, and then let's find you the perfect training course to get started with.
-              </p>
-            </div>
-            <div>
-              <%= link_to "Comfirm my enrolment", @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: 'govuk-button button confirm govuk-!-margin-bottom-0', role: 'button', draggable: 'false' %>
-            </div>
+      <% component.with_body do %>
+        <div class="enrolment-confirmation-model--wrapper">
+          <div>
+            <h2 class="govuk-heading-s">Ready to enrol?</h2>
+            <p class="govuk-body">Comfirm your enrolment on the certificate, and then let"s find you the perfect training course to get started with.</p>
           </div>
-        <% end %>
-      </div>
-
+          <div>
+            <%= link_to "Comfirm my enrolment", @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: "govuk-button button", role: "button", draggable: "false" %>
+          </div>
+        </div>
+      <% end %>
     <% end %>
-  <% end %>
+  </div>
 <% else %>
-  <%= link_to 'Log in', auth_url, method: :post, class: 'govuk-button button button--full-width', role: 'button', draggable: 'false' %>
+  <%= link_to "Log in", auth_url, method: :post, class: button_classes, role: "button", draggable: "false" %>
 <% end %>
-
-

--- a/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
+++ b/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
@@ -14,7 +14,7 @@
               <p class="govuk-body">Confirm your enrolment on the certificate, and then let's find you the perfect training course to get started with.</p>
             </div>
             <div>
-              <%= link_to "Comfirm my enrolment", @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: "govuk-button button", role: "button" %>
+              <%= link_to "Confirm my enrolment", @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: "govuk-button button", role: "button" %>
             </div>
           </div>
         <% end %>

--- a/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
+++ b/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
@@ -16,14 +16,14 @@
               <p class="govuk-body">Confirm your enrolment on the certificate, and then let's find you the perfect training course to get started with.</p>
             </div>
             <div>
-              <%= link_to "Confirm my enrolment", @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id, pathway_slug: @pathway.slug }), method: :post, class: "govuk-button button", role: "button" %>
+              <%= link_to "Confirm my enrolment", @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id, pathway_slug: @pathway&.slug }), method: :post, class: "govuk-button button", role: "button" %>
             </div>
           </div>
         <% end %>
       <% end %>
     </div>
   <% else %>
-    <%= link_to button_text, @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id, pathway_slug: @pathway.slug }), method: :post, class: button_classes, role: "button" %>
+    <%= link_to button_text, @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id, pathway_slug: @pathway&.slug }), method: :post, class: button_classes, role: "button" %>
   <% end %>
 <% else %>
   <%= link_to "Log in", auth_url, method: :post, class: button_classes, role: "button" %>

--- a/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
+++ b/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
@@ -3,7 +3,7 @@
     <div class="enrolment-confirmation-component">
       <%= render ModalComponent.new(
         title: "Enrol on the #{@programme.certificate_name}",
-        reopen_button_text: (@button_text || "Enrol"),
+        reopen_button_text: button_text,
         show_corner_decoration: false,
         reopen_button_class: ("enrolment-confirmation-component__button--full-width" if @full_width)
         ) do |component| %>
@@ -11,18 +11,22 @@
           <div class="enrolment-confirmation-component__wrapper">
             <div>
               <h2 class="govuk-heading-s">Ready to enrol?</h2>
-              <p class="govuk-body">Confirm your enrolment on the certificate, and then let"s find you the perfect training course to get started with.</p>
+              <p class="govuk-body">Confirm your enrolment on the certificate, and then let's find you the perfect training course to get started with.</p>
             </div>
             <div>
-              <%= link_to "Comfirm my enrolment", @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: "govuk-button button", role: "button", draggable: "false" %>
+              <%= link_to "Comfirm my enrolment", @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: "govuk-button button", role: "button" %>
             </div>
           </div>
         <% end %>
       <% end %>
     </div>
   <% else %>
-    <%= link_to (@button_text || "Enrol"), @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: button_classes, role: "button", draggable: "false" %>
+    <% if @programme.user_enrolled?(@current_user) %>
+      <%= link_to "Visit dashboard", dashboard_path, class: button_classes, role: "button" %>
+    <% else %>
+      <%= link_to button_text, @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: button_classes, role: "button" %>
+    <% end %>
   <% end %>
 <% else %>
-  <%= link_to "Log in", auth_url, method: :post, class: button_classes, role: "button", draggable: "false" %>
+  <%= link_to "Log in", auth_url, method: :post, class: button_classes, role: "button" %>
 <% end %>

--- a/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
+++ b/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
@@ -7,7 +7,6 @@
         show_corner_decoration: false,
         reopen_button_class: ("enrolment-confirmation-component-button--full-width" if @full_width)
         ) do |component| %>
-
         <% component.with_body do %>
           <div class="enrolment-confirmation-model--wrapper">
             <div>

--- a/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
+++ b/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
@@ -1,0 +1,34 @@
+<% if @current_user %>
+  <% if @programme.primary_certificate? || @programme.secondary_certificate? %>
+    <%= link_to 'Choose a pathway', @programme.public_path, class: 'govuk-button button button--full-width', role: 'button', draggable: 'false' %>
+  <% else %>
+    <div class="enrolment-confirmation-component">
+      <%= render ModalComponent.new(
+        title: "Enrol on the #{@programme.certificate_name}#{@programme == Programme.i_belong ? ' certificate' : ''}",
+        reopen_button_text: (@enrol_text || 'Enrol'),
+        show_corner_decoration: false) do |component| %>
+
+        <% component.with_body do %>
+          <div class="enrolment-confirmation-model--wrapper">
+            <div>
+              <h2 class="govuk-heading-s">
+                Ready to enrol?
+              </h2>
+              <p class="govuk-body">
+                Confirm your enrolment on the certificate, and then let's find you the perfect training course to get started with.
+              </p>
+            </div>
+            <div>
+              <%= link_to "Comfirm my enrolment", @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: 'govuk-button button confirm govuk-!-margin-bottom-0', role: 'button', draggable: 'false' %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+    <% end %>
+  <% end %>
+<% else %>
+  <%= link_to 'Log in', auth_url, method: :post, class: 'govuk-button button button--full-width', role: 'button', draggable: 'false' %>
+<% end %>
+
+

--- a/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
+++ b/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
@@ -1,5 +1,7 @@
 <% if @current_user %>
-  <% if @programme.enrolment_confirmation_required? %>
+  <% if @programme.user_enrolled?(@current_user) %>
+    <%= link_to "Visit dashboard", dashboard_path, class: button_classes, role: "button" %>
+  <% elsif @programme.enrolment_confirmation_required? %>
     <div class="enrolment-confirmation-component">
       <%= render ModalComponent.new(
         title: "Enrol on the #{@programme.certificate_name}",
@@ -21,11 +23,7 @@
       <% end %>
     </div>
   <% else %>
-    <% if @programme.user_enrolled?(@current_user) %>
-      <%= link_to "Visit dashboard", dashboard_path, class: button_classes, role: "button" %>
-    <% else %>
-      <%= link_to button_text, @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: button_classes, role: "button" %>
-    <% end %>
+    <%= link_to button_text, @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: button_classes, role: "button" %>
   <% end %>
 <% else %>
   <%= link_to "Log in", auth_url, method: :post, class: button_classes, role: "button" %>

--- a/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
+++ b/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
@@ -3,15 +3,15 @@
     <div class="enrolment-confirmation-component">
       <%= render ModalComponent.new(
         title: "Enrol on the #{@programme.certificate_name}",
-        reopen_button_text: (@enrol_button_text || "Enrol"),
+        reopen_button_text: (@button_text || "Enrol"),
         show_corner_decoration: false,
-        reopen_button_class: ("enrolment-confirmation-component-button--full-width" if @full_width)
+        reopen_button_class: ("enrolment-confirmation-component__button--full-width" if @full_width)
         ) do |component| %>
         <% component.with_body do %>
-          <div class="enrolment-confirmation-model--wrapper">
+          <div class="enrolment-confirmation-component__wrapper">
             <div>
               <h2 class="govuk-heading-s">Ready to enrol?</h2>
-              <p class="govuk-body">Comfirm your enrolment on the certificate, and then let"s find you the perfect training course to get started with.</p>
+              <p class="govuk-body">Confirm your enrolment on the certificate, and then let"s find you the perfect training course to get started with.</p>
             </div>
             <div>
               <%= link_to "Comfirm my enrolment", @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: "govuk-button button", role: "button", draggable: "false" %>
@@ -21,7 +21,7 @@
       <% end %>
     </div>
   <% else %>
-    <%= link_to (@enrol_button_text || "Enrol"), @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: button_classes, role: "button", draggable: "false" %>
+    <%= link_to (@button_text || "Enrol"), @programme.enrol_path(user_programme_enrolment: { user_id: @current_user.id, programme_id: @programme.id }), method: :post, class: button_classes, role: "button", draggable: "false" %>
   <% end %>
 <% else %>
   <%= link_to "Log in", auth_url, method: :post, class: button_classes, role: "button", draggable: "false" %>

--- a/app/components/enrolment_confirmation_component/enrolment_confirmation_component.scss
+++ b/app/components/enrolment_confirmation_component/enrolment_confirmation_component.scss
@@ -1,0 +1,12 @@
+.enrolment-confirmation-component {
+  .ncce-modal--body {
+    box-shadow: 4px 4px 8px 2px #00000040;
+  }
+}
+
+.enrolment-confirmation-model--wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 20px;
+}

--- a/app/components/enrolment_confirmation_component/enrolment_confirmation_component.scss
+++ b/app/components/enrolment_confirmation_component/enrolment_confirmation_component.scss
@@ -2,15 +2,17 @@
   .ncce-modal--body {
     box-shadow: 4px 4px 8px 2px #00000040;
   }
-}
 
-.enrolment-confirmation-model--wrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 20px;
-}
+  &__wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 20px;
+  }
 
-.enrolment-confirmation-component-button--full-width {
-  width: 100%;
+  &__button {
+    &--full-width {
+      width: 100%;
+    }
+  }
 }

--- a/app/components/enrolment_confirmation_component/enrolment_confirmation_component.scss
+++ b/app/components/enrolment_confirmation_component/enrolment_confirmation_component.scss
@@ -10,3 +10,7 @@
   align-items: center;
   margin-top: 20px;
 }
+
+.enrolment-confirmation-component-button--full-width {
+  width: 100%;
+}

--- a/app/components/modal_component.rb
+++ b/app/components/modal_component.rb
@@ -5,7 +5,7 @@ class ModalComponent < ViewComponent::Base
   renders_one :reopen_button
   renders_one :confirmation # are you sure?
 
-  attr_reader :expanded, :title, :reopen_button_text, :show_corner_decoration, :class_name, :reopen_button_class
+  attr_reader :expanded, :title, :reopen_button_text, :show_corner_decoration, :class_name, :reopen_button_class, :modal_id
 
   def initialize(title:, expanded: false, reopen_button_text: nil, show_corner_decoration: true, class_name: nil, reopen_button_class: nil, z_index: 1000)
     super
@@ -16,6 +16,7 @@ class ModalComponent < ViewComponent::Base
     @class_name = class_name
     @reopen_button_class = reopen_button_class
     @z_index = z_index
+    @modal_id = SecureRandom.hex(6)
   end
 
   def z_index

--- a/app/components/modal_component/modal_component.html.erb
+++ b/app/components/modal_component/modal_component.html.erb
@@ -12,7 +12,7 @@
   <% end %>
 
   <div class="ncce-modal <%= 'ncce-modal--expanded' if expanded %>" style="<%= z_index %>" data-modal-target="modal">
-    <span tabindex="0" data-modal-target="topFocus" aria-hidden="true"></span>
+    <div tabindex="0" data-modal-target="topFocus" aria-hidden="true"></div>
     <div id="<%= modal_id %>" class="ncce-modal--body <%= 'corner-decoration' if show_corner_decoration %>" tabindex="0">
       <div class="ncce-modal--header">
         <% if header %>
@@ -27,6 +27,6 @@
       </div>
       <%= body %>
     </div>
-    <span tabindex="0" data-modal-target="bottomFocus" aria-hidden="true"></span>
+    <div tabindex="0" data-modal-target="bottomFocus" aria-hidden="true"></div>
   </div>
 </div>

--- a/app/components/modal_component/modal_component.html.erb
+++ b/app/components/modal_component/modal_component.html.erb
@@ -1,4 +1,10 @@
-<div data-controller="modal" data-modal-confirm-value="true" class="<%= class_name %>">
+<div data-controller="modal" data-modal-confirm-value="true" data-modal-modal-id-value="<%= modal_id %>" class="<%= class_name %>">
+  <% if reopen_button %>
+    <%= reopen_button %>
+  <% elsif reopen_button_text.present? %>
+    <button class="govuk-button button ncce-modal--reopen <%= reopen_button_class %>" data-action="modal#toggle"><%= reopen_button_text %></button>
+  <% end %>
+
   <% if confirmation %>
     <div data-modal-target="confirmation">
       <%= confirmation %>
@@ -6,7 +12,8 @@
   <% end %>
 
   <div class="ncce-modal <%= 'ncce-modal--expanded' if expanded %>" style="<%= z_index %>" data-modal-target="modal">
-    <div class="ncce-modal--body <%= 'corner-decoration' if show_corner_decoration %>" tabindex="0">
+    <span tabindex="0" data-modal-target="topFocus" aria-hidden="true"></span>
+    <div id="<%= modal_id %>" class="ncce-modal--body <%= 'corner-decoration' if show_corner_decoration %>" tabindex="0">
       <div class="ncce-modal--header">
         <% if header %>
           <%= header %>
@@ -20,10 +27,6 @@
       </div>
       <%= body %>
     </div>
+    <span tabindex="0" data-modal-target="bottomFocus" aria-hidden="true"></span>
   </div>
-  <% if reopen_button %>
-    <%= reopen_button %>
-  <% elsif reopen_button_text.present? %>
-    <button class="govuk-button button ncce-modal--reopen <%= reopen_button_class %>" data-action="modal#toggle"><%= reopen_button_text %></button>
-  <% end %>
 </div>

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -197,6 +197,6 @@ class Programme < ApplicationRecord
   end
 
   def enrolment_confirmation_required?
-    raise NotImplementedError
+    false
   end
 end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -195,4 +195,8 @@ class Programme < ApplicationRecord
   def achievement_type
     raise NotImplementedError
   end
+
+  def enrolment_confirmation_required?
+    raise NotImplementedError
+  end
 end

--- a/app/models/programmes/a_level.rb
+++ b/app/models/programmes/a_level.rb
@@ -38,5 +38,9 @@ module Programmes
     def achievement_type
       :individual
     end
+
+    def enrolment_confirmation_required?
+      false
+    end
   end
 end

--- a/app/models/programmes/cs_accelerator.rb
+++ b/app/models/programmes/cs_accelerator.rb
@@ -131,5 +131,9 @@ module Programmes
     def achievement_type
       :individual
     end
+
+    def enrolment_confirmation_required?
+      false
+    end
   end
 end

--- a/app/models/programmes/i_belong.rb
+++ b/app/models/programmes/i_belong.rb
@@ -54,5 +54,9 @@ module Programmes
     def achievement_type
       :school
     end
+
+    def enrolment_confirmation_required?
+      false
+    end
   end
 end

--- a/app/models/programmes/primary_certificate.rb
+++ b/app/models/programmes/primary_certificate.rb
@@ -53,5 +53,9 @@ module Programmes
     def achievement_type
       :individual
     end
+
+    def enrolment_confirmation_required?
+      true
+    end
   end
 end

--- a/app/models/programmes/secondary_certificate.rb
+++ b/app/models/programmes/secondary_certificate.rb
@@ -64,5 +64,9 @@ module Programmes
     def achievement_type
       :individual
     end
+
+    def enrolment_confirmation_required?
+      false
+    end
   end
 end

--- a/app/views/certificates/pathways/show.html.erb
+++ b/app/views/certificates/pathways/show.html.erb
@@ -101,7 +101,7 @@
                 <li><%= line.html_safe %></li>
               <% end %>
             </ol>
-            <%= render EnrolmentConfirmationComponent.new(current_user:, programme: Programme.primary_certificate) %>
+            <%= render EnrolmentConfirmationComponent.new(current_user:, programme: @programme, pathway: @pathway) %>
           <% end %>
         <% end %>
         <%= render PathwayImprovementsComponent.new(pathway: @pathway) %>

--- a/app/views/certificates/pathways/show.html.erb
+++ b/app/views/certificates/pathways/show.html.erb
@@ -94,7 +94,16 @@
       </div>
 
       <div class="govuk-grid-column-one-third">
-        <%= render PathwayEnrolComponent.new(programme: @programme, pathway: @pathway, current_user: @current_user) %>
+        <%= render AsideComponent.new(title: 'How to enrol') do |component| %>
+          <% component.with_body do %>
+            <ol class="govuk-body-s">
+              <% @pathway.enrol_copy.each do |line| %>
+                <li><%= line.html_safe %></li>
+              <% end %>
+            </ol>
+            <%= render EnrolmentConfirmationComponent.new(current_user:, programme: Programme.primary_certificate) %>
+          <% end %>
+        <% end %>
         <%= render PathwayImprovementsComponent.new(pathway: @pathway) %>
         <%= render AsideComponent.new(
           title: 'Download the pathway PDF'

--- a/app/views/layouts/two-thirds.html.erb
+++ b/app/views/layouts/two-thirds.html.erb
@@ -1,0 +1,16 @@
+<% content_for :content do -%>
+  <div>
+    <main id="main-content" class="<%= content_for?(:main_class) ? yield(:main_class) : nil %>">
+      <%= render 'components/flash' %>
+
+      <%= render GovGridRowComponent.new do |row| %>
+        <%= row.with_column("two-thirds") do %>
+          <%= yield %>
+        <% end %>
+      <% end %>
+
+    </main>
+  </div>
+<% end -%>
+
+<%= render 'layouts/base' %>

--- a/app/webpacker/javascript/controllers/modal_controller.js
+++ b/app/webpacker/javascript/controllers/modal_controller.js
@@ -6,24 +6,35 @@ export default class extends ApplicationController {
   // confirmation modal if there are any changes. when this value is false,
   // it will prevent the confirmation modal from appearing.
   // static values = { confirm: { type: Boolean, default: false } }
-  static values = { confirm: Boolean }
+  static values = { confirm: Boolean, modalId:String }
 
-  static targets = ['modal', 'confirmation']
+  static targets = ['modal', 'confirmation', 'topFocus', 'bottomFocus']
 
   connect() {
     this.onKeyDown = this.onKeyDown.bind(this)
     this.onClick = this.onClick.bind(this)
     this.toggle = this.toggle.bind(this)
+    this.jumpToTop = this.jumpToTop.bind(this)
 
     document.body.addEventListener("keydown", this.onKeyDown)
     this.modalTarget.addEventListener("click", this.onClick)
     this.element.addEventListener("toggle", this.toggle)
+
+    this.bottomFocusTarget.addEventListener("focus", this.jumpToTop)
+    this.topFocusTarget.addEventListener("focus", this.jumpToTop)
   }
 
   disconnect() {
     document.body.removeEventListener("keydown", this.onKeyDown)
     this.modalTarget.removeEventListener("click", this.onClick)
     this.element.removeEventListener("toggle", this.toggle)
+    this.bottomFocusTarget.removeEventListener("focus", this.jumpToTop)
+    this.topFocusTarget.removeEventListener("focus", this.jumpToTop)
+  }
+
+  // keep focus within the modal when tabbing through elements
+  jumpToTop() {
+    document.getElementById(this.modalIdValue).focus()
   }
 
   toggle() {

--- a/previews/components/enrolment_confirmation_component_preview.rb
+++ b/previews/components/enrolment_confirmation_component_preview.rb
@@ -32,4 +32,13 @@ class EnrolmentConfirmationComponentPreview < ViewComponent::Preview
       full_width: false
     ))
   end
+
+  def user_already_enrolled
+    programme = UserProgrammeEnrolment.last || FactoryBot.create(:user_programme_enrolment)
+
+    render(EnrolmentConfirmationComponent.new(
+      current_user: User.last,
+      programme: Programme.find(programme.programme_id)
+    ))
+  end
 end

--- a/previews/components/enrolment_confirmation_component_preview.rb
+++ b/previews/components/enrolment_confirmation_component_preview.rb
@@ -1,25 +1,35 @@
 class EnrolmentConfirmationComponentPreview < ViewComponent::Preview
+  layout "two-thirds"
+
   def default
     render(EnrolmentConfirmationComponent.new(
-      current_user: User.last.presence,
+      current_user: User.last,
+      programme: Programme.primary_certificate
+    ))
+  end
+
+  def full_width_false
+    render(EnrolmentConfirmationComponent.new(
+      current_user: User.last,
       programme: Programme.primary_certificate,
       full_width: false
     ))
   end
 
-  def full_width
+  def custom_button_text
     render(EnrolmentConfirmationComponent.new(
-      current_user: User.last.presence,
-      programme: Programme.primary_certificate
+      current_user: User.last,
+      programme: Programme.primary_certificate,
+      full_width: false,
+      button_text: Faker::Lorem.words(number: 4)
     ))
   end
 
-  def custom_button_text
+  def user_not_logged_in
     render(EnrolmentConfirmationComponent.new(
-      current_user: User.last.presence,
+      current_user: nil,
       programme: Programme.primary_certificate,
-      full_width: false,
-      button_text: "Click here to enrol"
+      full_width: false
     ))
   end
 end

--- a/previews/components/enrolment_confirmation_component_preview.rb
+++ b/previews/components/enrolment_confirmation_component_preview.rb
@@ -19,7 +19,7 @@ class EnrolmentConfirmationComponentPreview < ViewComponent::Preview
       current_user: User.last.presence,
       programme: Programme.primary_certificate,
       full_width: false,
-      enrol_button_text: "Click here to enrol"
+      button_text: "Click here to enrol"
     ))
   end
 end

--- a/previews/components/enrolment_confirmation_component_preview.rb
+++ b/previews/components/enrolment_confirmation_component_preview.rb
@@ -1,0 +1,25 @@
+class EnrolmentConfirmationComponentPreview < ViewComponent::Preview
+  def default
+    render(EnrolmentConfirmationComponent.new(
+      current_user: User.last.presence,
+      programme: Programme.primary_certificate,
+      full_width: false
+    ))
+  end
+
+  def full_width
+    render(EnrolmentConfirmationComponent.new(
+      current_user: User.last.presence,
+      programme: Programme.primary_certificate
+    ))
+  end
+
+  def custom_button_text
+    render(EnrolmentConfirmationComponent.new(
+      current_user: User.last.presence,
+      programme: Programme.primary_certificate,
+      full_width: false,
+      enrol_button_text: "Click here to enrol"
+    ))
+  end
+end

--- a/spec/components/enrolment_confirmation_component_spec.rb
+++ b/spec/components/enrolment_confirmation_component_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
       render_inline(described_class.new(
         programme: primary_certificate,
         current_user: user,
-        enrol_button_text: "Click here to enrol",
+        button_text: "Click here to enrol",
         full_width: false
       ))
     end
@@ -59,7 +59,7 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
     end
 
     it "does not apply the full width button classes" do
-      expect(page).to_not have_css(".enrolment-confirmation-component-button--full-width")
+      expect(page).to_not have_css(".enrolment-confirmation-component__button--full-width")
     end
   end
 end

--- a/spec/components/enrolment_confirmation_component_spec.rb
+++ b/spec/components/enrolment_confirmation_component_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe EnrolmentConfirmationComponent, type: :component do
+  let(:user) { create(:user) }
+  let(:primary_certificate) { create(:primary_certificate) }
+  let(:cs_accelerator) { create(:cs_accelerator) }
+
+  context "when no current user" do
+    before do
+      render_inline(described_class.new(
+        programme: primary_certificate,
+        current_user: nil
+      ))
+    end
+
+    it "renders a log in button" do
+      expect(page).to have_text("Log in")
+    end
+  end
+
+  context "when enrolment confirmation is false on the programme" do
+    before do
+      render_inline(described_class.new(
+        programme: cs_accelerator,
+        current_user: user
+      ))
+    end
+
+    it "does not render the modal and enrols the user" do
+      expect(page).to have_link(href: cs_accelerator.enrol_path(user_programme_enrolment: {user_id: user.id, programme_id: cs_accelerator.id}))
+    end
+  end
+
+  context "when the enrolment comfirmation is true on the programme" do
+    before do
+      render_inline(described_class.new(
+        programme: primary_certificate,
+        current_user: user
+      ))
+    end
+
+    it "renders the modal button" do
+      expect(page).to have_css("button", text: "Enrol")
+    end
+  end
+
+  context "with button text and full width to false" do
+    before do
+      render_inline(described_class.new(
+        programme: primary_certificate,
+        current_user: user,
+        enrol_button_text: "Click here to enrol",
+        full_width: false
+      ))
+    end
+
+    it "renders the button text" do
+      expect(page).to have_text("Click here to enrol")
+    end
+
+    it "does not apply the full width button classes" do
+      expect(page).to_not have_css(".enrolment-confirmation-component-button--full-width")
+    end
+  end
+end

--- a/spec/components/enrolment_confirmation_component_spec.rb
+++ b/spec/components/enrolment_confirmation_component_spec.rb
@@ -13,8 +13,12 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
       ))
     end
 
+    it "does not render the modal" do
+      expect(page).to_not have_css(".ncce-modal")
+    end
+
     it "renders a log in button" do
-      expect(page).to have_text("Log in")
+      expect(page).to have_link("Log in", href: "/auth/stem")
     end
   end
 
@@ -26,8 +30,12 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
       ))
     end
 
-    it "does not render the modal and enrols the user" do
-      expect(page).to have_link(href: cs_accelerator.enrol_path(user_programme_enrolment: {user_id: user.id, programme_id: cs_accelerator.id}))
+    it "does not render the modal" do
+      expect(page).to_not have_css(".ncce-modal")
+    end
+
+    it "has an programme enrolment button" do
+      expect(page).to have_link("Enrol", href: cs_accelerator.enrol_path(user_programme_enrolment: {user_id: user.id, programme_id: cs_accelerator.id}))
     end
   end
 
@@ -39,8 +47,16 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
       ))
     end
 
-    it "renders the modal button" do
+    it "renders the modal" do
+      expect(page).to have_css(".ncce-modal")
+    end
+
+    it "renders the enrol button" do
       expect(page).to have_css("button", text: "Enrol")
+    end
+
+    it "renders the enrollment confimation button" do
+      expect(page).to have_link("Confirm my enrolment", href: primary_certificate.enrol_path(user_programme_enrolment: {user_id: user.id, programme_id: primary_certificate.id}))
     end
   end
 
@@ -54,8 +70,12 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
       ))
     end
 
+    it "renders the modal" do
+      expect(page).to have_css(".ncce-modal")
+    end
+
     it "renders the button text" do
-      expect(page).to have_text("Click here to enrol")
+      expect(page).to have_button("Click here to enrol")
     end
 
     it "does not apply the full width button classes" do
@@ -73,8 +93,12 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
       ))
     end
 
+    it "does not render the modal" do
+      expect(page).to_not have_css(".ncce-modal")
+    end
+
     it "renders the view dashboard button" do
-      expect(page).to have_text("Visit dashboard")
+      expect(page).to have_link("Visit dashboard", href: "/dashboard")
     end
   end
 
@@ -88,8 +112,12 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
       ))
     end
 
+    it "does not render the modal" do
+      expect(page).to_not have_css(".ncce-modal")
+    end
+
     it "renders the view dashboard button" do
-      expect(page).to have_text("Visit dashboard")
+      expect(page).to have_link("Visit dashboard", href: "/dashboard")
     end
   end
 end

--- a/spec/components/enrolment_confirmation_component_spec.rb
+++ b/spec/components/enrolment_confirmation_component_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
     end
   end
 
-  context "when the user is already enrolled" do
+  context "when the user is already enrolled on a non confirmation programme" do
     before do
       allow(cs_accelerator).to receive(:user_enrolled?).with(user).and_return(true)
 
@@ -73,7 +73,22 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
       ))
     end
 
-    it "render the view dashboard button" do
+    it "renders the view dashboard button" do
+      expect(page).to have_text("Visit dashboard")
+    end
+  end
+
+  context "when the user is already enrolled on a programme that requires confirmation" do
+    before do
+      allow(primary_certificate).to receive(:user_enrolled?).with(user).and_return(true)
+
+      render_inline(described_class.new(
+        programme: primary_certificate,
+        current_user: user
+      ))
+    end
+
+    it "renders the view dashboard button" do
       expect(page).to have_text("Visit dashboard")
     end
   end

--- a/spec/components/enrolment_confirmation_component_spec.rb
+++ b/spec/components/enrolment_confirmation_component_spec.rb
@@ -62,4 +62,19 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
       expect(page).to_not have_css(".enrolment-confirmation-component__button--full-width")
     end
   end
+
+  context "when the user is already enrolled" do
+    before do
+      allow(cs_accelerator).to receive(:user_enrolled?).with(user).and_return(true)
+
+      render_inline(described_class.new(
+        programme: cs_accelerator,
+        current_user: user
+      ))
+    end
+
+    it "render the view dashboard button" do
+      expect(page).to have_text("Visit dashboard")
+    end
+  end
 end

--- a/spec/components/enrolment_confirmation_component_spec.rb
+++ b/spec/components/enrolment_confirmation_component_spec.rb
@@ -4,12 +4,14 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
   let(:user) { create(:user) }
   let(:primary_certificate) { create(:primary_certificate) }
   let(:cs_accelerator) { create(:cs_accelerator) }
+  let(:pathway) { create(:pathway) }
 
   context "when no current user" do
     before do
       render_inline(described_class.new(
         programme: primary_certificate,
-        current_user: nil
+        current_user: nil,
+        pathway: nil
       ))
     end
 
@@ -26,7 +28,8 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
     before do
       render_inline(described_class.new(
         programme: cs_accelerator,
-        current_user: user
+        current_user: user,
+        pathway:
       ))
     end
 
@@ -35,7 +38,7 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
     end
 
     it "has an programme enrolment button" do
-      expect(page).to have_link("Enrol", href: cs_accelerator.enrol_path(user_programme_enrolment: {user_id: user.id, programme_id: cs_accelerator.id}))
+      expect(page).to have_link("Enrol", href: cs_accelerator.enrol_path(user_programme_enrolment: {user_id: user.id, programme_id: cs_accelerator.id, pathway_slug: pathway.slug}))
     end
   end
 
@@ -43,7 +46,8 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
     before do
       render_inline(described_class.new(
         programme: primary_certificate,
-        current_user: user
+        current_user: user,
+        pathway:
       ))
     end
 
@@ -56,7 +60,7 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
     end
 
     it "renders the enrollment confimation button" do
-      expect(page).to have_link("Confirm my enrolment", href: primary_certificate.enrol_path(user_programme_enrolment: {user_id: user.id, programme_id: primary_certificate.id}))
+      expect(page).to have_link("Confirm my enrolment", href: primary_certificate.enrol_path(user_programme_enrolment: {user_id: user.id, programme_id: primary_certificate.id, pathway_slug: pathway.slug}))
     end
   end
 
@@ -66,7 +70,8 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
         programme: primary_certificate,
         current_user: user,
         button_text: "Click here to enrol",
-        full_width: false
+        full_width: false,
+        pathway:
       ))
     end
 
@@ -89,7 +94,8 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
 
       render_inline(described_class.new(
         programme: cs_accelerator,
-        current_user: user
+        current_user: user,
+        pathway:
       ))
     end
 
@@ -108,7 +114,8 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
 
       render_inline(described_class.new(
         programme: primary_certificate,
-        current_user: user
+        current_user: user,
+        pathway:
       ))
     end
 

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -439,4 +439,12 @@ RSpec.describe Programme, type: :model do
       expect(programme.minimum_character_required_community_evidence).to eq(0)
     end
   end
+
+  describe "#enrolment_confirmation_required?" do
+    it "should default to false" do
+      programme = create(:programme)
+
+      expect(programme.enrolment_confirmation_required?).to eq(false)
+    end
+  end
 end

--- a/spec/models/programmes/primary_certificate_spec.rb
+++ b/spec/models/programmes/primary_certificate_spec.rb
@@ -99,4 +99,10 @@ RSpec.describe Programmes::PrimaryCertificate do
       expect(programme.user_qualifies_for_credly_cpd_badge?(user)).to be true
     end
   end
+
+  describe "#enrolment_confirmation_required?" do
+    it "should return true" do
+      expect(programme.enrolment_confirmation_required?).to be true
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,6 +28,7 @@ require "webmock/rspec"
 require "rspec/json_expectations"
 require "capybara/rspec"
 require "view_component/test_helpers"
+require "view_component/system_test_helpers"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
@@ -73,6 +74,13 @@ RSpec.configure do |config|
   config.include FeatureFlagHelper
   config.include ViewComponent::TestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
+  config.include ViewComponent::SystemTestHelpers, type: :component_sys_test
+
+  config.before(:each, type: :component_sys_test) do
+    def page
+      Capybara.current_session
+    end
+  end
 
   config.before(:suite) do
     Webpacker.compile if Webpacker.instance.compiler.stale?

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -76,6 +76,7 @@ RSpec.configure do |config|
   config.include Capybara::RSpecMatchers, type: :component
   config.include ViewComponent::SystemTestHelpers, type: :component_sys_test
 
+  # https://github.com/ViewComponent/view_component/issues/1630 - Overrrides the Capybara overwrite
   config.before(:each, type: :component_sys_test) do
     def page
       Capybara.current_session

--- a/spec/system/components/enrolment_confirmation_component_spec.rb
+++ b/spec/system/components/enrolment_confirmation_component_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe("Enrolment confirmation component system test", type: [:system, :
       # click the edge of modal to close
       click_on "Enrol"
       expect(page).to have_selector(".ncce-modal--header h2", text: "Enrol on the Teach primary computing certificate")
-      find(".ncce-modal--body").click(x: 0, y: 500)
+      find(".ncce-modal--body").click(x: 0, y: 200)
 
       # press ESC to close
       click_on "Enrol"

--- a/spec/system/components/enrolment_confirmation_component_spec.rb
+++ b/spec/system/components/enrolment_confirmation_component_spec.rb
@@ -4,6 +4,7 @@ require "axe/rspec"
 RSpec.describe("Enrolment confirmation component system test", type: [:system, :component_sys_test]) do
   let(:user) { create(:user) }
   let(:primary_certificate) { create(:primary_certificate) }
+  let(:secondary_certificate) { create(:secondary_certificate) }
 
   context "the programme requires enrolment confirmation" do
     before do
@@ -39,6 +40,38 @@ RSpec.describe("Enrolment confirmation component system test", type: [:system, :
       click_on "Enrol"
       expect(page).to have_selector(".ncce-modal--header h2", text: "Enrol on the Teach primary computing certificate")
       click_on "Confirm my enrolment"
+      expect(page).to have_no_selector(".ncce-modal--body")
+    end
+  end
+
+  context "the programme does not require enrolment confirmation" do
+    before do
+      with_rendered_component_path(render_inline(EnrolmentConfirmationComponent.new(
+        current_user: user,
+        programme: secondary_certificate
+      )), layout: "application") do |path|
+        visit(path)
+      end
+    end
+
+    it "does not render the modal" do
+      click_on "Enrol"
+      expect(page).to have_no_selector(".ncce-modal--body")
+    end
+  end
+
+  context "the user is not logged in" do
+    before do
+      with_rendered_component_path(render_inline(EnrolmentConfirmationComponent.new(
+        current_user: nil,
+        programme: secondary_certificate
+      )), layout: "application") do |path|
+        visit(path)
+      end
+    end
+
+    it "does not render the modal" do
+      find(".govuk-button").click
       expect(page).to have_no_selector(".ncce-modal--body")
     end
   end

--- a/spec/system/components/enrolment_confirmation_component_spec.rb
+++ b/spec/system/components/enrolment_confirmation_component_spec.rb
@@ -5,12 +5,14 @@ RSpec.describe("Enrolment confirmation component system test", type: [:system, :
   let(:user) { create(:user) }
   let(:primary_certificate) { create(:primary_certificate) }
   let(:secondary_certificate) { create(:secondary_certificate) }
+  let(:pathway) { create(:pathway) }
 
   context "when the programme requires enrolment confirmation" do
     before do
       with_rendered_component_path(render_inline(EnrolmentConfirmationComponent.new(
         current_user: user,
-        programme: primary_certificate
+        programme: primary_certificate,
+        pathway:
       )), layout: "application") do |path|
         visit(path)
       end

--- a/spec/system/components/enrolment_confirmation_component_spec.rb
+++ b/spec/system/components/enrolment_confirmation_component_spec.rb
@@ -43,36 +43,4 @@ RSpec.describe("Enrolment confirmation component system test", type: [:system, :
       expect(page).to have_no_selector(".ncce-modal--body")
     end
   end
-
-  context "the programme does not require enrolment confirmation" do
-    before do
-      with_rendered_component_path(render_inline(EnrolmentConfirmationComponent.new(
-        current_user: user,
-        programme: secondary_certificate
-      )), layout: "application") do |path|
-        visit(path)
-      end
-    end
-
-    it "does not render the modal" do
-      click_on "Enrol"
-      expect(page).to have_no_selector(".ncce-modal--body")
-    end
-  end
-
-  context "the user is not logged in" do
-    before do
-      with_rendered_component_path(render_inline(EnrolmentConfirmationComponent.new(
-        current_user: nil,
-        programme: secondary_certificate
-      )), layout: "application") do |path|
-        visit(path)
-      end
-    end
-
-    it "does not render the modal" do
-      find(".govuk-button").click
-      expect(page).to have_no_selector(".ncce-modal--body")
-    end
-  end
 end

--- a/spec/system/components/enrolment_confirmation_component_spec.rb
+++ b/spec/system/components/enrolment_confirmation_component_spec.rb
@@ -4,47 +4,42 @@ require "axe/rspec"
 RSpec.describe("Enrolment confirmation component system test", type: [:system, :component_sys_test]) do
   let(:user) { create(:user) }
   let(:primary_certificate) { create(:primary_certificate) }
-  let(:secondary_certificate) { create(:secondary_certificate) }
 
   context "the programme requires enrolment confirmation" do
     before do
       with_rendered_component_path(render_inline(EnrolmentConfirmationComponent.new(
         current_user: user,
         programme: primary_certificate
-      ))) do |path|
+      )), layout: "application") do |path|
         visit(path)
       end
     end
 
-    it "renders the certificate name" do
-      expect(page).to have_text("Enrol on the #{primary_certificate.certificate_name}")
+    it "lets you freely close the modal before confirming" do
+      # click the edge of modal to close
+      click_on "Enrol"
+      expect(page).to have_selector(".ncce-modal--header h2", text: "Enrol on the Teach primary computing certificate")
+      find(".ncce-modal--body").click(x: 0, y: 500)
+
+      # press ESC to close
+      click_on "Enrol"
+      expect(page).to have_selector(".ncce-modal--header h2", text: "Enrol on the Teach primary computing certificate")
+      send_keys :escape
+      expect(page).to have_no_selector(".ncce-modal--body")
+
+      # press the X icon to close
+      click_on "Enrol"
+      expect(page).to have_selector(".ncce-modal--header h2", text: "Enrol on the Teach primary computing certificate")
+      find(".icon-close").click
+      expect(page).to have_no_selector(".ncce-modal--body")
     end
 
-    it "renders the ready to enrol text" do
-      expect(page).to have_css("h2", text: "Ready to enrol?")
-    end
-
-    it "renders the enrolment confirmation text" do
-      expect(page).to have_css("p", text: "Confirm your enrolment on the certificate, and then let's find you the perfect training course to get started with.")
-    end
-
-    it "has the enrolment confirmation button" do
-      expect(page).to have_css("a", text: "Confirm my enrolment")
-    end
-  end
-
-  context "the programme does not require enrolment confirmation" do
-    before do
-      with_rendered_component_path(render_inline(EnrolmentConfirmationComponent.new(
-        current_user: user,
-        programme: secondary_certificate
-      ))) do |path|
-        visit(path)
-      end
-    end
-
-    it "renders the enrol button" do
-      expect(page).to have_link(href: secondary_certificate.enrol_path(user_programme_enrolment: {user_id: user.id, programme_id: secondary_certificate.id}))
+    it "lets the user enrol on the certificate" do
+      # continue with enrolment confirmation
+      click_on "Enrol"
+      expect(page).to have_selector(".ncce-modal--header h2", text: "Enrol on the Teach primary computing certificate")
+      click_on "Confirm my enrolment"
+      expect(page).to have_no_selector(".ncce-modal--body")
     end
   end
 end

--- a/spec/system/components/enrolment_confirmation_component_spec.rb
+++ b/spec/system/components/enrolment_confirmation_component_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+require "axe/rspec"
+
+RSpec.describe("Enrolment confirmation component system test", type: [:system, :component_sys_test]) do
+  let(:user) { create(:user) }
+  let(:primary_certificate) { create(:primary_certificate) }
+  let(:secondary_certificate) { create(:secondary_certificate) }
+
+  context "the programme requires enrolment confirmation" do
+    before do
+      with_rendered_component_path(render_inline(EnrolmentConfirmationComponent.new(
+        current_user: user,
+        programme: primary_certificate
+      ))) do |path|
+        visit(path)
+      end
+    end
+
+    it "renders the certificate name" do
+      expect(page).to have_text("Enrol on the #{primary_certificate.certificate_name}")
+    end
+
+    it "renders the ready to enrol text" do
+      expect(page).to have_css("h2", text: "Ready to enrol?")
+    end
+
+    it "renders the enrolment confirmation text" do
+      expect(page).to have_css("p", text: "Confirm your enrolment on the certificate, and then let's find you the perfect training course to get started with.")
+    end
+
+    it "has the enrolment confirmation button" do
+      expect(page).to have_css("a", text: "Confirm my enrolment")
+    end
+  end
+
+  context "the programme does not require enrolment confirmation" do
+    before do
+      with_rendered_component_path(render_inline(EnrolmentConfirmationComponent.new(
+        current_user: user,
+        programme: secondary_certificate
+      ))) do |path|
+        visit(path)
+      end
+    end
+
+    it "renders the enrol button" do
+      expect(page).to have_link(href: secondary_certificate.enrol_path(user_programme_enrolment: {user_id: user.id, programme_id: secondary_certificate.id}))
+    end
+  end
+end

--- a/spec/system/components/enrolment_confirmation_component_spec.rb
+++ b/spec/system/components/enrolment_confirmation_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe("Enrolment confirmation component system test", type: [:system, :
   let(:primary_certificate) { create(:primary_certificate) }
   let(:secondary_certificate) { create(:secondary_certificate) }
 
-  context "the programme requires enrolment confirmation" do
+  context "when the programme requires enrolment confirmation" do
     before do
       with_rendered_component_path(render_inline(EnrolmentConfirmationComponent.new(
         current_user: user,
@@ -32,14 +32,6 @@ RSpec.describe("Enrolment confirmation component system test", type: [:system, :
       click_on "Enrol"
       expect(page).to have_selector(".ncce-modal--header h2", text: "Enrol on the Teach primary computing certificate")
       find(".icon-close").click
-      expect(page).to have_no_selector(".ncce-modal--body")
-    end
-
-    it "lets the user enrol on the certificate" do
-      # continue with enrolment confirmation
-      click_on "Enrol"
-      expect(page).to have_selector(".ncce-modal--header h2", text: "Enrol on the Teach primary computing certificate")
-      click_on "Confirm my enrolment"
       expect(page).to have_no_selector(".ncce-modal--body")
     end
   end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2861

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?
- Created enrolment confirmation component
- Added method onto programme model that defaults confirmation to false unless specified on the programme itself as true
- Added relevant tests and previews

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
