### PR TITLE
Using all_record in sitemap Strapi lookups

### DIFF
--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -52,11 +52,11 @@ SitemapGenerator::Sitemap.create do
   # CMS Routes
   add "/privacy", changefreq: "monthly"
 
-  Cms::Collections::EnrichmentPage.all(1, 10).resources.each do |enrichment_page|
+  Cms::Collections::EnrichmentPage.all_records.each do |enrichment_page|
     add cms_page_path(enrichment_page.slug), changefreq: "monthly", lastmod: enrichment_page.updated_at
   end
 
-  Cms::Collections::WebPage.all(1, 200).resources.each do |page|
+  Cms::Collections::WebPage.all_records.each do |page|
     add cms_page_path(page.slug), changefreq: "monthly", lastmod: page.updated_at
   end
 


### PR DESCRIPTION
## Status

* Current Status: Ready for front-end / tech review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/3011

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Changing hardcoded pagination queries in sitemap to use the all records method instead.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
