### PR TITLE
Removing references to hubs and course formats from courses page

### DIFF
--- a/app/components/benchmark_bordered_cards_component/benchmark_bordered_cards_component.html.erb
+++ b/app/components/benchmark_bordered_cards_component/benchmark_bordered_cards_component.html.erb
@@ -3,7 +3,11 @@
     <%= content_tag :div, class: ['benchmark-bordered-card', { "#{card[:class_name]}": card[:class_name].present? }] do %>
       <div class="benchmark-bordered-card__content">
         <h2 class="govuk-heading-m bordered-card__title">
-          <a class="govuk-link--no-underline" href="<%= card[:title_link] %>"><%= card[:title] %></a>
+          <% if card[:title_link] %>
+            <a class="govuk-link--no-underline" href="<%= card[:title_link] %>"><%= card[:title] %></a>
+          <% else %>
+            <%= card[:title] %>
+          <% end %>
         </h2>
         <p class="govuk-body bordered-card__text">
           <%= card[:text] %>

--- a/app/components/course_component/course_component.html.erb
+++ b/app/components/course_component/course_component.html.erb
@@ -31,7 +31,7 @@
     </div>
   <% else %>
     <div class="govuk-body-s govuk-!-font-weight-bold ncce-courses__locations--always-open">
-      <span><%= t('.no_occurrences_html', hubs_link: link_to('your local Computing Hub', '/hubs', class: 'ncce-link', data: tracking_data('Coming soon'))) %></span>
+      <span><%= t('.no_occurrences_html')%></span>
     </div>
   <% end %>
   <%= render CourseOccurrencesComponent.new(course: @course) %>

--- a/app/components/course_component/course_component.yml
+++ b/app/components/course_component/course_component.yml
@@ -1,2 +1,2 @@
 en:
-  no_occurrences_html: "Dates coming soon. Contact %{hubs_link} for more information."
+  no_occurrences_html: "Dates coming soon."

--- a/app/helpers/careers_helper.rb
+++ b/app/helpers/careers_helper.rb
@@ -81,7 +81,7 @@ module CareersHelper
       },
       {
         title: "Guidance for you",
-        title_link: hubs_path,
+        title_link: nil,
         text: "We recommend conducting a 1:1 interview with every student, ensuring you provide quality guidance about STEM pathways using all the advice above.".html_safe,
         benchmark_icons: [
           "media/images/pages/careers-support/benchmark_8.svg"

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -6,9 +6,6 @@
       <p class="govuk-body">
         Discover our range of professional development courses, designed to help you teach computing. Courses cover key stages 1 to 4 and cater for all levels of knowledge.
       </p>
-      <p class="govuk-body">
-        Choose how and when you want to learn, through face to face, online, or live remote training.
-      </p>
     <% end %>
     <%= row.with_column("one-third") do %>
       <%= render AsideComponent.new(title: "Costs") do |component| %>

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -28,7 +28,6 @@ SitemapGenerator::Sitemap.create do
   add "/gcse-cs-support", changefreq: "monthly"
   add "/gender-balance", changefreq: "monthly"
   add "/get-involved", changefreq: "monthly"
-  add "/hubs", changefreq: "monthly"
   add "/i-belong", changefreq: "monthly"
   add "/impact-and-evaluation", changefreq: "monthly"
   add "/isaac-computer-science", changefreq: "monthly"

--- a/spec/components/benchmark_bordered_cards_component_spec.rb
+++ b/spec/components/benchmark_bordered_cards_component_spec.rb
@@ -65,5 +65,4 @@ RSpec.describe BenchmarkBorderedCardsComponent, type: :component do
       expect(page).to have_text("Pellentesque")
     end
   end
-
 end

--- a/spec/components/benchmark_bordered_cards_component_spec.rb
+++ b/spec/components/benchmark_bordered_cards_component_spec.rb
@@ -1,31 +1,69 @@
 require "rails_helper"
 
 RSpec.describe BenchmarkBorderedCardsComponent, type: :component do
-  before do
-    render_inline(
-      described_class.new(
-        cards: [
-          {
-            title: "Testing",
-            text: "Pellentesque commodo eros a enim. Sed fringilla mauris sit amet nibh.",
-            benchmark_icons: [
-              "media/images/pages/careers-support/benchmark_1.svg"
-            ]
-          }
-        ]
+  context "without link" do
+    before do
+      render_inline(
+        described_class.new(
+          cards: [
+            {
+              title: "Testing",
+              text: "Pellentesque commodo eros a enim. Sed fringilla mauris sit amet nibh.",
+              benchmark_icons: [
+                "media/images/pages/careers-support/benchmark_1.svg"
+              ]
+            }
+          ]
+        )
       )
-    )
+    end
+
+    it "should have benchmark banner component" do
+      expect(page).to have_css("div.benchmark-banner-wrapper")
+    end
+
+    it "should render title" do
+      expect(page).to have_text("Testing")
+    end
+
+    it "should render text" do
+      expect(page).to have_text("Pellentesque")
+    end
   end
 
-  it "should have benchmark banner component" do
-    expect(page).to have_css("div.benchmark-banner-wrapper")
+  context "with link" do
+    before do
+      render_inline(
+        described_class.new(
+          cards: [
+            {
+              title: "Testing",
+              title_link: "/courses",
+              text: "Pellentesque commodo eros a enim. Sed fringilla mauris sit amet nibh.",
+              benchmark_icons: [
+                "media/images/pages/careers-support/benchmark_1.svg"
+              ]
+            }
+          ]
+        )
+      )
+    end
+
+    it "should have benchmark banner component" do
+      expect(page).to have_css("div.benchmark-banner-wrapper")
+    end
+
+    it "should render title" do
+      expect(page).to have_text("Testing")
+    end
+
+    it "should have link" do
+      expect(page).to have_link("Testing", href: "/courses")
+    end
+
+    it "should render text" do
+      expect(page).to have_text("Pellentesque")
+    end
   end
 
-  it "should render title" do
-    expect(page).to have_text("Testing")
-  end
-
-  it "should render text" do
-    expect(page).to have_text("Pellentesque")
-  end
 end

--- a/spec/components/course_component_spec.rb
+++ b/spec/components/course_component_spec.rb
@@ -86,10 +86,6 @@ RSpec.describe CourseComponent, type: :component do
     it "shows the expected message" do
       expect(page).to have_text("Dates coming soon.")
     end
-
-    it "shows the expected link" do
-      expect(page).to have_link("your local Computing Hub", href: "/hubs")
-    end
   end
 
   context "when multiple course occurrences are present" do

--- a/spec/components/course_component_spec.rb
+++ b/spec/components/course_component_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe CourseComponent, type: :component do
     end
 
     it "shows the expected message" do
-      expect(page).to have_text("Dates coming soon. Contact your local Computing Hub for more information.")
+      expect(page).to have_text("Dates coming soon.")
     end
 
     it "shows the expected link" do


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/3031

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Removing hubs reference from course page. 
- Also removed the text referencing the different course formats.
- Removed hubs from sitemap

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
