### PR TITLE
Fixing flaky tests

### DIFF
--- a/spec/components/user_programme_course_bookings_with_asides_component_spec.rb
+++ b/spec/components/user_programme_course_bookings_with_asides_component_spec.rb
@@ -2,12 +2,9 @@ require "rails_helper"
 
 RSpec.describe UserProgrammeCourseBookingsWithAsidesComponent, type: :component do
   let(:user) { create(:user) }
-  let(:activity) {
-    activity = Activity.find_by(stem_activity_code: "CP199")
-    activity || create(:activity, stem_activity_code: "CP199", category: :online)
-  }
-  let(:activity_two) { create(:activity, stem_activity_code: "CP228") }
-  let(:activity_three) { create(:activity, stem_activity_code: "CS101", remote_delivered_cpd: true) }
+  let(:activity) { find_or_create_activity("CP199", category: :online) }
+  let(:activity_two) { find_or_create_activity("CP228") }
+  let(:activity_three) { find_or_create_activity("CS101", remote_delivered_cpd: true) }
   let(:programme) { create(:primary_certificate) }
   let(:achievement) { create(:achievement, user:) }
   let!(:courses) { create_list(:programme_activity_grouping, 2, :with_activities, sort_key: 2, community: false, programme:) }
@@ -17,6 +14,11 @@ RSpec.describe UserProgrammeCourseBookingsWithAsidesComponent, type: :component 
   let(:user_achievement) { create(:achievement, user:, activity:) }
   let(:remote_achievement) { create(:achievement, user:, activity: activity_three) }
   let(:completed_user_achievement) { create(:completed_achievement, user:, activity: activity_two) }
+
+  def find_or_create_activity(stem_activity_code, **)
+    activity = Activity.find_by(stem_activity_code:)
+    activity || create(:activity, stem_activity_code:, **)
+  end
 
   describe "when primary certificate" do
     context "with no user courses" do

--- a/spec/mailers/cms_mailer_spec.rb
+++ b/spec/mailers/cms_mailer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CmsMailer, type: :mailer do
   let(:user) { create(:user) }
   let(:activity) { create(:activity, programmes: [programme], title: "Test activity") }
   let!(:second_activity) { create(:activity, programmes: [programme], title: "Test activity second") }
-  let!(:other_activity) { create(:activity, programmes: [programme], title: "Other activity", stem_activity_code: "CP423") }
+  let!(:other_activity) { create(:activity, programmes: [programme], title: "Other activity", stem_activity_code: "CP823") }
   let!(:achievement) { create(:completed_achievement, activity:, user:) }
   let(:subject) { "I am a test email" }
   let(:slug) { "test-email-slug" }
@@ -46,7 +46,7 @@ RSpec.describe CmsMailer, type: :mailer do
       Cms::Mocks::EmailComponents::Cta.generate_raw_data(text: "CTA 1", link: "https://teachcomputing.org/cta1"),
       Cms::Mocks::EmailComponents::Cta.generate_raw_data(text: "CTA 2", link: "https://teachcomputing.org/cta2"),
       Cms::Mocks::EmailComponents::CourseList.generate_raw_data(section_title: nil, courses: [
-        Cms::Mocks::EmailComponents::Course.generate_data(activity_code: "CP423")
+        Cms::Mocks::EmailComponents::Course.generate_data(activity_code: "CP823")
       ])
     ]
   }
@@ -124,7 +124,7 @@ RSpec.describe CmsMailer, type: :mailer do
     end
 
     it "renders course link in text part" do
-      expect(@mail.text_part.body).to include("#{other_activity.title} (http://teachcomputing.test/courses/CP423/#{other_activity.title.parameterize})")
+      expect(@mail.text_part.body).to include("#{other_activity.title} (http://teachcomputing.test/courses/CP823/#{other_activity.title.parameterize})")
     end
 
     describe "Newer achievement" do


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/3016

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Fixing two tests there were being tripped up by repeated stem activity code.
- Moved the cms mailer one to a higher range to prevent collisions
- The user programme course booking, I have repeated the fix I used previously as the second one is now tripping up. These require specific keys that appear in the dynamics mocks

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
