### PR TITLE
Make legacy activities count towards certificate completion

### DIFF
--- a/app/components/community_activity_list_component.rb
+++ b/app/components/community_activity_list_component.rb
@@ -6,12 +6,15 @@ class CommunityActivityListComponent < ViewComponent::Base
     @class_name = class_name
     @button_class = button_class
 
-    activities_with_achievements = programme_activity_grouping.programme_activities.not_legacy.map do |programme_activity|
+    activities_with_achievements = programme_activity_grouping.programme_activities.map do |programme_activity|
       {
         programme_activity:,
         achievement: community_achievements&.find { _1.activity_id == programme_activity.activity_id }
       }
     end
+
+    # Remove legacy only if they have an achievement
+    activities_with_achievements.delete_if { _1[:achievement].nil? && _1[:programme_activity].legacy }
 
     complete, non_complete = activities_with_achievements.partition { _1[:achievement]&.in_state? :complete }
 

--- a/app/components/community_activity_list_component.rb
+++ b/app/components/community_activity_list_component.rb
@@ -13,7 +13,7 @@ class CommunityActivityListComponent < ViewComponent::Base
       }
     end
 
-    # Remove legacy only if they have an achievement
+    # Remove legacy if they do not have an achievement
     activities_with_achievements.delete_if { _1[:achievement].nil? && _1[:programme_activity].legacy }
 
     complete, non_complete = activities_with_achievements.partition { _1[:achievement]&.in_state? :complete }

--- a/app/models/programme_activity_grouping.rb
+++ b/app/models/programme_activity_grouping.rb
@@ -55,7 +55,6 @@ class ProgrammeActivityGrouping < ApplicationRecord
       .belonging_to_programme(programme)
       .joins(activity: :programme_activities)
       .where(
-        activities: {programme_activities: {legacy: false}},
         user: users
       )
       .group_by(&:user_id)

--- a/spec/components/community_activity_list_component_spec.rb
+++ b/spec/components/community_activity_list_component_spec.rb
@@ -47,4 +47,26 @@ RSpec.describe CommunityActivityListComponent, type: :component do
       expect(page).to have_css(".community-activity-list--show-hide")
     end
   end
+
+  context "with legacy activity" do
+    let(:activity) { create(:activity, title: "Legacy activity") }
+    let(:programme_activities) {
+      create_list(:programme_activity, 2, programme_activity_grouping:)
+      create(:programme_activity, programme_activity_grouping:, activity:, legacy: true)
+    }
+
+    context "without achievement" do
+      it "should not show legacy activity" do
+        expect(page).not_to have_text("Legacy activity")
+      end
+    end
+
+    context "with achievement" do
+      let(:community_achievements) { [create(:completed_achievement, activity: activity)] }
+
+      it "should show legacy activity" do
+        expect(page).to have_text("Legacy activity")
+      end
+    end
+  end
 end

--- a/spec/models/programme_activity_grouping_spec.rb
+++ b/spec/models/programme_activity_grouping_spec.rb
@@ -80,6 +80,12 @@ RSpec.describe ProgrammeActivityGrouping, type: :model do
     end
   end
 
+  describe "#objective_displayed_in_body?" do
+    it "should default to true" do
+      expect(programme_activity_grouping.objective_displayed_in_body?).to be true
+    end
+  end
+
   describe "#users_completed" do
     let!(:programme) { create(:programme) }
     let!(:programme_activity_grouping) { create(:programme_activity_grouping, required_for_completion: 3, programme:) }

--- a/spec/models/programme_activity_grouping_spec.rb
+++ b/spec/models/programme_activity_grouping_spec.rb
@@ -55,9 +55,9 @@ RSpec.describe ProgrammeActivityGrouping, type: :model do
         programme_activity.update(legacy: true)
       end
 
-      it "returns false" do
+      it "returns true" do
         grouping = programme_activity_groupings.first
-        expect(grouping.user_complete?(user)).to be false
+        expect(grouping.user_complete?(user)).to be true
       end
     end
   end


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Review App link(s): https://teachcomputing-pr-2329.herokuapp.com/
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2987

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Removed the logic that discounted legacy activities from programme activity grouping
- Updated community activity list to show legacy achievements, but not the activity unless the user has started on it

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
