### PR TITLE
Changing CSA exam logic

### DIFF
--- a/app/controllers/certificates/i_belong_controller.rb
+++ b/app/controllers/certificates/i_belong_controller.rb
@@ -15,7 +15,7 @@ module Certificates
       set_cpd_courses
       @cpd_group = @professional_development_groups.first
       @cpd_completed = @professional_development_groups.first.user_complete?(current_user)
-      @community_groups = @programme.programme_activity_groupings.community.order(:sort_key).includes(programme_activities: :activity)
+      @community_groups = @programme.programme_activity_groupings.community.order(:sort_key).includes(:programme_activities)
 
       @completed_comm_groups, @incomplete_comm_groups = @community_groups.partition { _1.user_complete?(current_user) }
 
@@ -51,7 +51,10 @@ module Certificates
     end
 
     def user_achievements(category)
-      current_user.achievements.belonging_to_programme(@programme).with_category(category)
+      current_user.achievements
+        .includes(:activity)
+        .belonging_to_programme(@programme)
+        .with_category(category)
         .without_category(:action)
         .not_in_state(:dropped)
         .sort_complete_first

--- a/app/controllers/certificates/secondary_certificate_controller.rb
+++ b/app/controllers/certificates/secondary_certificate_controller.rb
@@ -58,6 +58,7 @@ module Certificates
 
     def user_achievements(category)
       current_user.achievements.belonging_to_programme(@programme).with_category(category)
+        .includes(:activity)
         .without_category(:action)
         .not_in_state(:dropped)
         .sort_complete_first

--- a/app/models/pathway.rb
+++ b/app/models/pathway.rb
@@ -16,7 +16,7 @@ class Pathway < ApplicationRecord
   end
 
   def recommended_activities
-    pathway_activities
+    pathway_activities.includes(:activity)
   end
 
   def recommended_activities_for_user(user)

--- a/app/models/pathway.rb
+++ b/app/models/pathway.rb
@@ -16,7 +16,7 @@ class Pathway < ApplicationRecord
   end
 
   def recommended_activities
-    pathway_activities.includes(:activity)
+    pathway_activities.includes(activity: :replaced_by)
   end
 
   def recommended_activities_for_user(user)

--- a/app/models/pathway.rb
+++ b/app/models/pathway.rb
@@ -16,20 +16,11 @@ class Pathway < ApplicationRecord
   end
 
   def recommended_activities
-    pathway_activities.where(supplementary: false)
-  end
-
-  def supplementary_activities
-    pathway_activities.where(supplementary: true)
+    pathway_activities
   end
 
   def recommended_activities_for_user(user)
     user_activity_ids = user.achievements.map(&:activity_id)
     recommended_activities.where.not(activity_id: user_activity_ids)
-  end
-
-  def supplementary_activities_for_user(user)
-    user_activity_ids = user.achievements.map(&:activity_id)
-    supplementary_activities.where.not(activity_id: user_activity_ids)
   end
 end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -149,7 +149,7 @@ class Programme < ApplicationRecord
   end
 
   def programme_objectives
-    programme_activity_groupings.includes(:programme_activities).order(:sort_key)
+    programme_activity_groupings.order(:sort_key)
   end
 
   def programme_objectives_displayed_in_progress_bar

--- a/app/models/programmes/cs_accelerator.rb
+++ b/app/models/programmes/cs_accelerator.rb
@@ -19,7 +19,7 @@ module Programmes
         .belonging_to_programme(self)
         .in_state("complete")
 
-      # Allow legacy users with two face to face complete
+      # Allow legacy users with two face to face take test
       total_face_to_face = complete_achievements.with_category("face-to-face").sum(:credit)
       return true if total_face_to_face >= 20
 
@@ -38,10 +38,6 @@ module Programmes
 
     def notification_link
       cs_accelerator_certificate_path
-    end
-
-    def max_credits_for_certificate
-      100
     end
 
     def diagnostic

--- a/app/models/programmes/cs_accelerator.rb
+++ b/app/models/programmes/cs_accelerator.rb
@@ -65,7 +65,8 @@ module Programmes
     end
 
     def course_achievements(user)
-      user.achievements.belonging_to_programme(self)
+      user.achievements.includes(:activity)
+        .belonging_to_programme(self)
         .with_category([Activity::FACE_TO_FACE_CATEGORY,
           Activity::ONLINE_CATEGORY])
         .not_in_state(:dropped)

--- a/app/models/user_programme_assessment.rb
+++ b/app/models/user_programme_assessment.rb
@@ -2,9 +2,7 @@ class UserProgrammeAssessment
   include ProgrammesHelper
 
   def initialize(programme, user)
-    @enough_credits_for_test = false
-    @enough_credits_for_test = can_take_accelerator_test?(user, programme) if programme.assessment
-    @enough_activities_for_test = enough_activities_for_accelerator_test?(user, programme) if programme.assessment
+    @enough_credits_for_test = enough_credits_for_accelerator_test?(user, programme) if programme.assessment
     if @enough_credits_for_test && !programme.user_completed?(user)
       @attempts = programme.assessment.assessment_attempts.for_user(user)
       @failed_attempts = programme.assessment.assessment_attempts.for_user(user).in_state("failed")
@@ -13,10 +11,6 @@ class UserProgrammeAssessment
 
   def enough_credits_for_test?
     @enough_credits_for_test
-  end
-
-  def enough_activities_for_test?
-    @enough_activities_for_test
   end
 
   def total_num_attempts
@@ -49,11 +43,7 @@ class UserProgrammeAssessment
     failed_num_attempts < 2
   end
 
