### PR TITLE
Remove template caching error from Sentry

### DIFF
--- a/app/services/achiever/course/template.rb
+++ b/app/services/achiever/course/template.rb
@@ -87,6 +87,18 @@ class Achiever::Course::Template
       Achiever::Request.resource(RESOURCE_PATH, QUERY_STRINGS.merge(ProgrammeName: programme_name), false)
     end.uniq { _1["Template.COURSETEMPLATENO"].downcase }
 
+    if templates.empty?
+      Sentry.capture_message(
+        "No templates returned from Achiever API",
+        level: :error,
+        extra: {
+          programme_names: PROGRAMME_NAMES,
+          resource_path: RESOURCE_PATH,
+          query_strings: QUERY_STRINGS
+        }
+      )
+    end
+
     templates.filter_map do |template|
       activity = activities[template["Template.COURSETEMPLATENO"].downcase]
 


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/3056

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?
- Updated template caching to log info into rails logger rather than Sentry error
- Added Sentry error if templates aren't retrieved from Dynamics

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
