### PR TITLE
Fix links to primary course page on dashboard

### DIFF
--- a/app/components/user_programme_course_bookings_with_asides_component.rb
+++ b/app/components/user_programme_course_bookings_with_asides_component.rb
@@ -20,7 +20,7 @@ class UserProgrammeCourseBookingsWithAsidesComponent < CmsWithAsidesComponent
 
   private
 
-  def button_link_text
+  def programme_link
     return primary_courses_path if @programme == Programme.primary_certificate
 
     courses_path(certificate: @programme&.slug)

--- a/app/components/user_programme_course_bookings_with_asides_component.rb
+++ b/app/components/user_programme_course_bookings_with_asides_component.rb
@@ -20,6 +20,12 @@ class UserProgrammeCourseBookingsWithAsidesComponent < CmsWithAsidesComponent
 
   private
 
+  def button_link_text
+    return primary_courses_path if @programme == Programme.primary_certificate
+
+    courses_path(certificate: @programme&.slug)
+  end
+
   def course_sections
     [{title: "Booked courses", courses: in_progress_courses},
       {title: "Completed courses", courses: completed_courses}]

--- a/app/components/user_programme_course_bookings_with_asides_component/user_programme_course_bookings_with_asides_component.html.erb
+++ b/app/components/user_programme_course_bookings_with_asides_component/user_programme_course_bookings_with_asides_component.html.erb
@@ -39,12 +39,12 @@
       <% if !in_progress_courses.present? && !completed_courses.present? %>
       <div class="user-programme-course-bookings-with-asides__footer">
           <div><h2 class="govuk-heading-s govuk-!-margin-0">Find a CPD course to get started</h2></div>
-          <div><%= link_to 'Explore courses', courses_path(certificate: @programme&.slug), class: "govuk-button button ncce-button-chevron govuk-!-margin-0" %></div>
+          <div><%= link_to 'Explore courses', primary_courses_path, class: "govuk-button button ncce-button-chevron govuk-!-margin-0" %></div>
         </div>
       <% else %>
         <div class="user-programme-course-bookings-with-asides__footer">
           <div><h2 class="govuk-heading-s govuk-!-margin-0">Discover more courses</h2></div>
-          <div><%= link_to 'Explore courses ', courses_path(certificate: @programme&.slug), class: "govuk-button button ncce-button-chevron button--inverted govuk-!-margin-0" %></div>
+          <div><%= link_to 'Explore courses ', primary_courses_path, class: "govuk-button button ncce-button-chevron button--inverted govuk-!-margin-0" %></div>
         </div>
       <% end %>
     </div>

--- a/app/components/user_programme_course_bookings_with_asides_component/user_programme_course_bookings_with_asides_component.html.erb
+++ b/app/components/user_programme_course_bookings_with_asides_component/user_programme_course_bookings_with_asides_component.html.erb
@@ -39,12 +39,12 @@
       <% if !in_progress_courses.present? && !completed_courses.present? %>
       <div class="user-programme-course-bookings-with-asides__footer">
           <div><h2 class="govuk-heading-s govuk-!-margin-0">Find a CPD course to get started</h2></div>
-          <div><%= link_to 'Explore courses', button_link_text, class: "govuk-button button ncce-button-chevron govuk-!-margin-0" %></div>
+          <div><%= link_to 'Explore courses', programme_link, class: "govuk-button button ncce-button-chevron govuk-!-margin-0" %></div>
         </div>
       <% else %>
         <div class="user-programme-course-bookings-with-asides__footer">
           <div><h2 class="govuk-heading-s govuk-!-margin-0">Discover more courses</h2></div>
-          <div><%= link_to 'Explore courses ', button_link_text, class: "govuk-button button ncce-button-chevron button--inverted govuk-!-margin-0" %></div>
+          <div><%= link_to 'Explore courses ', programme_link, class: "govuk-button button ncce-button-chevron button--inverted govuk-!-margin-0" %></div>
         </div>
       <% end %>
     </div>

