### PR TITLE
Make resource card title optional

### DIFF
--- a/app/components/cms/image_component.rb
+++ b/app/components/cms/image_component.rb
@@ -7,6 +7,6 @@ class Cms::ImageComponent < ViewComponent::Base
     @image = image
     @show_caption = show_caption
     @link = link
-    @classes = classes
+    @classes = ["cms-image"] + Array.wrap(classes)
   end
 end

--- a/app/components/cms/image_component/image_component.html.erb
+++ b/app/components/cms/image_component/image_component.html.erb
@@ -1,8 +1,8 @@
-<div class="cms-image <%= @classes %>">
+<%= content_tag :div, class: @classes do %>
   <%= link_to_if(@link, cms_image(@image), @link) %>
   <% if @show_caption && !@image.caption.blank?%>
     <p class="govuk-body-s govuk-!-margin-bottom-0">
       <%= @image.caption %>
     </p>
   <% end %>
-</div>
+<% end %>

--- a/app/components/cms/resource_card_component/resource_card_component.html.erb
+++ b/app/components/cms/resource_card_component/resource_card_component.html.erb
@@ -1,12 +1,17 @@
 <%= content_tag :div, class: wrapper_classes do %>
-  <div class="cms-resource-card__top-content">
-    <div class="cms-resource-card__top-content-title">
-      <h2 class="govuk-heading-m"><%= @title %></h1>
+  <% if @title %>
+    <div class="cms-resource-card__top-content">
+      <div class="cms-resource-card__top-content-title">
+        <h2 class="govuk-heading-m"><%= @title %></h1>
+      </div>
+      <% if @icon %>
+        <div class="cms-resource-card__top-content-image">
+          <%= render Cms::ImageComponent.new(@icon) %>
+        </div>
+      <% end %>
     </div>
-    <div class="cms-resource-card__top-content-image">
-      <%= render Cms::ImageComponent.new(@icon) if @icon %>
-    </div>
-  </div>
+  <% end %>
+
   <div class="cms-resource-card__body-text">
     <%= render @body_text.render %>
   </div>

--- a/app/components/cms/resource_card_component/resource_card_component.scss
+++ b/app/components/cms/resource_card_component/resource_card_component.scss
@@ -12,10 +12,18 @@
     display: flex;
     justify-content: space-between;
     margin-bottom: 10px;
+    gap: 10px;
 
-    &-image img {
-      max-width: 100%;
-      height: auto;
+    &-image  {
+      .cms-image {
+        width: 50px;
+
+        img {
+          width: 100%;
+          height: auto;
+          object-fit: contain;
+        }
+      }
     }
 
     @include govuk-media-query($until: tablet) {
@@ -27,10 +35,6 @@
         object-fit: contain;
         object-position: center;
       }
-    }
-
-    &-title {
-      padding-right: 10px;
     }
   }
 

--- a/previews/components/cms/resource_card_component_preview.rb
+++ b/previews/components/cms/resource_card_component_preview.rb
@@ -18,6 +18,40 @@ class Cms::ResourceCardComponentPreview < ViewComponent::Preview
     ))
   end
 
+  def with_icons
+    card_section = Cms::Mocks::ResourceCardSection.as_model(
+      resource_cards: Array.new(3) {
+                        Cms::Mocks::ResourceCard.generate_data(
+                          color_theme: {data: Cms::Mocks::ColorScheme.generate_data(name: "standard")},
+                          icon: {data: Cms::Mocks::Image.generate_raw_data}
+                        )
+                      }
+    )
+    render(Cms::CardWrapperComponent.new(
+      title: card_section.title,
+      cards_block: card_section.cards_block,
+      background_color: nil,
+      cards_per_row: 3
+    ))
+  end
+
+  def no_title
+    card_section = Cms::Mocks::ResourceCardSection.as_model(
+      resource_cards: Array.new(3) {
+                        Cms::Mocks::ResourceCard.generate_data(
+                          color_theme: {data: Cms::Mocks::ColorScheme.generate_data(name: "standard")},
+                          title: nil
+                        )
+                      }
+    )
+    render(Cms::CardWrapperComponent.new(
+      title: card_section.title,
+      cards_block: card_section.cards_block,
+      background_color: nil,
+      cards_per_row: 3
+    ))
+  end
+
   def with_color_theme
     card_section = Cms::Mocks::ResourceCardSection.as_model(
       resource_cards: Array.new(3) {

--- a/spec/components/cms/image_component_spec.rb
+++ b/spec/components/cms/image_component_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Cms::ImageComponent, type: :component do
         ))
       end
 
-      it "should add them" do
+      it "should add both classes" do
         expect(page).to have_css(".cms-image.another-class")
       end
     end
@@ -95,7 +95,7 @@ RSpec.describe Cms::ImageComponent, type: :component do
         ))
       end
 
-      it "should add them" do
+      it "should add both of them" do
         expect(page).to have_css(".cms-image.another-class.second-class")
       end
     end

--- a/spec/components/cms/image_component_spec.rb
+++ b/spec/components/cms/image_component_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe Cms::ImageComponent, type: :component do
       expect(page).to have_css("img")
     end
 
+    it "should set default class" do
+      expect(page).to have_css(".cms-image")
+    end
+
     it "should have link" do
       expect(page).to have_link(href: "https://www.google.com")
     end
@@ -67,5 +71,35 @@ RSpec.describe Cms::ImageComponent, type: :component do
     it "should not show caption" do
       expect(page).not_to have_text(caption)
     end
+  end
+
+  context "with additional classes" do
+
+    context "as string" do
+      before do
+        render_inline(described_class.new(
+          Cms::Mocks::Image.as_model(caption:),
+          classes: "another-class"
+        ))
+      end
+
+      it "should add them" do
+        expect(page).to have_css(".cms-image.another-class")
+      end
+    end
+
+    context "as array" do
+      before do
+        render_inline(described_class.new(
+          Cms::Mocks::Image.as_model(caption:),
+          classes: ["another-class", "second-class"]
+        ))
+      end
+
+      it "should add them" do
+        expect(page).to have_css(".cms-image.another-class.second-class")
+      end
+    end
+
   end
 end

--- a/spec/components/cms/image_component_spec.rb
+++ b/spec/components/cms/image_component_spec.rb
@@ -74,7 +74,6 @@ RSpec.describe Cms::ImageComponent, type: :component do
   end
 
   context "with additional classes" do
-
     context "as string" do
       before do
         render_inline(described_class.new(
@@ -100,6 +99,5 @@ RSpec.describe Cms::ImageComponent, type: :component do
         expect(page).to have_css(".cms-image.another-class.second-class")
       end
     end
-
   end
 end

--- a/spec/components/cms/resource_card_component_spec.rb
+++ b/spec/components/cms/resource_card_component_spec.rb
@@ -41,13 +41,17 @@ RSpec.describe Cms::ResourceCardComponent, type: :component do
   context "has only the required values" do
     before do
       render_inline(described_class.new(
-        title: "Card title",
+        title: nil,
         icon: nil,
         color_theme: nil,
         body_text: body_text,
         button_text: nil,
         button_link: nil
       ))
+    end
+
+    it "does not render header section" do
+      expect(page).to_not have_css(".cms-resource-card__top-content")
     end
 
     it "does not render an icon" do


### PR DESCRIPTION
## Status

* Current Status: Ready for front-end / tech review
* Review App link(s): https://teachcomputing-pr-2356.herokuapp.com/
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2998

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Changed the card to work if there was no title provided (will not show icon if no title given)
- Limited the size of the icons
- Fixed a weird class print error in the cms-image component

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
