### PR TITLE
Fixing description nil error on legacy activites

### DIFF
--- a/app/components/primary_dashboard_community_activity_component/primary_dashboard_community_activity_component.html.erb
+++ b/app/components/primary_dashboard_community_activity_component/primary_dashboard_community_activity_component.html.erb
@@ -20,7 +20,7 @@
               <p class="govuk-body-m govuk-!-margin-bottom-0"><%= strip_tags(upa.activity.title) %></p>
             </div>
           </div>
-          <p class="govuk-body-s primary-dashboard-community-activity__activity-details-description"><%= upa.activity.public_copy_description.html_safe %></p>
+          <p class="govuk-body-s primary-dashboard-community-activity__activity-details-description"><%= upa.activity.public_description %></p>
         </div>
       <% end %>
     </div>
@@ -51,7 +51,7 @@
                   } %>
             </div>
           </div>
-          <p class="govuk-body-s"><%= upa.activity.public_copy_description.html_safe %></p>
+          <p class="govuk-body-s"><%= upa.activity.public_description %></p>
           <%= render CommunityEvidenceSubmissionModalComponent.new(activity: upa.activity, achievement: upa) %>
         </div>
       <% end %>

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -73,4 +73,9 @@ class Activity < ApplicationRecord
   def evidence_not_required?
     self_verification_info.blank? && public_copy_evidence.blank?
   end
+
+  def public_description
+    return public_copy_description.html_safe unless public_copy_description.nil?
+    description&.html_safe
+  end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Activity, type: :model do
   let(:user_achievement) { create(:achievement, user_id: user.id, activity_id: online_activity.id) }
   let(:diagnostic_tool_activity) { create(:activity, :cs_accelerator_diagnostic_tool) }
   let(:removable_activity) { create(:activity, :user_removable) }
+  let(:activity_with_public_copy_description) { create(:activity, public_copy_description: "I am some public copy description <span>I have html</span>") }
+  let(:activity_without_public_copy_description) { create(:activity, public_copy_description: nil, description: "I am regular description <span>I have html</span>") }
 
   describe "associations" do
     it "has_one assessment" do
@@ -229,6 +231,16 @@ RSpec.describe Activity, type: :model do
     it "returns false when the course stem acitivity code not present" do
       activity = build(:activity, stem_activity_code: nil)
       expect(activity.active_course?).to eq(false)
+    end
+  end
+
+  describe "#public_description" do
+    it "should return html safe copy of public_copy_description when present" do
+      expect(activity_with_public_copy_description.public_description).to eq("I am some public copy description <span>I have html</span>")
+    end
+
+    it "should return html safe copy of description when publoc_copy_description is nil" do
+      expect(activity_without_public_copy_description.public_description).to eq("I am regular description <span>I have html</span>")
     end
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2942

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Creating new safe method for activities to check for public copy first, then falling back to description is not included, and also allowing for nil values (to deal with legacy objects)

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
