### PR TITLE
Pin webpack to 4.46.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "sass-loader": "^10.5.2",
     "trix": "^2.1",
     "turbolinks": "^5.2.0",
-    "webpack": "^4.46.0",
+    "webpack": "4.46.0",
     "webpack-cli": "^3.3.12",
     "yargs-parser": "^21.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9221,7 +9221,7 @@ __metadata:
     stylelint-scss: ^6.10
     trix: ^2.1
     turbolinks: ^5.2.0
-    webpack: ^4.46.0
+    webpack: 4.46.0
     webpack-cli: ^3.3.12
     webpack-dev-server: ^3.11.2
     yargs-parser: ^21.1
@@ -13657,7 +13657,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:^4.46.0":
+"webpack@npm:4.46.0, webpack@npm:^4.46.0":
   version: 4.46.0
   resolution: "webpack@npm:4.46.0"
   dependencies:


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/3073

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?
Pinning webpack to 4.46.0 to remove dependabot PR. Update not required at this time.
