### PR TITLE
Improve the notification functionality

### DIFF
--- a/app/models/programmes/cs_accelerator.rb
+++ b/app/models/programmes/cs_accelerator.rb
@@ -50,16 +50,7 @@ module Programmes
       enrolment = user.user_programme_enrolments.find_by(programme_id: id)
       return false if enrolment.nil? || enrolment.in_state?(:complete, :unenrolled)
 
-      return false unless in_notifiable_period?(user)
-
       enough_activities_for_test?(user)
-    end
-
-    def in_notifiable_period?(user)
-      enrolment = user.user_programme_enrolments.find_by(programme_id: id)
-      notifiable_date_range = 48.hours.ago..Time.current
-
-      notifiable_date_range.cover?(enrolment.last_enrolled_at)
     end
 
     def notification_link

--- a/spec/models/programmes/cs_accelerator_spec.rb
+++ b/spec/models/programmes/cs_accelerator_spec.rb
@@ -176,7 +176,6 @@ RSpec.describe Programmes::CSAccelerator do
     context "when a user is not enrolled" do
       before do
         setup_short_f2f_and_online_achievement
-        allow(programme).to receive(:in_notifiable_period?).with(user).and_return(true)
         allow(programme).to receive(:enough_activities_for_test?).with(user).and_return(true)
       end
 
@@ -186,22 +185,9 @@ RSpec.describe Programmes::CSAccelerator do
       end
     end
 
-    context "when in_notifiable_period? is false" do
-      before do
-        setup_short_f2f_and_online_achievement
-        allow(programme).to receive(:in_notifiable_period?).with(user).and_return(false)
-        allow(programme).to receive(:enough_activities_for_test?).with(user).and_return(true)
-      end
-
-      it "returns false" do
-        expect(programme.show_notification_for_test?(user)).to eq(false)
-      end
-    end
-
     context "when the user does not have enough_activities_for_test?" do
       before do
         setup_short_f2f_and_online_achievement
-        allow(programme).to receive(:in_notifiable_period?).with(user).and_return(true)
         allow(programme).to receive(:enough_activities_for_test?).with(user).and_return(false)
       end
 
@@ -213,36 +199,11 @@ RSpec.describe Programmes::CSAccelerator do
     context "when the user should be shown the notification" do
       before do
         setup_short_f2f_and_online_achievement
-        allow(programme).to receive(:in_notifiable_period?).with(user).and_return(true)
         allow(programme).to receive(:enough_activities_for_test?).with(user).and_return(true)
       end
 
       it "returns true" do
         expect(programme.show_notification_for_test?(user)).to eq(true)
-      end
-    end
-  end
-
-  describe "#in_notifiable_period?" do
-    context "when the last_enrolled_at date on enrolment is within 48 hours" do
-      before do
-        setup_one_online_achievement
-        allow_any_instance_of(UserProgrammeEnrolment).to receive(:last_enrolled_at).and_return(1.day.ago)
-      end
-
-      it "returns true" do
-        expect(programme.in_notifiable_period?(user)).to eq(true)
-      end
-    end
-
-    context "when the last_enrolled_at date on enrolment is not within 48 hours" do
-      before do
-        setup_one_online_achievement
-        allow_any_instance_of(UserProgrammeEnrolment).to receive(:last_enrolled_at).and_return(3.days.ago)
-      end
-
-      it "returns true" do
-        expect(programme.in_notifiable_period?(user)).to eq(false)
       end
     end
   end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2923

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?
- Updated the CS accelerator model notification code to remove the 48 hour notification period. The notification will now continue to show for the user until programme has been completed.