### PR TITLE
Changing enrolment button to go to certificate page

### DIFF
--- a/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
+++ b/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
@@ -1,6 +1,6 @@
 <% if current_user %>
   <% if @programme.user_enrolled?(current_user) %>
-    <%= link_to "Visit dashboard", dashboard_path, class: button_classes, role: "button" %>
+    <%= link_to "Visit dashboard", @programme.path, class: button_classes, role: "button" %>
   <% elsif @programme.enrolment_confirmation_required? %>
     <div class="enrolment-confirmation-component">
       <%= render ModalComponent.new(

--- a/spec/components/enrolment_confirmation_component_spec.rb
+++ b/spec/components/enrolment_confirmation_component_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
     end
 
     it "renders the view dashboard button" do
-      expect(page).to have_link("Visit dashboard", href: "/dashboard")
+      expect(page).to have_link("Visit dashboard", href: "/certificate/subject-knowledge")
     end
   end
 
@@ -124,7 +124,7 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
     end
 
     it "renders the view dashboard button" do
-      expect(page).to have_link("Visit dashboard", href: "/dashboard")
+      expect(page).to have_link("Visit dashboard", href: "/certificate/primary-certificate")
     end
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Review App link(s): https://teachcomputing-pr-2284.herokuapp.com/
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2948

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Changing enrolment confirmation to go to certificate path rather than the dashboard

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