--- a/app/components/user_programme_course_bookings_with_asides_component/user_programme_course_bookings_with_asides_component.html.erb
+++ b/app/components/user_programme_course_bookings_with_asides_component/user_programme_course_bookings_with_asides_component.html.erb
@@ -39,12 +39,12 @@
       <% if !in_progress_courses.present? && !completed_courses.present? %>
       <div class="user-programme-course-bookings-with-asides__footer">
           <div><h2 class="govuk-heading-s govuk-!-margin-0">Find a CPD course to get started</h2></div>
-          <div><%= link_to 'Explore courses', primary_courses_path, class: "govuk-button button ncce-button-chevron govuk-!-margin-0" %></div>
+          <div><%= link_to 'Explore courses', button_link_text, class: "govuk-button button ncce-button-chevron govuk-!-margin-0" %></div>
         </div>
       <% else %>
         <div class="user-programme-course-bookings-with-asides__footer">
           <div><h2 class="govuk-heading-s govuk-!-margin-0">Discover more courses</h2></div>
-          <div><%= link_to 'Explore courses ', primary_courses_path, class: "govuk-button button ncce-button-chevron button--inverted govuk-!-margin-0" %></div>
+          <div><%= link_to 'Explore courses ', button_link_text, class: "govuk-button button ncce-button-chevron button--inverted govuk-!-margin-0" %></div>
         </div>
       <% end %>
     </div>

--- a/spec/components/user_programme_course_bookings_with_asides_component_spec.rb
+++ b/spec/components/user_programme_course_bookings_with_asides_component_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe UserProgrammeCourseBookingsWithAsidesComponent, type: :component 
     it "does not render the aside" do
       expect(page).to_not have_css(".aside-component")
     end
+
+    it "renders the explore courses button" do
+      expect(page).to have_css("a", text: "Explore courses")
+    end
   end
 
   context "with completed course" do

--- a/spec/components/user_programme_course_bookings_with_asides_component_spec.rb
+++ b/spec/components/user_programme_course_bookings_with_asides_component_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe UserProgrammeCourseBookingsWithAsidesComponent, type: :component 
 
   describe "when not primary certificate" do
     let(:secondary_certificate) { create(:secondary_certificate) }
-    let!(:secondary_programme_activity_grouping) { create(:programme_activity_grouping, programme: secondary_certificate)}
+    let!(:secondary_programme_activity_grouping) { create(:programme_activity_grouping, programme: secondary_certificate) }
     context "with no user courses" do
       before do
         allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)

--- a/spec/components/user_programme_course_bookings_with_asides_component_spec.rb
+++ b/spec/components/user_programme_course_bookings_with_asides_component_spec.rb
@@ -15,168 +15,192 @@ RSpec.describe UserProgrammeCourseBookingsWithAsidesComponent, type: :component 
   let(:remote_achievement) { create(:achievement, user:, activity: activity_three) }
   let(:completed_user_achievement) { create(:completed_achievement, user:, activity: activity_two) }
 
-  context "with no user courses" do
-    before do
-      allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
-      allow_any_instance_of(ProgrammeActivityGrouping).to receive(:user_complete?).and_return(true)
+  describe "when primary certificate" do
+    context "with no user courses" do
+      before do
+        allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
+        allow_any_instance_of(ProgrammeActivityGrouping).to receive(:user_complete?).and_return(true)
 
-      stub_strapi_aside_section("test-aside")
+        stub_strapi_aside_section("test-aside")
 
