### PR TITLE
Fixing image leaking on home page

### DIFF
--- a/app/components/cms/featured_blog_posts_component/featured_blog_posts_component.scss
+++ b/app/components/cms/featured_blog_posts_component/featured_blog_posts_component.scss
@@ -19,6 +19,14 @@
   @include govuk-media-query($from: desktop) {
     margin-right: 12px;
   }
+
+  .cms-image {
+    width: 100%;
+
+    img {
+      width: 100%;
+    }
+  }
 }
 
 .ncce-feat__panel-container {


### PR DESCRIPTION
## Status

* Current Status: Ready for front-end / tech review
* Review App link(s): 
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/3021

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Making image in the featured main section 100% width on homepage

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
