### PR TITLE
Remove vital_model_checker rake task

### DIFF
--- a/lib/tasks/vital_model_checker.rake
+++ b/lib/tasks/vital_model_checker.rake
@@ -1,9 +1,0 @@
-task vital_model_checker: :environment do
-  online_achievements_count = Achievement.with_category("online").where(created_at: (Time.now - 24.hours)..Time.now).count
-
-  Sentry.capture_message("No online achievements created at in the last 24 hours.") if online_achievements_count == 0
-
-  f2f_achievements_count = Achievement.with_category("face-to-face").where(created_at: (Time.now - 24.hours)..Time.now).count
-
-  Sentry.capture_message("No face to face achievements created at in the last 24 hours.") if f2f_achievements_count == 0
-end


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/3055

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?
This rake task was created 4 years ago and now that TC is a tested and mature rails app we don't need to be monitoring achievement creation. As we move into more online CPD, this is also brings false-positive warnings in Sentry due to lack of face-to-face courses.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
