### PR TITLE
Replace enrol buttons with view component across the site

### DIFF
--- a/app/components/enrolment_confirmation_component.rb
+++ b/app/components/enrolment_confirmation_component.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 class EnrolmentConfirmationComponent < ViewComponent::Base
-  attr_reader :button_text
+  attr_reader :button_text, :logged_out_button_text
 
   delegate :auth_url, :current_user, to: :helpers
 
-  def initialize(programme:, full_width: true, button_text: "Enrol", pathway: nil)
+  def initialize(programme:, full_width: true, button_text: "Enrol", logged_out_button_text: "Log in", pathway: nil)
     @programme = programme
     @full_width = full_width
     @button_text = button_text
+    @logged_out_button_text = logged_out_button_text
     @pathway = pathway
   end
 

--- a/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
+++ b/app/components/enrolment_confirmation_component/enrolment_confirmation_component.html.erb
@@ -26,5 +26,5 @@
     <%= link_to button_text, @programme.enrol_path(user_programme_enrolment: { user_id: current_user.id, programme_id: @programme.id, pathway_slug: @pathway&.slug }), method: :post, class: button_classes, role: "button" %>
   <% end %>
 <% else %>
-  <%= link_to "Log in", auth_url, method: :post, class: button_classes, role: "button" %>
+  <%= link_to logged_out_button_text, auth_url, method: :post, class: button_classes, role: "button" %>
 <% end %>

--- a/app/views/pages/enrolment/a_level_certificate.html.erb
+++ b/app/views/pages/enrolment/a_level_certificate.html.erb
@@ -25,26 +25,12 @@
         <p class="govuk-body">This certificate is for anyone planning to teach A level Computer Science or currently doing so. It is particularly valuable to teachers without qualifications in the subject who wish to demonstrate the capability to teach at this level.</p>
         <h1 class="govuk-heading-m">How do I get started?</h1>
         <p class="govuk-body">If you are confident in your A level subject knowledge, once you've enrolled you can complete the test to achieve your certificate. If you are less experienced, we recommend you access CPD to strengthen your knowledge in preparation for the test.</p>
-        <% if current_user %>
-          <% if @programme.user_enrolled?(current_user) %>
-            <%= link_to 'Visit dashboard',
-              a_level_path,
-              class: 'button govuk-button govuk-!-margin-bottom-4'
-            %>
-          <% else %>
-            <%= link_to 'Enrol to gain access to the test',
-              @programme.enrol_path(user_programme_enrolment: { user_id: current_user.id, programme_id: @programme.id }),
-              method: :post,
-              class: 'button govuk-button govuk-!-margin-bottom-4'
-            %>
-          <% end %>
-        <% else %>
-          <%= link_to 'Log in to enrol',
-            auth_url,
-            method: :post,
-            class: 'button govuk-button govuk-!-margin-bottom-4'
-          %>
-        <% end %>
+        <%= render EnrolmentConfirmationComponent.new(
+              programme: Programme.a_level,
+              button_text: "Enrol to gain access to the test",
+              logged_out_button_text: "Log in to enrol",
+              full_width: false
+            ) %>
         <h1 class="govuk-heading-m">Benefits for you</h1>
         <ul class="govuk-list govuk-list--bullet">
           <li>receive a nationally recognised qualification</li>

--- a/app/views/pages/enrolment/a_level_certificate.html.erb
+++ b/app/views/pages/enrolment/a_level_certificate.html.erb
@@ -1,3 +1,5 @@
+<% meta_tag :title, 'A level Computer Science subject knowledge - Teach Computing' %>
+
 <div class="hero">
   <div class="govuk-width-container">
     <div class="govuk-main-wrapper hero__wrapper">

--- a/app/views/pages/enrolment/i_belong.html.erb
+++ b/app/views/pages/enrolment/i_belong.html.erb
@@ -57,7 +57,11 @@
           <div class="lp-support__card white-bg lp-support__card--bordered">
             <h2 class="govuk-heading-m"><%= t(".#{session_state}.where_to_start_card.heading")%></h2>
             <ol class="govuk-list govuk-list--number"><%= t(".#{session_state}.where_to_start_card.body_html")%></ol>
-            <%= link_to t(".#{session_state}.where_to_start_card.link_text"), cta_link_path, method: cta_link_method, class: 'button govuk-button govuk-!-margin-bottom-0' %>
+            <%= render EnrolmentConfirmationComponent.new(
+              programme: Programme.i_belong,
+              button_text: "Enrol on the programme",
+              logged_out_button_text: "Log in to enrol"
+            ) %>
           </div>
         </div>
       </div>

--- a/app/views/pages/enrolment/i_belong.html.erb
+++ b/app/views/pages/enrolment/i_belong.html.erb
@@ -1,3 +1,5 @@
+<% meta_tag :title, 'I Belong: encouraging girls into computer science - Teach Computing' %>
+
 <div class="hero hero hero--orange-bg">
   <div class="govuk-width-container">
     <div class="govuk-main-wrapper hero__wrapper">

--- a/app/views/pages/enrolment/subject_knowledge.html.erb
+++ b/app/views/pages/enrolment/subject_knowledge.html.erb
@@ -30,15 +30,10 @@
               <li>Participate in a mix of courses to suit your experience</li>
               <li>Pass a short test to receive your certificate</li>
             </ol>