-  def can_take_accelerator_test?(user, programme)
-    programme.credits_achieved_for_certificate(user) >= programme.max_credits_for_certificate
-  end
-
-  def enough_activities_for_accelerator_test?(user, programme)
-    programme.enough_activities_for_test?(user)
+  def enough_credits_for_accelerator_test?(user, programme)
+    programme.enough_credits_for_test?(user)
   end
 end

--- a/app/view_objects/csa_dash.rb
+++ b/app/view_objects/csa_dash.rb
@@ -5,25 +5,11 @@ class CSADash
   end
 
   def user_programme_pathway
-    return @user_programme_pathway if defined? @user_programme_pathway
-
-    @user_programme_pathway = @user.programme_pathway(@programme)
+    @user_programme_pathway ||= @user.programme_pathway(@programme)
   end
 
-  def compulsory_achievement
-    return @compulsory_achievement if defined? @compulsory_achievement
-
-    @compulsory_achievement = @programme.compulsory_achievement(@user)
-  end
-
-  def non_compulsory_achievements
-    return @non_compulsory_achievements if defined? @non_compulsory_achievements
-
-    @non_compulsory_achievements = @programme.non_compulsory_achievements(@user)
-  end
-
-  def user_completed_non_compulsory_achievement?
-    @user_completed_non_compulsory_achievement ||= @programme.user_completed_non_compulsory_achievement?(@user)
+  def course_achievements
+    @course_achievements ||= @programme.course_achievements(@user)
   end
 
   def other_programme_pathways_for_user
@@ -31,19 +17,11 @@ class CSADash
   end
 
   def recommended_activities_for_user
-    return @recommended_activities_for_user if defined? @recommended_activities_for_user
-
-    @recommended_activities_for_user = user_programme_pathway&.recommended_activities_for_user(@user)
-  end
-
-  def supplementary_activities_for_user
-    return @supplementary_activities_for_user if defined? @supplementary_activities_for_user
-
-    @supplementary_activities_for_user = user_programme_pathway.supplementary_activities_for_user(@user)
+    @recommended_activities_for_user ||= user_programme_pathway&.recommended_activities_for_user(@user)
   end
 
   def has_enough_activities_for_test
-    @has_enough_activities_for_test ||= @programme.enough_activities_for_test?(@user)
+    @has_enough_activities_for_test ||= @programme.enough_credits_for_test?(@user)
   end
 
   def user_programme_assessment

--- a/app/views/certificates/a_level/_achievement_list.html.erb
+++ b/app/views/certificates/a_level/_achievement_list.html.erb
@@ -9,7 +9,6 @@
         <% @cpd_courses.each do |pa| %>
           <%= render CpdCourseComponent.new(current_user: @current_user, activity: pa.activity, last_margin: false) %>
         <% end %>
-        <p class="govuk-body govuk-!-margin-top-4"><%= t('.other_formats') %></p>
 
         <div class='ncce-activity-list__button-wrapper'>
           <%= link_to t('.all_courses_button'),

--- a/app/views/certificates/cs_accelerator/_achievements.html.erb
+++ b/app/views/certificates/cs_accelerator/_achievements.html.erb
@@ -1,7 +1,7 @@
 <div class="ncce-csa-dash__objective
   <%= 'ncce-csa-dash__objective--incomplete' unless test_available %>">
   <span class="ncce-csa-dash__objective-text">
-    Complete two online courses or a full residential course.
+    Complete two online courses or a full residential course
   </span>
 </div>
 

--- a/app/views/certificates/cs_accelerator/_achievements.html.erb
+++ b/app/views/certificates/cs_accelerator/_achievements.html.erb
@@ -1,46 +1,12 @@
 <div class="ncce-csa-dash__objective
-  <%= 'ncce-csa-dash__objective--incomplete' unless compulsory_achievement&.complete? %>">
+  <%= 'ncce-csa-dash__objective--incomplete' unless test_available %>">
   <span class="ncce-csa-dash__objective-text">
-    Complete a face to face or remote course
-  </span>
-</div>
-
-<% if compulsory_achievement %>
-  <div class="ncce-pathway-courses__short">
-    <div class="ncce-pathway-courses__course">
-      <p>
-        <% if compulsory_achievement.active_course? %>
-          <%= link_to compulsory_achievement.title,
-                      course_path(id: compulsory_achievement.stem_activity_code,
-                                  name: compulsory_achievement.slug),
-                      class: 'ncce-link' %>
-        <% else %>
-          <%= compulsory_achievement.title %>
-        <% end %>
-      </p>
-
-      <div class="ncce-flex__space-between">
-        <span class="govuk-body-s ncce-pathway-courses__course_type <%= activity_icon_class(compulsory_achievement.activity) %>">
-          <%= activity_type(compulsory_achievement.activity) %> course
-        </span>
-        <strong class="govuk-tag ncce-pathway-courses__status ncce-courses__tag">
-          <%= compulsory_achievement.complete? ? 'Completed' : 'In progress' %>
-        </strong>
-      </div>
-    </div>
-  </div>
-<% end %>
-
-<div class="ncce-csa-dash__objective
-  <%= 'ncce-csa-dash__objective--incomplete' unless user_completed_non_compulsory_achievement %>
-ncce-csa-dash__objective--borderless">
-  <span class="ncce-csa-dash__objective-text">
-  Complete any other KS3 and GCSE Computer Science subject knowledge course
+    Complete two online courses or a full residential course.
   </span>
 </div>
 
 <div class="ncce-pathway-courses__short">
-  <% non_compulsory_achievements.each do |achievement| %>
+  <% course_achievements.each do |achievement| %>
     <div class="ncce-pathway-courses__course">
       <p>
         <% if achievement.active_course? %>
