### PR TITLE
Removing old register link

### DIFF
--- a/app/views/pages/_pedagogy_asides.html.erb
+++ b/app/views/pages/_pedagogy_asides.html.erb
@@ -10,7 +10,6 @@
   <%= link_to(t("#{tr8_prefix}.research_bytes.button_text"), 'https://email.teachcomputing.org/q/119zKWEGEfJa/wv', class: 'govuk-button button', data: tracking_data('Read latest research')) %>
   <ul class="govuk-list govuk-list--ncce">
     <li><%= link_to(t("#{tr8_prefix}.research_bytes.link_1"), cms_posts_path(tag: :pedagogy), class: 'ncce-link', data: tracking_data('See past articles')) %></li>
-    <li><%= link_to(t("#{tr8_prefix}.research_bytes.link_2"), 'https://ncce.stem.org.uk/user/register?from=NCCE', class: 'ncce-link', data: tracking_data('Register')) %> <%= t("#{tr8_prefix}.research_bytes.link_2_extra") %></li>
   </ul>
 </div>
 


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2919

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Remove reference to register link

