### PR TITLE
Adding replaced_by logic to course cards

### DIFF
--- a/app/components/cms/card_wrapper_component/card_wrapper_component.html.erb
+++ b/app/components/cms/card_wrapper_component/card_wrapper_component.html.erb
@@ -8,9 +8,11 @@
     <% end %>
     <div class="cms-card-wrapper__grid" style="<%= cards_per_row %>">
       <% @cards_block.each do |card| %>
-        <div class="cms-card-wrapper__card">
-          <%= render card.render %>
-        </div>
+        <% if card.render.render? %>
+          <div class="cms-card-wrapper__card">
+            <%= render card.render %>
+          </div>
+        <% end %>
       <% end %>
     </div>
   <% end %>

--- a/app/components/cms/course_card_component.rb
+++ b/app/components/cms/course_card_component.rb
@@ -6,9 +6,9 @@ class Cms::CourseCardComponent < ViewComponent::Base
     to: :helpers
 
   def initialize(title:, banner_text:, course:, description:, image:)
-    @title = title
     @banner_text = banner_text
     @course = course
+    @title = title.presence || @course&.title
     @description = description
     @image = image
   end

--- a/app/components/cms/course_card_component/course_card_component.html.erb
+++ b/app/components/cms/course_card_component/course_card_component.html.erb
@@ -11,9 +11,9 @@
 
   <%= link_to @title, course_path(id: @course.activity_code, name: @course.title.parameterize), class: 'govuk-!-font-weight-bold govuk-body ncce-link' %>
   <div class="courses-cms-card__details">
-    <p class="govuk-body">
-      <%= render @description.render %>
-    </p>
+    <div class="courses-cms-card__details-content">
+      <%= render @description.render if @description %>
+    </div>
     <div class="courses-cms-card__icons">
       <div>
         <span class="govuk-body-s <%= course_meta_icon_class(@course) %> courses-cms-card__type">

