### PR TITLE
Converting blank achiever_organisation_id to nil

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,7 @@ class User < ApplicationRecord
     user.stem_credentials_access_token = credentials.token
     user.stem_credentials_refresh_token = credentials.refresh_token
     user.stem_credentials_expires_at = Time.zone.at(credentials.expires_at)
-    user.stem_achiever_organisation_no = info.achiever_organisation_no
+    user.stem_achiever_organisation_no = info.achiever_organisation_no.presence
     user.last_sign_in_at = Time.current
     user.school_name = info.school_name
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,6 +16,16 @@ RSpec.describe User do
       stem_user_id: "id-stem-user"
     )
   end
+  let(:stem_info_blank_org) do
+    OmniAuth::AuthHash::InfoHash.new(
+      achiever_contact_no: "ca432eb9-9b34-46db-afbb-fbd1efa89e6b",
+      achiever_organisation_no: "",
+      email: "user2@example.com",
+      first_name: "Jane",
+      last_name: "Doe",
+      stem_user_id: "id-stem-user"
+    )
+  end
   let(:uid) { "id-stem-user" }
   let(:user) { described_class.from_auth(uid, stem_credentials, stem_info) }
 
@@ -123,6 +133,11 @@ RSpec.describe User do
 
     it "has the last sign in date set" do
       expect(user.last_sign_in_at).to be_today
+    end
+
+    it "if achiever_organisation_no is blank it get sets to nil" do
+      new_user = described_class.from_auth(uid, stem_credentials, stem_info_blank_org)
+      expect(new_user.stem_achiever_organisation_no).to be_nil
     end
   end
 


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2910

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

In the new CRUP system, the achiever_organisation_id returns as a blank string, rather than a null. This should be null to be consistent with older implementations. This will convert blanks to nil.

## Steps to perform after deploying to production

Need to process anyone who has a blank organisation ID to nil after deployment (to deal with anyone in the interim, and fix the data teams reports)