### PR TITLE
Display course-specific duration for online course

### DIFF
--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -154,4 +154,8 @@ module CoursesHelper
 
     course[:title]
   end
+
+  def course_duration_text(course)
+    pluralize(course.duration_value, course.duration.downcase.chomp("s")) if course.duration.present?
+  end
 end

--- a/app/views/courses/_courses-details.html.erb
+++ b/app/views/courses/_courses-details.html.erb
@@ -13,13 +13,13 @@
     <strong class="govuk-tag ncce-courses__tag ncce-courses__tag ncce-courses__filter-tag--<%= programme.parameterize %>"><%= display_programme_tag programme %></strong>
   <% end %>
   <div class="course-details__icons">
-  <% if @course.online_cpd %>
-    <span class="govuk-body icon-online">Free online course</span>
-    <span class="govuk-body icon-clock">Approximately 8 hours of self-study</span>
-  <% else %>
-    <span class="govuk-body <%= course_meta_icon_class(@occurrences.first) %>"><%= "#{remote_or_face_to_face(@course)} course" %></span>
-    <span class="govuk-body icon-clock"><%= pluralize(@course.duration_value, @course.duration.downcase.chomp('s')) if @course.duration.present? %></span>
-    <%= render 'courses/courses-locations', course: @course %>
-  <% end %>
+    <% if @course.online_cpd %>
+      <span class="govuk-body icon-online">Free online course</span>
+      <span class="govuk-body icon-clock"><%= pluralize(@course.duration_value, @course.duration.downcase.chomp('s')) if @course.duration.present? %></span>
+    <% else %>
+      <span class="govuk-body <%= course_meta_icon_class(@occurrences.first) %>"><%= "#{remote_or_face_to_face(@course)} course" %></span>
+      <span class="govuk-body icon-clock"><%= pluralize(@course.duration_value, @course.duration.downcase.chomp('s')) if @course.duration.present? %></span>
+      <%= render 'courses/courses-locations', course: @course %>
+    <% end %>
   </div>
 </div>

--- a/app/views/courses/_courses-details.html.erb
+++ b/app/views/courses/_courses-details.html.erb
@@ -15,10 +15,10 @@
   <div class="course-details__icons">
     <% if @course.online_cpd %>
       <span class="govuk-body icon-online">Free online course</span>
-      <span class="govuk-body icon-clock"><%= pluralize(@course.duration_value, @course.duration.downcase.chomp('s')) if @course.duration.present? %></span>
+      <span class="govuk-body icon-clock"><%= course_duration_text(@course) %></span>
     <% else %>
       <span class="govuk-body <%= course_meta_icon_class(@occurrences.first) %>"><%= "#{remote_or_face_to_face(@course)} course" %></span>
-      <span class="govuk-body icon-clock"><%= pluralize(@course.duration_value, @course.duration.downcase.chomp('s')) if @course.duration.present? %></span>
+      <span class="govuk-body icon-clock"><%= course_duration_text(@course) %></span>
       <%= render 'courses/courses-locations', course: @course %>
     <% end %>
   </div>

--- a/spec/helpers/courses_helper_spec.rb
+++ b/spec/helpers/courses_helper_spec.rb
@@ -5,6 +5,7 @@ describe CoursesHelper, type: :helper do
   let(:activity) { create(:activity) }
   let(:activity_two) { create(:activity) }
   let(:achievement) { create(:achievement, user_id: user.id, activity_id: activity.id) }
+  let(:course_template) { Achiever::Course::Template.find_by_activity_code("CP428") }
 
   let(:courses) do
     (0..10).map do |i|
@@ -360,6 +361,14 @@ describe CoursesHelper, type: :helper do
 
     it "renders the correct copy for Primary" do
       expect(helper.certificate_card_summary(build(:primary_certificate))).to eq("This course is part of Teach primary computing")
+    end
+  end
+
+  describe "#course_duration_text" do
+    it "renders the correct duration text" do
+      stub_course_templates
+      stub_duration_units
+      expect(helper.course_duration_text(course_template)).to eq("5 hours")
     end
   end
 end

--- a/spec/views/courses/_courses-details.html_spec.rb
+++ b/spec/views/courses/_courses-details.html_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe("courses/_courses-details", type: :view) do
     end
 
     it "displays the time" do
-      expect(rendered).to have_css(".icon-clock", text: "Approximately 8 hours of self-study")
+      expect(rendered).to have_css(".icon-clock", text: "4 weeks")
     end
 
     it "does not display occurrences" do


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2901

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?
- Online CPD to show the course duration from duration_unit and duration the same as other course formats