-      render_inline(
-        described_class.new(
-          programme: programme,
-          aside_slug: "test-aside"
+        render_inline(
+          described_class.new(
+            programme: programme,
+            aside_slug: "test-aside"
+          )
         )
-      )
+      end
+
+      it "renders the section title" do
+        expect(page).to have_css("h2", text: "Step one: CPD courses")
+      end
+
+      it "does not render any courses" do
+        expect(page).to_not have_css(".user-programme-course-bookings-with-asides__course-wrapper")
+      end
+
+      it "renders the explore courses button" do
+        expect(page).to have_css(".govuk-button", text: "Explore courses")
+      end
+
+      it "does not render the aside" do
+        expect(page).to_not have_css(".aside-component")
+      end
+
+      it "renders the explore courses button with link to primary course page" do
+        expect(page).to have_link("Explore courses", href: "/primary-certificate/courses")
+      end
     end
 
-    it "renders the section title" do
-      expect(page).to have_css("h2", text: "Step one: CPD courses")
+    context "with completed course" do
+      before do
+        allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
+        allow_any_instance_of(ProgrammeActivityGrouping).to receive(:user_complete?).and_return(true)
+
+        completed_user_achievement
+
+        stub_course_templates
+        stub_duration_units
+        stub_strapi_aside_section("test-aside")
+
+        render_inline(
+          described_class.new(
+            programme: programme,
+            aside_slug: "test-aside"
+          )
+        )
+      end
+
+      it "renders the booked courses title" do
+        expect(page).to have_css("h2", text: "Completed courses")
+      end
+
+      it "renders the course details" do
+        expect(page).to have_css(".user-programme-course-bookings-with-asides__course-wrapper", count: 1)
+      end
+
+      it "renders the aside" do
+        expect(page).to have_css(".aside-component")
+      end
+
+      it "renders the course title and link" do
+        expect(page).to have_css("a", text: completed_user_achievement.activity.title)
+      end
+
+      it "renders the course icon" do
+        expect(page).to have_css("[class^='icon']")
+      end
+
+      it "renders the course duration" do
+        expect(page).to have_css(".icon-clock")
+      end
     end
 
-    it "does not render any courses" do
-      expect(page).to_not have_css(".user-programme-course-bookings-with-asides__course-wrapper")
+    context "with in progress course" do
+      before do
+        allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
+        allow_any_instance_of(ProgrammeActivityGrouping).to receive(:user_complete?).and_return(true)
+
+        user_achievement
+
+        stub_course_templates
+        stub_duration_units
+        stub_strapi_aside_section("test-aside")
+
+        render_inline(
+          described_class.new(
+            programme: programme,
+            aside_slug: "test-aside"
+          )
+        )
+      end
+
+      it "renders the booked courses title" do
+        expect(page).to have_css("h2", text: "Booked courses")
+      end
+
+      it "renders the course details" do
+        expect(page).to have_css(".user-programme-course-bookings-with-asides__course-wrapper", count: 1)
+      end
+
+      it "renders the aside" do
+        expect(page).to have_css(".aside-component")
+      end
+
+      it "renders the online course icon" do
+        expect(page).to have_css(".icon-online")
+      end
+
+      it "renders the completed tick image" do
+        expect(page).to have_css("img[src*='activity-complete-icon']")
+      end
     end
 
-    it "renders the explore courses button" do
-      expect(page).to have_css(".govuk-button", text: "Explore courses")
-    end
+    context "with completed and in progress courses and no aside" do
+      before do
+        allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
+        allow_any_instance_of(ProgrammeActivityGrouping).to receive(:user_complete?).and_return(true)
 
-    it "does not render the aside" do
-      expect(page).to_not have_css(".aside-component")
-    end
+        remote_achievement
+        completed_user_achievement
 
-    it "renders the explore courses button" do
-      expect(page).to have_css("a", text: "Explore courses")
+        stub_course_templates
+        stub_duration_units
+
+        render_inline(
+          described_class.new(
+            programme: programme,
+            aside_slug: nil
+          )
+        )
+      end
+
+      it "renders the booked and completed courses title" do
+        expect(page).to have_css("h2", text: "Booked courses")
+        expect(page).to have_css("h2", text: "Completed courses")
+      end
+
+      it "renders the course details" do
+        expect(page).to have_css(".user-programme-course-bookings-with-asides__course-wrapper", count: 2)
+      end
+
+      it "renders the aside" do
+        expect(page).to_not have_css(".aside-component")
+      end
+
+      it "renders the completed tick image" do
+        expect(page).to have_css("img[src*='activity-complete-icon']")
+      end
+
+      it "does not render the aside component" do
+        expect(page).to_not have_css(".aside-component")
+      end
+
+      it "renders the face to face icon" do
+        expect(page).to have_css(".icon-remote")
+      end
     end
   end
 
-  context "with completed course" do
-    before do
-      allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
-      allow_any_instance_of(ProgrammeActivityGrouping).to receive(:user_complete?).and_return(true)
+  describe "when not primary certificate" do
+    let(:secondary_certificate) { create(:secondary_certificate) }
+    let!(:secondary_programme_activity_grouping) { create(:programme_activity_grouping, programme: secondary_certificate)}
+    context "with no user courses" do
+      before do
+        allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
+        stub_strapi_aside_section("test-aside")
 
-      completed_user_achievement
-
-      stub_course_templates
-      stub_duration_units
-      stub_strapi_aside_section("test-aside")
-
-      render_inline(
-        described_class.new(
-          programme: programme,
-          aside_slug: "test-aside"
+        render_inline(
+          described_class.new(
+            programme: secondary_certificate,
+            aside_slug: "test-aside"
+          )
         )
-      )
-    end
+      end
 
-    it "renders the booked courses title" do
-      expect(page).to have_css("h2", text: "Completed courses")
-    end
-
-    it "renders the course details" do
-      expect(page).to have_css(".user-programme-course-bookings-with-asides__course-wrapper", count: 1)
-    end
-
-    it "renders the aside" do
-      expect(page).to have_css(".aside-component")
-    end
-
-    it "renders the course title and link" do
-      expect(page).to have_css("a", text: completed_user_achievement.activity.title)
-    end
-
-    it "renders the course icon" do
-      expect(page).to have_css("[class^='icon']")
-    end
-
-    it "renders the course duration" do
-      expect(page).to have_css(".icon-clock")
-    end
-  end
-
-  context "with in progress course" do
-    before do
-      allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
-      allow_any_instance_of(ProgrammeActivityGrouping).to receive(:user_complete?).and_return(true)
-
-      user_achievement
-
-      stub_course_templates
-      stub_duration_units
-      stub_strapi_aside_section("test-aside")
-
-      render_inline(
-        described_class.new(
-          programme: programme,
-          aside_slug: "test-aside"
-        )
-      )
-    end
-
-    it "renders the booked courses title" do
-      expect(page).to have_css("h2", text: "Booked courses")
-    end
-
-    it "renders the course details" do
-      expect(page).to have_css(".user-programme-course-bookings-with-asides__course-wrapper", count: 1)
-    end
-
-    it "renders the aside" do
-      expect(page).to have_css(".aside-component")
-    end
-
-    it "renders the online course icon" do
-      expect(page).to have_css(".icon-online")
-    end
-
-    it "renders the completed tick image" do
-      expect(page).to have_css("img[src*='activity-complete-icon']")
-    end
-  end
-
-  context "with completed and in progress courses and no aside" do
-    before do
-      allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
-      allow_any_instance_of(ProgrammeActivityGrouping).to receive(:user_complete?).and_return(true)
-
-      remote_achievement
-      completed_user_achievement
-
-      stub_course_templates
-      stub_duration_units
-
-      render_inline(
-        described_class.new(
-          programme: programme,
-          aside_slug: nil
-        )
-      )
-    end
-
-    it "renders the booked and completed courses title" do
-      expect(page).to have_css("h2", text: "Booked courses")
-      expect(page).to have_css("h2", text: "Completed courses")
-    end
-
-    it "renders the course details" do
-      expect(page).to have_css(".user-programme-course-bookings-with-asides__course-wrapper", count: 2)
-    end
-
-    it "renders the aside" do
-      expect(page).to_not have_css(".aside-component")
-    end
-
-    it "renders the completed tick image" do
-      expect(page).to have_css("img[src*='activity-complete-icon']")
-    end
-
-    it "does not render the aside component" do
-      expect(page).to_not have_css(".aside-component")
-    end
-
-    it "renders the face to face icon" do
-      expect(page).to have_css(".icon-remote")
+      it "renders the explore courses button with link to course page with programme filter" do
+        expect(page).to have_link("Explore courses", href: "/courses?certificate=secondary-certificate")
+      end
     end
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2940

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?
- New method in the user courses dashboard component to send the user to the correct course page depending on the programme
- Added additional tests in for the method
