### PR TITLE
Bug fix: FetchUsersCompletedCoursesFromAchieverJob duplication

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -17,7 +17,6 @@ class AuthController < ApplicationController
       flash[:notice] = "Hello and welcome to the National Centre for Computing Education"
       redirect_to course_booking_uri ? "#{course_booking_uri}?firstLogin=true" : dashboard_path(firstLogin: true)
     end
-
   rescue => e
     Sentry.with_scope do |scope|
       scope.set_context("CustomClaim", {


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/3066

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?
- Moved the call to the `FetchUsersCompletedCoursesFromAchieverJob` into `if user_exists` statement in the auth controller, which was duplicating the same job running when a user logged into TC. Details of this bug in the ticket.

## Steps to perform after deploying to production

*If the production environment requires any extra work after this PR has been deployed detail it here. This could be running a Rake task, migrating a DB table, or upgrading a Gem. That kind of thing.*