@@ -49,7 +15,6 @@ ncce-csa-dash__objective--borderless">
           <%= achievement.title %>
         <% end %>
       </p>
-
 
       <div class="ncce-flex__space-between">
         <span class="govuk-body-s ncce-pathway-courses__course_type <%= activity_icon_class(achievement.activity) %>">

--- a/app/views/certificates/cs_accelerator/_achievements.html.erb
+++ b/app/views/certificates/cs_accelerator/_achievements.html.erb
@@ -7,6 +7,7 @@
 
 <div class="ncce-pathway-courses__short">
   <% course_achievements.each do |achievement| %>
+
     <div class="ncce-pathway-courses__course">
       <p>
         <% if achievement.active_course? %>

--- a/app/views/certificates/cs_accelerator/complete.html.erb
+++ b/app/views/certificates/cs_accelerator/complete.html.erb
@@ -53,12 +53,6 @@
                   )
                 } %>
               </div>
-              <div class="govuk-body ncce-activity-list ncce-csa-dash__section">
-                <%= render partial: 'certificates/pathways/supplementary_courses', locals: {
-                  pathway: @user_pathway,
-                  supplementary_activities: @user_pathway&.supplementary_activities
-                } %>
-              </div>
             <% else %>
               <%= link_to t('.all_courses_button'),
                 courses_path(certificate: @programme.slug), class: 'govuk-button button',

--- a/app/views/certificates/cs_accelerator/show.html.erb
+++ b/app/views/certificates/cs_accelerator/show.html.erb
@@ -5,72 +5,56 @@
 <% meta_tag :image_alt, 'Secondary Teachers - Teach Computing' %>
 <%= render 'pages/certification/hero', full_width: true %>
 
-<div class="light-grey-bg">
-  <div class="govuk-width-container">
-    <div class="govuk-main-wrapper govuk-main-wrapper--xl">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h2 class="govuk-heading-m">Welcome to the KS3 and GCSE Computer Science subject knowledge certificate!</h2>
-          <p class="govuk-body-m govuk-!-margin-bottom-7">
-            <% if @csa_dash.has_enough_activities_for_test %>
-              You've completed enough courses to access the test. You should continue to complete any courses you think are right for you. When you are ready, you can <%= link_to 'take our test or practice with our mock test', '#csa-test', class: 'ncce-link', data: tracking_data('View test and mock test') %>
-              </p>
-            <% else %>
-              To access our test and get your certificate, you'll need to complete two days of professional development, including at least one face-to-face or remote course. You can choose another face-to-face, remote or online course to make up the remaining hours of CPD required to unlock the assessment.
-            <% end %>
-          </p>
 
-          <%= render partial: 'certificates/cs_accelerator/pathway-prompt', locals: { user_programme_pathway: @csa_dash.user_programme_pathway } %>
+<%= render GovGridRowComponent.new(background_color: "light-grey") do |row| %>
+  <%= row.with_column(:"two-thirds") do %>
+    <h2 class="govuk-heading-m">Welcome to the KS3 and GCSE Computer Science subject knowledge certificate!</h2>
+    <p class="govuk-body-m govuk-!-margin-bottom-7">
+      <% if @csa_dash.has_enough_activities_for_test %>
+        You've completed enough courses to access the test. You should continue to complete any courses you think are right for you. When you are ready, you can <%= link_to 'take our test or practice with our mock test', '#csa-test', class: 'ncce-link', data: tracking_data('View test and mock test') %>
+      <% else %>
+        To access the test and get your certificate, you'll need to complete a minimum of two online courses or a full residential course at our centre in York. Upon meeting this requirement for professional development, the assessment will be unlocked for you in your dashboard.
+      <% end %>
+    </p>
 
-          <div class="govuk-body ncce-csa-dash__section-unpadded">
-            <%= render partial: 'certificates/cs_accelerator/achievements', locals: {
-              compulsory_achievement: @csa_dash.compulsory_achievement,
-              user_completed_non_compulsory_achievement: @csa_dash.user_completed_non_compulsory_achievement?,
-              non_compulsory_achievements: @csa_dash.non_compulsory_achievements
-            } %>
+    <%= render partial: 'certificates/cs_accelerator/pathway-prompt', locals: { user_programme_pathway: @csa_dash.user_programme_pathway } %>
 
-            <div class="ncce-csa-dash__section ncce-csa-dash__section-padded">
-              <%= render partial: 'certificates/pathways/recommended_courses', locals: {
-                event_category: 'CSA enrolled',
-                pathway: @csa_dash.user_programme_pathway,
-                recommended_activities: @csa_dash.recommended_activities_for_user
-              } %>
-            </div>
-          </div>
+    <div class="govuk-body ncce-csa-dash__section-unpadded">
+      <%= render partial: 'certificates/cs_accelerator/achievements', locals: {
+        course_achievements: @csa_dash.course_achievements,
+        test_available: @csa_dash.has_enough_activities_for_test
+      } %>
 
