### PR TITLE
Silence excessive coverage warnings

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,7 @@ require "simplecov"
 
 SimpleCov.minimum_coverage ENV["SIMPLECOV_MIN_COVERAGE"].to_i
 SimpleCov.start "rails" do
+  require_relative 'support/simplecov_warnings_patch' # To remove excess warnings from line below
   enable_coverage_for_eval
 
   add_group "Services", "app/services"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,7 @@ require "simplecov"
 
 SimpleCov.minimum_coverage ENV["SIMPLECOV_MIN_COVERAGE"].to_i
 SimpleCov.start "rails" do
-  require_relative 'support/simplecov_warnings_patch' # To remove excess warnings from line below
+  require_relative "support/simplecov_warnings_patch" # To remove excess warnings from line below
   enable_coverage_for_eval
 
   add_group "Services", "app/services"

--- a/spec/support/simplecov_warnings_patch.rb
+++ b/spec/support/simplecov_warnings_patch.rb
@@ -6,9 +6,9 @@ module SimpleCov
     # it also shows up for views when we `enable_coverage_for_eval`
     # patching here so that we can turn this off via ENV VAR
     def coverage_exceeding_source_warn
-      return unless ENV['SHOW_EXCESS_LINE_WARNING']
+      return unless ENV["SHOW_EXCESS_LINE_WARNING"]
 
-      message = "Warning: coverage data provided by Coverage [#{coverage_data['lines'].size}] "
+      message = "Warning: coverage data provided by Coverage [#{coverage_data["lines"].size}] "
       message += "exceeds number of lines in #{filename} [#{src.size}]"
       warn message
     end

--- a/spec/support/simplecov_warnings_patch.rb
+++ b/spec/support/simplecov_warnings_patch.rb
@@ -1,0 +1,16 @@
+module SimpleCov
+  class SourceFile
+    # Suggested fix from https://github.com/simplecov-ruby/simplecov/issues/1057
+    #
+    # this is needed for SimpleCov Issue#56
+    # it also shows up for views when we `enable_coverage_for_eval`
+    # patching here so that we can turn this off via ENV VAR
+    def coverage_exceeding_source_warn
+      return unless ENV['SHOW_EXCESS_LINE_WARNING']
+
+      message = "Warning: coverage data provided by Coverage [#{coverage_data['lines'].size}] "
+      message += "exceeds number of lines in #{filename} [#{src.size}]"
+      warn message
+    end
+  end
+end


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2973

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Applying monkey patch to silence line warnings from enabling erb test coverage

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
