### PR TITLE
Updating time_diff_words method to handle months that aren't 30 days

### DIFF
--- a/app/services/cms/models/collections/email_template.rb
+++ b/app/services/cms/models/collections/email_template.rb
@@ -49,10 +49,9 @@ module Cms
           achievements = user.sorted_completed_cpd_achievements_by(programme: @programme)
           if achievements.any?
             achievement = achievements.last
-            last_cpd_completed_ago = distance_of_time_in_words(achievement.updated_at, DateTime.now)
 
             merges += [
-              ["{last_cpd_completed_ago}", last_cpd_completed_ago],
+              ["{last_cpd_completed_ago}", time_ago_in_words(achievement.updated_at)],
               ["{last_cpd_completed_year}", "in #{achievement.updated_at.year}"],
               ["{last_cpd_title}", achievement.activity.title]
             ]

--- a/app/services/cms/models/collections/email_template.rb
+++ b/app/services/cms/models/collections/email_template.rb
@@ -2,6 +2,8 @@ module Cms
   module Models
     module Collections
       class EmailTemplate
+        include ActionView::Helpers::DateHelper
+
         attr_accessor :slug, :email_content, :programme, :completed_programme_activity_groups, :activity_state, :enrolled
 
         def initialize(slug:, subject:, email_content:, programme_slug:, completed_programme_activity_group_slugs:, activity_state:, enrolled:)
@@ -47,8 +49,10 @@ module Cms
           achievements = user.sorted_completed_cpd_achievements_by(programme: @programme)
           if achievements.any?
             achievement = achievements.last
+            last_cpd_completed_ago = distance_of_time_in_words(achievement.updated_at, DateTime.now)
+
             merges += [
-              ["{last_cpd_completed_ago}", time_diff_words(achievement.updated_at)],
+              ["{last_cpd_completed_ago}", last_cpd_completed_ago],
               ["{last_cpd_completed_year}", "in #{achievement.updated_at.year}"],
               ["{last_cpd_title}", achievement.activity.title]
             ]
@@ -56,21 +60,6 @@ module Cms
           new_text = text.dup # to unfreeze the string
           merges.each { new_text.gsub!(_1[0], _1[1]) }
           new_text
-        end
-
-        def time_diff_words(date)
-          from_time = date.to_time
-          to_time = DateTime.now.to_time
-
-          months = (to_time.year * 12 + to_time.month) - (from_time.year * 12 + from_time.month)
-          months = 1 if months == 0
-
-          if months >= 12
-            years = months / 12
-            "#{years} #{"year".pluralize(years)}"
-          else
-            "#{months} #{"month".pluralize(months)}"
-          end
         end
       end
     end

--- a/app/services/cms/models/collections/email_template.rb
+++ b/app/services/cms/models/collections/email_template.rb
@@ -59,11 +59,15 @@ module Cms
         end
 
         def time_diff_words(date)
-          diff = DateTime.now.to_i - date.to_i
-          months = diff / (60 * 60 * 24 * 30)
+          from_time = date.to_time
+          to_time = DateTime.now.to_time
+
+          months = (to_time.year * 12 + to_time.month) - (from_time.year * 12 + from_time.month)
           months = 1 if months == 0
+
           if months >= 12
-            "#{months / 12} #{"year".pluralize(months / 12)}"
+            years = months / 12
+            "#{years} #{"year".pluralize(years)}"
           else
             "#{months} #{"month".pluralize(months)}"
           end

--- a/spec/services/cms/models/collections/email_template_spec.rb
+++ b/spec/services/cms/models/collections/email_template_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Cms::Models::Collections::EmailTemplate do
       travel_back
     end
 
-    it "should replace achievement placeholders using distance_of_time_in_words" do
+    it "should replace achievement placeholders using time_ago_in_words" do
       content = @model.process_blocks(text_content, user)
       text = content.dig(2, :children, 0, :text)
       expect(text).to eq("You completed Past activity about 1 month ago.")


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/3048

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?
- The time_diff_words method was failing tests as it assumed that months would have 30 days, but as we are now comparing back to February which only had 28 days the method needed updating to account for this.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