-          <% if @csa_dash.user_programme_pathway.present? %>
-            <div class="govuk-body ncce-activity-list ncce-csa-dash__section">
-              <%= render partial: 'certificates/pathways/supplementary_courses', locals: {
-                pathway: @csa_dash.user_programme_pathway ,
-                supplementary_activities: @csa_dash.supplementary_activities_for_user
-              } %>
-            </div>
-          <% end %>
-
-          <% if @csa_dash.has_enough_activities_for_test %>
-            <%= render partial: 'certificates/cs_accelerator/csa-test', locals: {
-                user_programme_assessment: @csa_dash.user_programme_assessment
-            } %>
-          <% end %>
-          <h3 class="govuk-heading-m"><%= t('.take_development_further') %></h3>
-          <p class="govuk-body"><%= t('.take_development_further_body') %></p>
-          <%= link_to t('.take_development_further_cta'), secondary_path, class: 'govuk-button button' %>
-        </div>
-        <div class="govuk-grid-column-one-third">
-          <div class='ncce-aside ncce-pathway-aside'>
-            <%= render partial: 'certificates/cs_accelerator/pathway-switcher', locals: {
-              other_programme_pathways_for_user: @csa_dash.other_programme_pathways_for_user,
-              user_pathway: @csa_dash.user_programme_pathway,
-              completed: @programme.user_completed?(current_user)
-            } %>
-          </div>
-          <%= render 'components/support-aside' %>
-          <div class="ncce-aside--borderless">
-            <%= render FeedbackComponent.new(heading: 'Help us improve our certificate experience', area: :cs_accelerator) %>
-          </div>
-        </div>
+      <div class="ncce-csa-dash__section ncce-csa-dash__section-padded">
+        <%= render partial: 'certificates/pathways/recommended_courses', locals: {
+          event_category: 'CSA enrolled',
+          pathway: @csa_dash.user_programme_pathway,
+          recommended_activities: @csa_dash.recommended_activities_for_user
+        } %>
       </div>
     </div>
-  </div>
 
-</div>
+    <% if @csa_dash.has_enough_activities_for_test %>
+      <%= render partial: 'certificates/cs_accelerator/csa-test', locals: {
+          user_programme_assessment: @csa_dash.user_programme_assessment
+      } %>
+    <% end %>
+    <h3 class="govuk-heading-m"><%= t('.take_development_further') %></h3>
+    <p class="govuk-body"><%= t('.take_development_further_body') %></p>
+    <%= link_to t('.take_development_further_cta'), secondary_path, class: 'govuk-button button' %>
+  <% end %>
+
+  <%= row.with_column(:"one-third") do %>
+    <div class='ncce-aside ncce-pathway-aside'>
+      <%= render partial: 'certificates/cs_accelerator/pathway-switcher', locals: {
+        other_programme_pathways_for_user: @csa_dash.other_programme_pathways_for_user,
+        user_pathway: @csa_dash.user_programme_pathway,
+        completed: @programme.user_completed?(current_user)
+      } %>
+    </div>
+    <%= render 'components/support-aside' %>
+    <div class="ncce-aside--borderless">
+      <%= render FeedbackComponent.new(heading: 'Help us improve our certificate experience', area: :cs_accelerator) %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/certificates/pathways/_recommended_courses.html.erb
+++ b/app/views/certificates/pathways/_recommended_courses.html.erb
@@ -18,7 +18,6 @@
         <% recommended_activities.each do |pa| %>
           <%= render CpdCourseComponent.new(current_user: @current_user, activity: pa.activity) %>
         <% end %>
-        <p class='govuk-body govuk-!-margin-top-4 govuk-!-margin-bottom-0'><%= t('.other_formats') %></p>
       </div>
     </div>
   <% end %>

--- a/app/views/components/_support-aside.html.erb
+++ b/app/views/components/_support-aside.html.erb
@@ -1,7 +1,6 @@
 <div class="ncce-aside landing-page__aside">
   <h2 class="govuk-heading-s ncce-aside__title">Support</h2>
-  <p class='govuk-body-s'>We are happy to support you along the way. Call 019 0432 8300 or email <%= mail_to 'info@teachcomputing.org', 'info@teachcomputing.org', class: 'ncce-link', data: { event_action: 'click', event_category: 'CSA enrolled', event_label: 'Email us' }  %>.</p>
-  <p class="govuk-body-s">Have a question about your activities on this page?  Check out our <%= link_to 'Frequently Asked Questions', '/faq/courses', class: 'ncce-link', data: { event_action: 'click', event_category: 'CSA enrolled', event_label: 'FAQs' } %></p>
+  <p class='govuk-body-s'>We are happy to support you along the way. Call 01904 328 300 or email <%= mail_to 'info@teachcomputing.org', 'info@teachcomputing.org', class: 'ncce-link', data: { event_action: 'click', event_category: 'CSA enrolled', event_label: 'Email us' }  %>.</p>
   <p class="govuk-body-s">Need to catch up on your learning?</p>
   <p class="govuk-body-s"><%= link_to 'Download our Handbook', gcse_and_ks3_handbook_url, class: 'ncce-link' %></p>
   <p class="govuk-body-s"><%= link_to 'Download our GCSE Specification Map', 'https://static.teachcomputing.org/GCSE_specifications_to_CSA_course_map.pdf', class: 'ncce-link' %></p>

--- a/config/locales/views/a_level/_achievement_list.en.yml
+++ b/config/locales/views/a_level/_achievement_list.en.yml
@@ -6,4 +6,3 @@ en:
           title: Need more support?
           courses: Join our A level CPD to improve your knowledge and pedagogy skills. All our CPD is available at no cost to teachers in state-funded schools and colleges.
         all_courses_button: View more courses
-        other_formats: Some courses are available in different formats

--- a/config/locales/views/certificates/pathways/_recommended_courses.en.yml
+++ b/config/locales/views/certificates/pathways/_recommended_courses.en.yml
@@ -5,4 +5,3 @@ en:
         courses_intro:
           html: "Courses based on your pathway"
         all_courses_button: "View more courses"
-        other_formats: "Some courses are available in different formats"

--- a/spec/models/pathway_spec.rb
+++ b/spec/models/pathway_spec.rb
@@ -73,18 +73,10 @@ RSpec.describe Pathway, type: :model do
   end
 
   describe "#recommended_activities" do