--- a/app/components/cms/course_card_component/course_card_component.scss
+++ b/app/components/cms/course_card_component/course_card_component.scss
@@ -1,5 +1,8 @@
 
 .courses-cms-card {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
 
   &__image-wrapper {
     margin-bottom: 12px;
@@ -36,6 +39,12 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    
+    flex: 1 1 auto;
+
+    &-content {
+      flex: 1 1 auto;
+    }
   }
 
   &__icons {

--- a/app/components/cms/course_card_component/course_card_component.scss
+++ b/app/components/cms/course_card_component/course_card_component.scss
@@ -50,6 +50,7 @@
   &__icons {
     height: 22px;
     padding: 10px;
+    margin-top: 1rem;
     display: flex;
     flex-direction: row;
     justify-content: space-between;

--- a/app/services/cms/dynamic_components/course_card.rb
+++ b/app/services/cms/dynamic_components/course_card.rb
@@ -8,11 +8,21 @@ module Cms
         @banner_text = banner_text
         @description = description
         @image = image
-        @course = begin
-          Achiever::Course::Template.find_by_activity_code(course_code)
-        rescue ActiveRecord::RecordNotFound
-          nil
+
+        activity = Activity.find_by(stem_activity_code: course_code)
+        @course = if activity
+          if activity.replaced_by
+            get_achiever_course(activity.replaced_by)
+          elsif activity
+            get_achiever_course(activity)
+          end
         end
+      end
+
+      def get_achiever_course(activity)
+        Achiever::Course::Template.find_by_activity_code(activity.stem_activity_code)
+      rescue ActiveRecord::RecordNotFound
+        nil
       end
 
       def render

--- a/app/services/cms/dynamic_components/course_card.rb
+++ b/app/services/cms/dynamic_components/course_card.rb
@@ -12,6 +12,7 @@ module Cms
         activity = Activity.find_by(stem_activity_code: course_code)
         @course = if activity
           if activity.replaced_by
+            Sentry.capture_message("Course card has been found with a now replaced course (#{course_code} -> #{activity.replaced_by.stem_activity_code}) - get comms to update Strapi to new course instance")
             get_achiever_course(activity.replaced_by)
           elsif activity
             get_achiever_course(activity)

--- a/app/views/achievement_mailer/completed_course.html.erb
+++ b/app/views/achievement_mailer/completed_course.html.erb
@@ -2,7 +2,7 @@
   <p class='govuk-body'>Hello <%= @user.first_name %>,</p>
 
   <p class='govuk-body'>Thanks for engaging with the KS3 and GCSE Computer Science subject knowledge certificate. You're making great progress towards achieving your subject knowledge certificate.</p>
-  <p class='govuk-body'>Once you have completed your next course, you will have reached ten hours of CPD and become <b>eligible to take the test and achieve your qualification.</b></p>
+  <p class='govuk-body'>Once you have completed your next course, you will have reached ten hours of CPD and become <strong>eligible to take the test and achieve your qualification.</strong></p>
   <h3 class="govuk-heading-s">Next steps</h3>
   <p class='govuk-body'>Choose from any of our computer science subject knowledge courses.</p>
   <%= link_to 'Browse all courses', courses_url(certificate: 'subject-knowledge', emailTrigger: 'CSA4'), class: 'govuk-button button' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,14 +2,6 @@ Rails.application.routes.draw do
   Healthcheck.routes(self)
   root to: "cms#home", action: :home
 
-  # April 2025 Route Redirect
-
-  get "/computing-clusters", to: redirect("/")
-
-  # April 2025 Route Redirect
-
-  get "/computing-clusters", to: redirect("/")
-
   resources :achievements, only: %i[create destroy update] do
     collection do
       post :submit
@@ -155,6 +147,7 @@ Rails.application.routes.draw do
 
   # April 2025 Redirects
 
+  get "/computing-clusters", to: redirect("/")
   get "/hubs", to: redirect("/")
   get "/bursary", to: redirect("/")
   get "/funding", to: redirect("/")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ Rails.application.routes.draw do
 
   get "/computing-clusters", to: redirect("/")
 
+  # April 2025 Route Redirect
+
+  get "/computing-clusters", to: redirect("/")
+
   resources :achievements, only: %i[create destroy update] do
     collection do
       post :submit

--- a/spec/components/cms/course_card_component_spec.rb
+++ b/spec/components/cms/course_card_component_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Cms::CourseCardComponent, type: :component do
-  let(:course) {Achiever::Course::Template.all.first}
+  let(:course) { Achiever::Course::Template.all.first }
   before do
     stub_course_templates
     stub_duration_units
@@ -51,7 +51,6 @@ RSpec.describe Cms::CourseCardComponent, type: :component do
     it "renders title as link" do
       expect(page).to have_link(course.title, href: "/courses/#{course.activity_code}/#{course.title.parameterize}")
     end
-
   end
 
   context "when course is nil" do
@@ -69,7 +68,6 @@ RSpec.describe Cms::CourseCardComponent, type: :component do
       expect(page).not_to have_css(".courses-cms-card")
     end
   end
-
 
   context "when description is nil" do
     before do

--- a/spec/components/cms/course_card_component_spec.rb
+++ b/spec/components/cms/course_card_component_spec.rb
@@ -3,32 +3,87 @@
 require "rails_helper"
 
 RSpec.describe Cms::CourseCardComponent, type: :component do
+  let(:course) {Achiever::Course::Template.all.first}
   before do
     stub_course_templates
     stub_duration_units
-    @course = Achiever::Course::Template.all.first
-    render_inline(described_class.new(
-      title: "Learn how to teach computing",
-      banner_text: "Banner text",
-      course: @course,
-      description: Cms::Mocks::RichBlocks.as_model,
-      image: Cms::Mocks::Image.as_model
-    ))
   end
 
-  it "renders the banner text and makes it uppercase" do
-    expect(page).to have_css(".courses-cms-card__banner", text: "BANNER TEXT")
+  context "given title" do
+    before do
+      render_inline(described_class.new(
+        title: "Learn how to teach computing",
+        banner_text: "Banner text",
+        course: course,
+        description: Cms::Mocks::RichBlocks.as_model,
+        image: Cms::Mocks::Image.as_model
+      ))
+    end
+
+    it "renders the banner text and makes it uppercase" do
+      expect(page).to have_css(".courses-cms-card__banner", text: "BANNER TEXT")
+    end
+
+    it "renders title as link" do
+      expect(page).to have_link("Learn how to teach computing", href: "/courses/#{course.activity_code}/#{course.title.parameterize}")
+    end
+
+    it "renders description" do
+      expect(page).to have_css(".cms-rich-text-block-component")
+    end
+
+    it "renders image" do
+      expect(page).to have_css(".cms-image")
+    end
   end
 
-  it "renders title as link" do
-    expect(page).to have_link("Learn how to teach computing", href: "/courses/#{@course.activity_code}/#{@course.title.parameterize}")
+  context "without title" do
+    before do
+      render_inline(described_class.new(
+        title: nil,
+        banner_text: "Banner text",
+        course:,
+        description: Cms::Mocks::RichBlocks.as_model,
+        image: Cms::Mocks::Image.as_model
+      ))
+    end
+
+    it "renders title as link" do
+      expect(page).to have_link(course.title, href: "/courses/#{course.activity_code}/#{course.title.parameterize}")
+    end
+
   end
 
-  it "renders description" do
-    expect(page).to have_css(".cms-rich-text-block-component")
+  context "when course is nil" do
+    before do
+      render_inline(described_class.new(
+        title: nil,
+        banner_text: "Banner text",
+        course: nil,
+        description: Cms::Mocks::RichBlocks.as_model,
+        image: Cms::Mocks::Image.as_model
+      ))
+    end
+
+    it "doesnt render" do
+      expect(page).not_to have_css(".courses-cms-card")
+    end
   end
 
-  it "renders image" do
-    expect(page).to have_css(".cms-image")
+
+  context "when description is nil" do
+    before do
+      render_inline(described_class.new(
+        title: nil,
+        banner_text: "Banner text",
+        course:,
+        description: nil,
+        image: Cms::Mocks::Image.as_model
+      ))
+    end
+
+    it "does render" do
+      expect(page).to have_css(".courses-cms-card")
+    end
   end
 end

--- a/spec/services/cms/dynamic_components/course_card_section_spec.rb
+++ b/spec/services/cms/dynamic_components/course_card_section_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe Cms::DynamicComponents::CourseCard do
     let!(:card_section) { Cms::Providers::Strapi::Factories::ComponentFactory.process_component(Cms::Mocks::CourseCardSection.generate_raw_data(cards: [replaced_course_card])) }
     let(:first_block) { card_section.cards_block.first }
 
-
     it "should render as Cms::CardWrapperComponent" do
       expect(card_section.render).to be_a(Cms::CardWrapperComponent)
     end

--- a/spec/services/cms/dynamic_components/course_card_section_spec.rb
+++ b/spec/services/cms/dynamic_components/course_card_section_spec.rb
@@ -1,7 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Cms::DynamicComponents::CourseCard do
+  let!(:activity) { Activity.find_by(stem_activity_code: "CP228") || create(:activity, stem_activity_code: "CP228") }
+  let!(:new_activity) { Activity.find_by(stem_activity_code: "CP229") || create(:activity, stem_activity_code: "CP229") }
+  let!(:replaced_activity) { create(:activity, stem_activity_code: "RP228", replaced_by: new_activity) }
   let(:valid_course_card) { Cms::Mocks::DynamicComponents::CourseCard.generate_data(course_code: "CP228") }
+  let(:replaced_course_card) { Cms::Mocks::DynamicComponents::CourseCard.generate_data(course_code: "RP228") }
   let(:invalid_course_card) { Cms::Mocks::DynamicComponents::CourseCard.generate_data(course_code: "NV228") }
 
   before do
@@ -10,30 +14,57 @@ RSpec.describe Cms::DynamicComponents::CourseCard do
   end
 
   context "with valid activity" do
-    before do
-      @card_section = Cms::Providers::Strapi::Factories::ComponentFactory.process_component(Cms::Mocks::CourseCardSection.generate_raw_data(cards: [valid_course_card]))
-    end
+    let(:card_section) { Cms::Providers::Strapi::Factories::ComponentFactory.process_component(Cms::Mocks::CourseCardSection.generate_raw_data(cards: [valid_course_card])) }
+    let(:first_block) { card_section.cards_block.first }
 
     it "should render as Cms::CardWrapperComponent" do
-      expect(@card_section.render).to be_a(Cms::CardWrapperComponent)
+      expect(card_section.render).to be_a(Cms::CardWrapperComponent)
     end
 
     it "should render cards as Cms::DynamicsComponents::CourseCard" do
-      expect(@card_section.cards_block.first.render).to be_a(Cms::CourseCardComponent)
+      expect(first_block.render).to be_a(Cms::CourseCardComponent)
     end
 
     it "should return true for valid code" do
-      expect(@card_section.cards_block.first.render.render?).to be true
+      expect(first_block.render.render?).to be true
+    end
+
+    it "should have correct course instance" do
+      expect(first_block.course.activity_code).to eq("CP228")
     end
   end
 
   context "with invalid activity" do
-    before do
-      @card_section = Cms::Providers::Strapi::Factories::ComponentFactory.process_component(Cms::Mocks::CourseCardSection.generate_raw_data(cards: [invalid_course_card]))
-    end
+    let(:card_section) { Cms::Providers::Strapi::Factories::ComponentFactory.process_component(Cms::Mocks::CourseCardSection.generate_raw_data(cards: [invalid_course_card])) }
+    let(:first_block) { card_section.cards_block.first }
 
     it "should return false for invalid code" do
-      expect(@card_section.cards_block.first.render.render?).to be false
+      expect(first_block.render.render?).to be false
+    end
+
+    it "should have no course instance" do
+      expect(first_block.course).to be_nil
+    end
+  end
+
+  context "with replaced activity" do
+    let(:card_section) { Cms::Providers::Strapi::Factories::ComponentFactory.process_component(Cms::Mocks::CourseCardSection.generate_raw_data(cards: [replaced_course_card])) }
+    let(:first_block) { card_section.cards_block.first }
+
+    it "should render as Cms::CardWrapperComponent" do
+      expect(card_section.render).to be_a(Cms::CardWrapperComponent)
+    end
+
+    it "should render cards as Cms::DynamicsComponents::CourseCard" do
+      expect(first_block.render).to be_a(Cms::CourseCardComponent)
+    end
+
+    it "should return true for valid code" do
+      expect(first_block.render.render?).to be true
+    end
+
+    it "should have correct course instance" do
+      expect(first_block.course.activity_code).to eq("CP229")
     end
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for  tech review
* Review App link(s): https://teachcomputing-pr-2374.herokuapp.com/
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/3000

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Implemented the replaced by check on the data model for course cards
- This will replace the link and the icon information, but leave the course title and description the same
- This is intended as a temporary protection in case a course card is missed, but should be updated in Strapi to correct course instance, hence sentry notification

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
