### PR TITLE
Add system tests for primary dashboard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   ruby: circleci/ruby@1
-  browser-tools: circleci/browser-tools@1.4.8
+  browser-tools: circleci/browser-tools@1.5.1
 
 jobs:
   brakeman:

--- a/spec/system/certificates/primary_certificate/show_spec.rb
+++ b/spec/system/certificates/primary_certificate/show_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe("Primary certificate page") do
+  let(:user) { create(:user, email: "web@teachcomputing.org") }
+  let(:programme) { create(:primary_certificate) }
+  let!(:programme_activity_grouping) { create(:programme_activity_grouping, programme:) }
+  let!(:community_programme_activity_grouping) { create(:programme_activity_grouping, programme:, community: true) }
+  let!(:user_programme_enrolment) { create(:user_programme_enrolment, user:, programme:) }
+
+  let(:activities) { create_list(:activity, 3, :community) }
+
+  before do
+    allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)
+
+    mock_data = Cms::Mocks::Programme.generate_raw_data(slug: programme.slug)
+    stub_strapi_programme(programme.slug, programme: mock_data)
+    stub_strapi_aside_section("primary-certificate-need-help")
+    stub_strapi_aside_section("primary-dashboard-cpd-section")
+
+    activities.each_with_index do |activity, index|
+      activity.update(title: "Activity #{index + 1}")
+      create(:programme_activity,
+        programme_activity_grouping: community_programme_activity_grouping,
+        programme:,
+        activity:)
+    end
+  end
+
+  it "creates a user achievement when activity is selected" do
+    activity = programme.programme_activity_groupings.community.first.activities.first
+    visit primary_certificate_path
+
+    expect {
+      select activity.title, from: "activity"
+      sleep 1
+      click_on "Choose activity"
+      sleep 5
+    }.to change { user.reload.achievements.count }.by(1)
+
+    latest_achievement = user.achievements.last
+    expect(latest_achievement.activity_id).to eq(activity.id)
+  end
+end

--- a/spec/system/certificates/primary_certificate/show_spec.rb
+++ b/spec/system/certificates/primary_certificate/show_spec.rb
@@ -49,4 +49,30 @@ RSpec.describe("Primary certificate page") do
 
     expect(page).to_not have_css(".primary-dashboard-community-activity__activity-details")
   end
+
+  it "adds multiple activities to the dashboard when selected" do
+    activities = programme.programme_activity_groupings.community.first.activities
+    visit primary_certificate_path
+
+    select activities.first.title, from: "activity"
+    click_on "Choose activity"
+
+    sleep 1
+
+    select activities.second.title, from: "activity"
+    click_on "Choose activity"
+
+    sleep 1
+
+    select activities.third.title, from: "activity"
+    click_on "Choose activity"
+
+    expect(page).to have_css(".primary-dashboard-community-activity__activity-details", count: 3)
+    expect(page).to have_text(activities.first.title)
+    expect(page).to have_text(activities.second.title)
+    expect(page).to have_text(activities.third.title)
+    expect(page).to have_text(activities.first.public_copy_description)
+    expect(page).to have_text(activities.second.public_copy_description)
+    expect(page).to have_text(activities.third.public_copy_description)
+  end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2920

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?
- Added system testing for primary dashboard functionality when removing and adding activities