-    it "returns pathway_activities not set as supplementary" do
+    it "returns pathway_activities regardless of if set as supplementary" do
       recommended = create_list(:pathway_activity, 3, pathway: pathway, supplementary: false)
-      create_list(:pathway_activity, 3, pathway: pathway, supplementary: true)
+      recommended += create_list(:pathway_activity, 3, pathway: pathway, supplementary: true)
       expect(pathway.recommended_activities).to match_array(recommended)
-    end
-  end
-
-  describe "#supplementary_activities" do
-    it "returns pathway_activities set as supplementary" do
-      create_list(:pathway_activity, 3, pathway: pathway, supplementary: false)
-      supplementary = create_list(:pathway_activity, 3, pathway: pathway, supplementary: true)
-      expect(pathway.supplementary_activities).to match_array(supplementary)
     end
   end
 
@@ -96,17 +88,6 @@ RSpec.describe Pathway, type: :model do
       create(:pathway_activity, pathway: pathway, activity: activity, supplementary: false)
       recommended = create_list(:pathway_activity, 3, pathway: pathway, supplementary: false)
       expect(pathway.recommended_activities_for_user(user)).to match_array(recommended)
-    end
-  end
-
-  describe "#supplementary_activities_for_user" do
-    it "returns pathway_activities set as supplementary where user is not taking course" do
-      user = create(:user)
-      activity = create(:activity)
-      create(:achievement, user: user, activity: activity)
-      create(:pathway_activity, pathway: pathway, activity: activity, supplementary: true)
-      supplementary = create_list(:pathway_activity, 3, pathway: pathway, supplementary: true)
-      expect(pathway.supplementary_activities_for_user(user)).to match_array(supplementary)
     end
   end
 end

--- a/spec/models/programmes/cs_accelerator_spec.rb
+++ b/spec/models/programmes/cs_accelerator_spec.rb
@@ -108,64 +108,6 @@ RSpec.describe Programmes::CSAccelerator do
     end
   end
 
-  describe "#credits_achieved_for_certificate" do
-    context "when the user has not done any activities" do
-      it "returns 0" do
-        expect(programme.credits_achieved_for_certificate(user)).to eq(0)
-      end
-    end
-
-    context "when the user has done 1 online activity" do
-      before do
-        setup_one_online_achievement
-      end
-
-      it "returns 50%" do
-        expect(programme.credits_achieved_for_certificate(user)).to eq(50)
-      end
-    end
-
-    context "when the user has done 1 short f2f activity" do
-      before do
-        setup_one_short_f2f_achievement
-      end
-
-      it "returns 50%" do
-        expect(programme.credits_achieved_for_certificate(user)).to eq(50)
-      end
-    end
-
-    context "when the user has done 2 online activities" do
-      before do
-        setup_two_online_achievements
-      end
-
-      it "returns 50%" do
-        expect(programme.credits_achieved_for_certificate(user)).to eq(50)
-      end
-    end
-
-    context "when the user has done 2 short f2f activities" do
-      before do
-        setup_two_short_f2f_achievements
-      end
-
-      it "returns 100%" do
-        expect(programme.credits_achieved_for_certificate(user)).to eq(100)
-      end
-    end
-
-    context "when the user has done 1 f2f & 1 online activity" do
-      before do
-        setup_short_f2f_and_online_achievement
-      end
-
-      it "returns 100%" do
-        expect(programme.credits_achieved_for_certificate(user)).to eq(100)
-      end
-    end
-  end
-
   describe "#max_credits_for_certificate" do
     it "returns 100 for 10 hour system" do
       expect(programme.max_credits_for_certificate).to eq(100)
@@ -176,7 +118,7 @@ RSpec.describe Programmes::CSAccelerator do
     context "when a user is not enrolled" do
       before do
         setup_short_f2f_and_online_achievement
-        allow(programme).to receive(:enough_activities_for_test?).with(user).and_return(true)
+        allow(programme).to receive(:enough_credits_for_test?).with(user).and_return(true)
       end
 
       it "returns false" do
@@ -185,10 +127,10 @@ RSpec.describe Programmes::CSAccelerator do
       end
     end
 
-    context "when the user does not have enough_activities_for_test?" do
+    context "when the user does not have enough_credits_for_test?" do
       before do
         setup_short_f2f_and_online_achievement
-        allow(programme).to receive(:enough_activities_for_test?).with(user).and_return(false)
+        allow(programme).to receive(:enough_credits_for_test?).with(user).and_return(false)
       end
 
       it "returns false" do
@@ -199,7 +141,7 @@ RSpec.describe Programmes::CSAccelerator do
     context "when the user should be shown the notification" do
       before do
         setup_short_f2f_and_online_achievement
-        allow(programme).to receive(:enough_activities_for_test?).with(user).and_return(true)
+        allow(programme).to receive(:enough_credits_for_test?).with(user).and_return(true)
       end
 
       it "returns true" do
@@ -208,10 +150,10 @@ RSpec.describe Programmes::CSAccelerator do
     end
   end
 
-  describe "#enough_activities_for_test?" do
+  describe "#enough_credits_for_test?" do
     context "when the user has not done any activities" do
       it "returns false" do
-        expect(programme.enough_activities_for_test?(user)).to eq(false)
+        expect(programme.enough_credits_for_test?(user)).to eq(false)
       end
     end
 
@@ -221,7 +163,7 @@ RSpec.describe Programmes::CSAccelerator do
       end
 
       it "returns false" do
-        expect(programme.enough_activities_for_test?(user)).to eq(false)
+        expect(programme.enough_credits_for_test?(user)).to eq(false)
       end
     end
 
