### PR TITLE
CMS Slug sanitise

### DIFF
--- a/app/controllers/concerns/cms_processing.rb
+++ b/app/controllers/concerns/cms_processing.rb
@@ -16,6 +16,8 @@ module CmsProcessing
     preview = preview_params[:preview] || false
     preview_key = preview_params[:preview_key] || nil
 
+    validate_slug!(resource_id)
+
     # Temp fix to handle / routes should not be need if we move to graphql
     raise ActiveRecord::RecordNotFound if resource_id.include? "_"  # Prevent routing to underscored versions
     resource_id.tr!("/", "_") # Convert / to _ so it can be handled strapi side
@@ -32,5 +34,9 @@ module CmsProcessing
 
   def preview_params
     params.permit(:preview, :preview_key)
+  end
+
+  def validate_slug!(slug)
+    raise ActiveRecord::RecordNotFound unless /^[a-zA-z0-9\-_\/]+$/.match(slug)
   end
 end

--- a/spec/requests/cms/cms_blog_spec.rb
+++ b/spec/requests/cms/cms_blog_spec.rb
@@ -22,6 +22,26 @@ RSpec.describe CmsController do
       end
     end
 
+    context "invalid slug" do
+      it "should raise error" do
+        expect{
+          get("/blog/not(avalid)page")
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "should raise error for sql attempt" do
+        expect{
+          get("/blog/#{CGI.escape("select from users where 1=1;")}")
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "should raise error for graphql attempt" do
+        expect{
+          get("/blog/#{CGI.escape("users { email }")}")
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
     context "with a missing page" do
       before do
         stub_strapi_not_found("blogs/eggs")

--- a/spec/requests/cms/cms_web_page_spec.rb
+++ b/spec/requests/cms/cms_web_page_spec.rb
@@ -1,39 +1,62 @@
 require "rails_helper"
 
 RSpec.describe CmsController do
-  describe "GET #cms_page" do
-    describe "GET #web_page_resource" do
+  describe "GET #web_page_resource" do
+    context "valid slug" do
+
       before do
         stub_strapi_web_page("primary-early-careers")
         get "/primary-early-careers"
       end
+
       it "assigns @resource" do
         expect(assigns(:resource)).to be_a(Object)
       end
+
       it "renders the template" do
         expect(response).to render_template("resource")
       end
     end
 
-    describe "GET #cms_page/refresh" do
-      before do
-        stub_strapi_web_page("primary-early-careers")
+    context "invalid slug" do
+      it "should raise error" do
+        expect{
+          get("/not(avalid)page")
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
-      it "redirects to original page" do
-        get "/primary-early-careers/refresh"
-        expect(response).to redirect_to("/primary-early-careers")
+      it "should raise error for sql attempt" do
+        expect{
+          get("/#{CGI.escape("select from users where 1=1;")}")
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
-      it "reloads aside cache" do
-        expect(Cms::Collections::AsideSection).to receive(:clear_cache)
-        get "/primary-early-careers/refresh"
+      it "should raise error for graphql attempt" do
+        expect{
+          get("/#{CGI.escape("users { email }")}")
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
+    end
+  end
 
-      it "reloads page cache" do
-        expect(Cms::Collections::WebPage).to receive(:clear_cache).with("primary-early-careers")
-        get "/primary-early-careers/refresh"
-      end
+  describe "GET #web_page_resource/refresh" do
+    before do
+      stub_strapi_web_page("primary-early-careers")
+    end
+
+    it "redirects to original page" do
+      get "/primary-early-careers/refresh"
+      expect(response).to redirect_to("/primary-early-careers")
+    end
+
+    it "reloads aside cache" do
+      expect(Cms::Collections::AsideSection).to receive(:clear_cache)
+      get "/primary-early-careers/refresh"
+    end
+
+    it "reloads page cache" do
+      expect(Cms::Collections::WebPage).to receive(:clear_cache).with("primary-early-careers")
+      get "/primary-early-careers/refresh"
     end
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Review App link(s): *populate this with links to the relevant parts of the review app*
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/3003

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Limit cms slugs to specific characters to stop malicious attempts being passed to Strapi

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
