### PR TITLE
Removing type, date and location filter from searches

### DIFF
--- a/app/views/courses/_aside-filters.html.erb
+++ b/app/views/courses/_aside-filters.html.erb
@@ -2,20 +2,6 @@
 <div class="ncce-courses__filters-wrapper-title--desktop">
   <h2 class="govuk-heading-s">Filter courses</h2>
 </div>
-<div class="ncce-aside ncce-aside--filters govuk-!-margin-top-2">
-  <div class="ncce-courses__filters-wrapper-title--mobile govuk-!-margin-top-1">
-    <h2 class="govuk-heading-s">Filter courses</h2>
-  </div>
-  <%= label_tag :date_range, 'Have a specific date?', class: 'govuk-body-m ncce-label--s' %>
-  <%= render DatepickerComponent.new(
-      "date_range",
-      nil,
-      flatpickr: { mode: "range" },
-      options: { data: { action: "changeRange->course-filter#filter changeRange->course-filter#addRangeFilter changeRange->course-filter#dateRangeSearched"} },
-      input_options: { placeholder: "Select a date or date range" }
-    )
-  %>
-</div>
 
 <div class="ncce-aside ncce-aside--filters govuk-!-margin-top-2" data-action="resize@window->course-filter#openFilterFormOnDesktop" data-course-filter-target="filterFormHeader">
   <div class="ncce-aside--filters-header">

--- a/app/views/courses/_aside-filters.html.erb
+++ b/app/views/courses/_aside-filters.html.erb
@@ -60,17 +60,6 @@
       <%= hidden_field_tag :certificate, @certificate_filter %>
     <% end %>
 
-    <%= label_tag :format, 'Course format:', class: 'govuk-body-s ncce-label--s' %>
-    <div class="govuk-checkboxes govuk-!-margin-bottom-2">
-      <% @course_filter.course_formats.each_with_index do |course_format, index| %>
-        <div class='govuk-checkboxes__item ncce-checkboxes__item'>
-          <%= check_box_tag 'course_format[]', course_format[:value], @course_filter&.current_format&.include?(course_format[:value]), class: 'govuk-checkboxes__input ncce-checkboxes__input',
-            data: { action: 'change->course-filter#processValueChanges change->course-filter#filter change->course-filter#toggleActiveCheckbox', 'aria-label': 'Filter by format' }, id: "course_format_#{index}" %>
-          <%= label_tag "course_format_#{index}", course_format[:label], class: 'govuk-label govuk-checkboxes__label ncce-label ncce-checkboxes__label' %>
-        </div>
-      <% end %>
-    </div>
-
     <%= label_tag :format, 'Course Length:', class: 'govuk-body-s ncce-label--s' %>
     <div class="govuk-checkboxes govuk-!-margin-bottom-2">
       <% @course_filter.course_lengths.each_with_index do |course_length, index| %>
@@ -82,38 +71,6 @@
       <% end %>
     </div>
 
-    <div class="hidden ncce-aside--filters-geo-wrapper" data-course-filter-target="faceToFaceFilter">
-      <div class="ncce-aside--filters-geo">
-        <%= label_tag :format, 'Find face to face courses near you:', class: 'govuk-body-s ncce-label--s' %>
-        <%= text_field_tag :location, @course_filter.current_location, class: 'govuk-input ncce-search-input ncce-aside--filters-location', placeholder: 'Town, city or postcode',
-          data: { course_filter_target: 'locationSearch' } %>
-        <%= submit_tag 'Search location',
-          class: 'govuk-button button govuk-!-margin-bottom-1',
-          data: {
-            action: "click->course-filter#filter click->course-filter#addLocationFilter click->course-filter#locationSearched",
-            event_action: 'click',
-            event_category: 'Courses',
-            event_label: 'Search location'
-          } %>
-      </div>
-      <div class="hidden govuk-body ncce-aside--filters-radius" data-course-filter-target="distanceFilter">
-        <span>Within a</span>
-        <%= select_tag :radius,
-          options_for_select(@course_filter.search_radii.map { |r| ["#{r} mile", r]}, @course_filter.current_radius),
-          {
-            class: ['govuk-select', 'ncce-select', 'ncce-select--filters', 'ncce-aside--filters-narrow-select', { 'filter--active' => @course_filter.current_radius }],
-            'aria-label': 'Filter by distance',
-            data: { action: "input->course-filter#filter", course_filter_target: "radiusSelect"}
-          }
-        %>
-      <span>radius of </span><span data-course-filter-target="geocodedLocation">search location</span>
-      </div>
-      <div class="hidden ncce-aside--filters-geo-error" data-course-filter-target="geocodingError">
-        <p class="govuk-body-s">
-          The location was not recognised. Please check it is correct.
-        </p>
-      </div>
-    </div>
     <button type="button" class="govuk-button button ncce-courses__view-results" data-action="click->course-filter#closeFilterForm" data-course-filter-target="viewResultsCount">View <%= pluralize(@course_filter.total_results_count, 'result') %></button>
     <%= hidden_field_tag 'js_enabled', false %>
 