@@ -231,7 +173,7 @@ RSpec.describe Programmes::CSAccelerator do
       end
 
       it "returns false" do
-        expect(programme.enough_activities_for_test?(user)).to eq(false)
+        expect(programme.enough_credits_for_test?(user)).to eq(false)
       end
     end
 
@@ -241,7 +183,7 @@ RSpec.describe Programmes::CSAccelerator do
       end
 
       it "returns false" do
-        expect(programme.enough_activities_for_test?(user)).to eq(false)
+        expect(programme.enough_credits_for_test?(user)).to eq(true)
       end
     end
 
@@ -251,7 +193,7 @@ RSpec.describe Programmes::CSAccelerator do
       end
 
       it "returns true" do
-        expect(programme.enough_activities_for_test?(user)).to eq(true)
+        expect(programme.enough_credits_for_test?(user)).to eq(true)
       end
     end
 
@@ -261,7 +203,7 @@ RSpec.describe Programmes::CSAccelerator do
       end
 
       it "returns true" do
-        expect(programme.enough_activities_for_test?(user)).to eq(true)
+        expect(programme.enough_credits_for_test?(user)).to eq(true)
       end
     end
   end
@@ -285,72 +227,10 @@ RSpec.describe Programmes::CSAccelerator do
     end
   end
 
-  describe "#compulsory_achievement" do
-    context "when user has no f2f achievements" do
-      it "returns nil" do
-        expect(programme.compulsory_achievement(user)).to eq(nil)
-      end
-    end
-
-    context "when user has single f2f achievement" do
-      it "returns the achievement" do
-        achievement = create(:achievement, user: user)
-        create(:programme_activity, programme:, activity: achievement.activity)
-        expect(programme.compulsory_achievement(user)).to eq(achievement)
-      end
-
-      it "ignores dropped achievements" do
-        achievement = create(:achievement, user: user)
-        achievement.transition_to(:dropped)
-        create(:programme_activity, programme:, activity: achievement.activity)
-        expect(programme.compulsory_achievement(user)).to eq(nil)
-      end
-    end
-
-    context "when user has multiple f2f achievements" do
-      let!(:earliest_achievement) do
-        create(:achievement, user: user, created_at: Time.now - 7.days)
-      end
-
-      let!(:another_achievement) { create(:achievement, user: user) }
-      let!(:further_achievement) { create(:achievement, user: user) }
-
-      before do
-        [earliest_achievement, another_achievement, further_achievement].each do
-          create(:programme_activity, programme:, activity: _1.activity)
-        end
-      end
-
-      it "returns the first achievement if none are complete" do
-        expect(programme.compulsory_achievement(user)).to eq(earliest_achievement)
-      end
-
-      it "returns the complete achievement if 1 is complete" do
-        another_achievement.transition_to(:complete)
-        expect(programme.compulsory_achievement(user)).to eq(another_achievement)
-      end
-
-      it "returns the achievement completed first if multiple are complete" do
-        further_achievement.transition_to(:complete)
-        another_achievement.transition_to(:complete)
-        expect(programme.compulsory_achievement(user)).to eq(further_achievement)
-      end
-    end
-
-    context "when user has no f2f achievements but has online achievements" do
-      it "returns nil" do
-        activity = create(:activity, :online)
-        create(:programme_activity, programme_id: programme.id, activity:)
-        create(:achievement, user: user, activity: activity)
-        expect(programme.compulsory_achievement(user)).to eq(nil)
-      end
-    end
-  end
-
-  describe "#non_compulsory_achievements" do
+  describe "#course_achievements" do
     context "when user has no achievements" do
       it "returns empty list" do
-        expect(programme.non_compulsory_achievements(user)).to eq([])
+        expect(programme.course_achievements(user)).to eq([])
       end
     end
 
@@ -363,97 +243,24 @@ RSpec.describe Programmes::CSAccelerator do
           create(:achievement, activity: create(:activity, category: "diagnostic"), user: user)
         ].each { create(:programme_activity, programme: programme, activity: _1.activity) }
 
-        expect(programme.non_compulsory_achievements(user)).to eq([])
+        expect(programme.course_achievements(user)).to eq([])
       end
     end
 
-    context "when user has compulsory achievement but no others" do
-      it "returns empty list" do
-        achievement = create(:achievement, user: user)
-        create(:programme_activity, programme_id: programme.id, activity: achievement.activity)
-        expect(programme.non_compulsory_achievements(user)).to eq([])
-      end
-    end
+    context "when user has course achievements" do
+      let(:online_achievement) { create(:achievement, activity: create(:activity, category: "online"), user: user) }
+      let(:f2f_achievement) { create(:achievement, activity: create(:activity, category: "face-to-face"), user: user) }
 
-    context "when user has no f2f achievements but does have online achievements" do
-      it "returns online achievements" do
-        achievements = [
-          create(:achievement, :online, user: user),
-          create(:achievement, :online, user: user)
-        ]
-        achievements.each { create(:programme_activity, activity: _1.activity, programme:) }
-        expect(programme.non_compulsory_achievements(user)).to match_array(achievements)
-      end
-    end
-
-    context "when user has f2f achievements and online achievements" do
-      it "returns online achievements and f2f achievements except the first one" do
-        f2f_achievements = create_list(:achievement, 2, user: user)
-        first = create(:achievement, user: user, created_at: Time.now - 7.days)
-        online_achievements = create_list(:achievement, 2, :online, user: user)
-        [*f2f_achievements, first, *online_achievements].each do
-          create(:programme_activity, activity: _1.activity, programme:)
-        end
-        results = programme.non_compulsory_achievements(user)
-        expect(results).to match_array(f2f_achievements + online_achievements)
+      before do
+        [online_achievement, f2f_achievement].each { create(:programme_activity, programme: programme, activity: _1.activity) }
       end
 