-            <% if current_user %>
-            <p class="govuk-body">
-              <%= link_to 'Enrol on this certificate', enrol_cs_accelerator_certificate_path(user_programme_enrolment: { user_id: current_user.id, programme_id: Programme.cs_accelerator.id }), method: :post, class: 'govuk-button button--aside', role: 'button', draggable: 'false' %>
-            </p>
-            <% else %>
-            <p class="govuk-body">
-              <%= link_to 'Log in', auth_url, method: :post, class: 'govuk-button button--aside', role: 'button', draggable: 'false' %>
-            </p>
-            <% end %>
+            <%= render EnrolmentConfirmationComponent.new(
+              programme: Programme.cs_accelerator,
+              button_text: "Enrol on this certificate"
+            ) %>
           <% end %>
         <% end %>
         <%= render AsideComponent.new(

--- a/app/views/pages/enrolment/subject_knowledge.html.erb
+++ b/app/views/pages/enrolment/subject_knowledge.html.erb
@@ -1,4 +1,4 @@
-<% meta_tag :title, 'KS3 and GCSE - Teach Computing' %>
+<% meta_tag :title, 'Key stage 3 and GCSE Computer Science certificate - Teach Computing' %>
 <%= render 'pages/certification/hero_with_certificate_logo' %>
 <div class="govuk-width-container">
   <div class="govuk-main-wrapper govuk-main-wrapper--xl">

--- a/config/locales/views/pages/enrolment/i_belong.en.yml
+++ b/config/locales/views/pages/enrolment/i_belong.en.yml
@@ -10,7 +10,6 @@ en:
               <li>Enrol on the programme</li>
               <li>Obtain your free handbook and posters</li>
               <li>Explore the CPD and activities</li>
-            link_text: Log in to enrol
         unenrolled:
           where_to_start_card:
             heading: Where to start?
@@ -19,7 +18,6 @@ en:
               <li>Obtain your free handbook and posters</li>
               <li>Complete our ‘Encouraging Girls into GCSE Computer Science’ short course</li>
               <li>Participate in a range of recommended activity</li>
-            link_text: Enrol on the programme
         enrolled:
           where_to_start_card:
             heading: Completing the programme
@@ -27,7 +25,6 @@ en:
               <li>Complete the I Belong short course for your key stage</li>
               <li>Participate in a range of recommended activity</li>
               <li>Claim your school certificate</li>
-            link_text: Visit dashboard
         resources:
           primary_handbook:
             title: "I Belong primary handbook"

--- a/spec/components/enrolment_confirmation_component_spec.rb
+++ b/spec/components/enrolment_confirmation_component_spec.rb
@@ -88,6 +88,20 @@ RSpec.describe EnrolmentConfirmationComponent, type: :component do
     end
   end
 
+  context "when no current user and logged out button text" do
+    before do
+      allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(nil)
+      render_inline(described_class.new(
+        programme: cs_accelerator,
+        logged_out_button_text: "Log in to enrol"
+      ))
+    end
+
+    it "renders a log in button" do
+      expect(page).to have_link("Log in to enrol", href: "/auth/stem")
+    end
+  end
+
   context "when the user is already enrolled on a non confirmation programme" do
     before do
       allow_any_instance_of(AuthenticationHelper).to receive(:current_user).and_return(user)

--- a/spec/views/pages/enrolment/a_level_certificate.html_spec.rb
+++ b/spec/views/pages/enrolment/a_level_certificate.html_spec.rb
@@ -27,16 +27,34 @@ RSpec.describe("pages/enrolment/a_level_certificate", type: :view) do
     expect(rendered).to have_css(".govuk-heading-m", text: "How do I get started?")
   end
 
-  it "has an enrol button" do
-    expect(rendered).to have_link("Enrol to gain access")
-  end
-
   it "has a isaac section" do
     expect(rendered).to have_css(".govuk-heading-m", text: "How we can help you and your students")
   end
 
   it "has an isaac CS section" do
     expect(rendered).to have_link("Discover Isaac Computer Science", href: "https://isaaccomputerscience.org/")
+  end
+
+  context "when user is not logged in" do
+    before do
+      allow(view).to receive(:current_user).and_return(nil)
+      render
+    end
+
+    it "has a log in to enrol button" do
+      expect(rendered).to have_link("Log in to enrol")
+    end
+  end
+
+  context "when user is logged in" do
+    before do
+      allow(view).to receive(:current_user).and_return(user)
+      render
+    end
+
+    it "has a enrol to gain access to the test button" do
+      expect(rendered).to have_link("Enrol to gain access to the test")
+    end
   end
 
   describe "hero section" do

--- a/spec/views/pages/enrolment/cs_accelerator.html_spec.rb
+++ b/spec/views/pages/enrolment/cs_accelerator.html_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe("pages/enrolment/subject_knowledge", type: :view) do
     end
 
     it "has Enrol button" do
-      expect(rendered).to have_css(".button--aside", text: "Enrol on this certificate")
+      expect(rendered).to have_link("Enrol on this certificate")
     end
   end
 
@@ -43,7 +43,7 @@ RSpec.describe("pages/enrolment/subject_knowledge", type: :view) do
     end
 
     it "has a button to log in" do
-      expect(rendered).to have_css(".button--aside", text: "Log in")
+      expect(rendered).to have_link("Log in", href: "/auth/stem")
     end
   end
 

--- a/spec/views/pages/enrolment/i_belong.html_spec.rb
+++ b/spec/views/pages/enrolment/i_belong.html_spec.rb
@@ -36,4 +36,8 @@ RSpec.describe("pages/enrolment/i_belong", type: :view) do
   it "has 7 resource cards" do
     expect(rendered).to have_css(".non-bordered-card", count: 7)
   end
+
+  it "has a log in to enrol button" do
+    expect(rendered).to have_link("Log in to enrol")
+  end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2893

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?
- Replaced hard coded buttons with EnrolmentConfirmationComponent on certificate pages
- Added logged_out_button_text to component
- Updated test suite to cover changes