--- a/spec/system/courses/index_spec.rb
+++ b/spec/system/courses/index_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe("Courses page", type: :system) do
     stub_subjects
     stub_age_groups
     stub_course_templates
+    stub_duration_units
   end
 
   context "when using a desktop", js: true do
@@ -36,11 +37,11 @@ RSpec.describe("Courses page", type: :system) do
 
     describe "with a checkbox filter" do
       before do
-        check("course_format_0", visible: false)
+        check("course_length_0", visible: false)
       end
 
       it "shows the expected number of results" do
-        expect(page).to have_css(".ncce-courses__count", text: "Showing 30 results")
+        expect(page).to have_css(".ncce-courses__count", text: "Showing 3 results")
       end
     end
 
@@ -86,11 +87,11 @@ RSpec.describe("Courses page", type: :system) do
     describe "with filters applied" do
       before do
         click_button(class: "ncce-courses__filter-form-toggle")
-        check("course_format_1", visible: false)
+        check("course_length_1", visible: false)
       end
 
       it "shows the expected number of results" do
-        expect(page).to have_css(".ncce-courses__count", text: "Showing 25 results")
+        expect(page).to have_css(".ncce-courses__count", text: "Showing 22 results")
       end
 
       it "shows the expected number of filters" do
@@ -98,7 +99,7 @@ RSpec.describe("Courses page", type: :system) do
       end
 
       it "increases the filter count when another filter is clicked" do
-        check("course_format_2", visible: false)
+        check("course_length_2", visible: false)
         expect(page).to have_css(".ncce-courses__filter-form-toggle-applied", text: "2 filters applied")
       end
 

--- a/spec/views/courses/_aside-filters.html_spec.rb
+++ b/spec/views/courses/_aside-filters.html_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe("courses/_aside-filters", type: :view) do
       end
 
       it "renders the checkboxes" do
-        expect(rendered).to have_css(".ncce-checkboxes__input", count: 7)
+        expect(rendered).to have_css(".ncce-checkboxes__input", count: 4)
 
         expect(rendered).to have_css(".ncce-checkboxes__label", text: "0 - 3 Hours")
         expect(rendered).to have_css(".ncce-checkboxes__label", text: "3 - 6 Hours")

--- a/spec/views/courses/_aside-filters.html_spec.rb
+++ b/spec/views/courses/_aside-filters.html_spec.rb
@@ -75,10 +75,6 @@ RSpec.describe("courses/_aside-filters", type: :view) do
       it "renders the checkboxes" do
         expect(rendered).to have_css(".ncce-checkboxes__input", count: 7)
 
-        expect(rendered).to have_css(".ncce-checkboxes__label", text: "Face to face")
-        expect(rendered).to have_css(".ncce-checkboxes__label", text: "Online")
-        expect(rendered).to have_css(".ncce-checkboxes__label", text: "Remote")
-
         expect(rendered).to have_css(".ncce-checkboxes__label", text: "0 - 3 Hours")
         expect(rendered).to have_css(".ncce-checkboxes__label", text: "3 - 6 Hours")
         expect(rendered).to have_css(".ncce-checkboxes__label", text: "1 Day")


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Review App link(s): https://teachcomputing-pr-2345.herokuapp.com/
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2982

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Removed Type, Date and Location filters from the front end of the search system
- We have not removed the logic, this is because their might be a need to add these filters back in in the future, and we can leave the backend logic without issue.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