-      it "ignores dropped achievements" do
-        f2f_achievements = create_list(:achievement, 2, user: user)
-        first = create(:achievement, user: user, created_at: Time.now - 7.days)
-        online_achievements = create_list(:achievement, 2, :online, user: user)
-        dropped_achievement = create(:achievement, user: user)
-        dropped_achievement.transition_to(:dropped)
-        [*f2f_achievements, first, *online_achievements, dropped_achievement].each do
-          create(:programme_activity, activity: _1.activity, programme:)
-        end
-        results = programme.non_compulsory_achievements(user)
-        expect(results).not_to include(dropped_achievement)
+      it "includes online courses" do
+        expect(programme.course_achievements(user)).to include(online_achievement)
       end
-    end
-  end
 
-  describe "#user_completed_non_compulsory_achievement?" do
-    context "when user has no achievements" do
-      it "returns false" do
-        expect(programme.user_completed_non_compulsory_achievement?(user)).to eq(false)
-      end
-    end
-
-    context "when user has no complete non compulsory achievement" do
-      it "returns false" do
-        create_list(:achievement, 2, :online, user: user)
-        expect(programme.user_completed_non_compulsory_achievement?(user))
-          .to eq(false)
-      end
-    end
-
-    context "when user at least one complete non compulsory achievement" do
-      it "returns true" do
-        f2f_achievements = create_list(:achievement, 2, user: user)
-        compulsory_achievement = create(:achievement, user: user, created_at: Time.now - 7.days)
-        compulsory_achievement.transition_to(:complete)
-        online_achievement = create(:achievement, :online, user: user)
-        online_achievement.transition_to(:complete)
-        [*f2f_achievements, compulsory_achievement, online_achievement].each do
-          create(:programme_activity, activity: _1.activity, programme:)
-        end
-        expect(programme.user_completed_non_compulsory_achievement?(user))
-          .to eq(true)
-      end
-    end
-
-    context "when user completed compulsory but not non compulsory achievement" do
-      it "returns false" do
-        f2f_achievements = create_list(:achievement, 2, user: user)
-        compulsory_achievement = create(:achievement, user: user, created_at: Time.now - 7.days)
-        compulsory_achievement.transition_to(:complete)
-        online_achievement = create(:achievement, :online, user: user)
-        [*f2f_achievements, compulsory_achievement, online_achievement].each do
-          create(:programme_activity, activity: _1.activity, programme:)
-        end
-        expect(programme.user_completed_non_compulsory_achievement?(user))
-          .to eq(false)
+      it "includes face-to-face courses" do
+        expect(programme.course_achievements(user)).to include(f2f_achievement)
       end
     end
   end

--- a/spec/models/programmes/cs_accelerator_spec.rb
+++ b/spec/models/programmes/cs_accelerator_spec.rb
@@ -108,12 +108,6 @@ RSpec.describe Programmes::CSAccelerator do
     end
   end
 
-  describe "#max_credits_for_certificate" do
-    it "returns 100 for 10 hour system" do
-      expect(programme.max_credits_for_certificate).to eq(100)
-    end
-  end
-
   describe "#show_notification_for_test?" do
     context "when a user is not enrolled" do
       before do

--- a/spec/models/user_programme_assessment_spec.rb
+++ b/spec/models/user_programme_assessment_spec.rb
@@ -108,10 +108,6 @@ RSpec.describe UserProgrammeAssessment do
       expect(user_programme_asessment.total_num_attempts).to eq(0)
     end
 
-    it "assigns the new test gate correctly" do
-      expect(user_programme_asessment.enough_activities_for_test?).to be(false)
-    end
-
     context "when user can take the test" do
       before do
         setup_achievements_for_taking_test
@@ -131,10 +127,6 @@ RSpec.describe UserProgrammeAssessment do
 
       it "assigns the number of attempts at test correctly" do
         expect(user_programme_asessment.total_num_attempts).to eq(0)
-      end
-
-      it "assigns the new test gate correctly" do
-        expect(user_programme_asessment.enough_activities_for_test?).to be(true)
       end
     end
 

--- a/spec/view_objects/csa_dash_spec.rb
+++ b/spec/view_objects/csa_dash_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe CSADash do
     end
   end
 
-  describe "#has_enough_activities_for_test" do
+  describe "#enough_credits_for_test?" do
     it "calls method on programme" do
       allow(csa).to receive(:enough_credits_for_test?)
       dash.has_enough_activities_for_test

--- a/spec/view_objects/csa_dash_spec.rb
+++ b/spec/view_objects/csa_dash_spec.rb
@@ -13,36 +13,11 @@ RSpec.describe CSADash do
     end
   end
 
-  describe "#compulsory_achievement" do
-    it "calls through to compulsory achievement method on programme" do
-      allow(csa).to receive(:compulsory_achievement)
-
-      dash.compulsory_achievement
-      expect(csa).to have_received(:compulsory_achievement).with(user)
-    end
-  end
-
-  describe "#non_compulsory_achievements" do
-    it "calls through to non_compulsory achievements method on programme" do
-      allow(csa).to receive(:non_compulsory_achievements)
-      dash.non_compulsory_achievements
-      expect(csa).to have_received(:non_compulsory_achievements).with(user)
-    end
-  end
-
-  describe "#user_completed_non_compulsory_achievement?" do
-    it "calls through to correct method on programme" do
-      allow(csa).to receive(:user_completed_non_compulsory_achievement?)
-      dash.user_completed_non_compulsory_achievement?
-      expect(csa).to have_received(:user_completed_non_compulsory_achievement?).with(user)
-    end
-  end
-
-  describe "#user_completed_non_compulsory_achievement?" do
-    it "calls through to correct method on programme" do
-      allow(csa).to receive(:user_completed_non_compulsory_achievement?)
-      dash.user_completed_non_compulsory_achievement?
-      expect(csa).to have_received(:user_completed_non_compulsory_achievement?).with(user)
+  describe "#course_achievements" do
+    it "calls through to course_achievements achievements method on programme" do
+      allow(csa).to receive(:course_achievements)
+      dash.course_achievements
+      expect(csa).to have_received(:course_achievements).with(user)
     end
   end
 
