### PR TITLE
Removing computing clusters page

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -26,7 +26,6 @@ module NavigationHelper
          {text: "Computing Hubs", link: hubs_path, label: "Computing hubs"},
          {text: "I Belong programme", link: about_i_belong_path, label: "i-belong"},
          {text: "GCSE Computer Science support", link: cms_page_path("gcse-cs-support"), label: "GCSE support"},
-         {text: "Computing Clusters", link: cms_page_path("computing-clusters"), label: "Computing clusters"},
          {text: "School Trusts", link: cms_page_path("school-trusts"), label: "School trusts"}
        ]},
       {text: "Teaching resources",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,10 @@ Rails.application.routes.draw do
   Healthcheck.routes(self)
   root to: "pages#home", action: :home
 
+  # April 2025 Route Redirect
+
+  get "/computing-clusters", to: redirect("/")
+
   resources :achievements, only: %i[create destroy update] do
     collection do
       post :submit

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -22,7 +22,6 @@ SitemapGenerator::Sitemap.create do
   add "/careers-week", changefreq: "monthly"
   add "/careers-support", changefreq: "monthly"
   add "/certification", changefreq: "monthly"
-  add "/computing-clusters", changefreq: "monthly"
   add "/contact", changefreq: "monthly"
   add "/courses", changefreq: "daily"
   add "/curriculum", changefreq: "weekly"


### PR DESCRIPTION
## Status

* Current Status: Ready for front-end review
* Review App link(s): https://teachcomputing-pr-2283.herokuapp.com/
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2950

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Removing page from header and sitemap, and then adding in redirect

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