@@ -71,25 +46,11 @@ RSpec.describe CSADash do
     end
   end
 
-  describe "#supplementary_activities_for_user" do
-    it "calls correct method on users pathway" do
-      allow(csa).to receive(:pathways_excluding)
-      pathway = instance_double(Pathway)
-      allow(pathway).to receive(:supplementary_activities_for_user)
-      allow(user).to receive(:programme_pathway) { pathway }
-
-      dash.supplementary_activities_for_user
-      expect(pathway)
-        .to have_received(:supplementary_activities_for_user)
-        .with(user)
-    end
-  end
-
   describe "#has_enough_activities_for_test" do
     it "calls method on programme" do
-      allow(csa).to receive(:enough_activities_for_test?)
+      allow(csa).to receive(:enough_credits_for_test?)
       dash.has_enough_activities_for_test
-      expect(csa).to have_received(:enough_activities_for_test?).with(user)
+      expect(csa).to have_received(:enough_credits_for_test?).with(user)
     end
   end
 

--- a/spec/views/certificates/cs_accelerator/_achievements.html.erb_spec.rb
+++ b/spec/views/certificates/cs_accelerator/_achievements.html.erb_spec.rb
@@ -13,9 +13,8 @@ RSpec.describe("certificates/_achievements", type: :view) do
   it "links to activity if it has stem_activity_code" do
     render partial: "certificates/cs_accelerator/achievements",
       locals: {
-        non_compulsory_achievements: [stem_id_achievement],
-        compulsory_achievement: nil,
-        user_completed_non_compulsory_achievement: false
+        course_achievements: [stem_id_achievement],
+        test_available: false
       }
     expect(rendered).to have_link(stem_id_achievement.title)
   end
@@ -23,19 +22,35 @@ RSpec.describe("certificates/_achievements", type: :view) do
   it "does not error if achievement has no stem id" do
     render partial: "certificates/cs_accelerator/achievements",
       locals: {
-        non_compulsory_achievements: [no_stem_id_achievement],
-        compulsory_achievement: nil,
-        user_completed_non_compulsory_achievement: false
+        course_achievements: [no_stem_id_achievement],
+        test_available: false
       }
     expect(rendered).not_to have_link(no_stem_id_achievement.title)
+  end
+
+  it "add incomplete class when test not available" do
+    render partial: "certificates/cs_accelerator/achievements",
+      locals: {
+        course_achievements: [no_stem_id_achievement],
+        test_available: false
+      }
+    expect(rendered).to have_css(".ncce-csa-dash__objective--incomplete")
+  end
+
+  it "not add incomplete class when test available" do
+    render partial: "certificates/cs_accelerator/achievements",
+      locals: {
+        course_achievements: [no_stem_id_achievement],
+        test_available: true
+      }
+    expect(rendered).not_to have_css(".ncce-csa-dash__objective--incomplete")
   end
 
   it "does not link if achievement has been retired" do
     render partial: "certificates/cs_accelerator/achievements",
       locals: {
-        non_compulsory_achievements: [retired_achievement],
-        compulsory_achievement: nil,
-        user_completed_non_compulsory_achievement: false
+        course_achievements: [retired_achievement],
+        test_available: false
       }
     expect(rendered).not_to have_link(retired_achievement.title)
   end

--- a/spec/views/certificates/cs_accelerator/complete.html_spec.rb
+++ b/spec/views/certificates/cs_accelerator/complete.html_spec.rb
@@ -54,10 +54,6 @@ RSpec.describe("certificates/cs_accelerator/complete") do
       expect(rendered).not_to have_css(".recommended-courses-wrapper")
     end
 
-    it "does not show the additional pathways" do
-      expect(rendered).not_to have_css(".supplementary-courses__header")
-    end
-
     it "has a code club link" do
       expect(rendered).to have_link("Code Club", href: "https://codeclub.org/en/start-a-code-club")
     end
@@ -121,10 +117,6 @@ RSpec.describe("certificates/cs_accelerator/complete") do
 
     it "does show the recommended pathways" do
       expect(rendered).to have_css(".recommended-courses-wrapper")
-    end
-
-    it "does show the additional pathways" do
-      expect(rendered).to have_css(".supplementary-courses__header")
     end
 
     it "shows when a user has made progress on a course in both recommended and additional pathway activities" do


### PR DESCRIPTION
## Status

* Current Status: Ready for front-end / tech review
* Review App link(s): https://teachcomputing-pr-2354.herokuapp.com/
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/3012

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Due to the move to more online courses, we needed to change the logic of the CSA exam gateway, now you need 20 credits worth of face to face (this covers the legacy option where users could do two face to face course) or 30 credits, which covers the following scenarios
- 1 face to face & 1 online (10 + 20)
- 2 online (20 + 20)
- 1 residential (40)

Dashboard has been update to reflect the single poll of options for courses, rather than required and recommended
Removed a load of old logic related to testing
While was doing this cleared the bullet warnings off dashboards relating to eager loading warnings

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
