### PR TITLE
Update controllers to use params

### DIFF
--- a/app/controllers/class_marker/webhooks_controller.rb
+++ b/app/controllers/class_marker/webhooks_controller.rb
@@ -1,5 +1,6 @@
 class ClassMarker::WebhooksController < ApplicationController
   skip_before_action :verify_authenticity_token, :authenticate
+  before_action :verify_hmac_signature
 
   def assessment
     test_id = params.dig(:test, :test_id)

--- a/app/controllers/class_marker/webhooks_controller.rb
+++ b/app/controllers/class_marker/webhooks_controller.rb
@@ -4,7 +4,7 @@ class ClassMarker::WebhooksController < ApplicationController
   before_action :verify_hmac_signature
 
   def assessment
-    UpdateUserAssessmentAttemptFromClassMarkerJob.perform_later(request[:test][:test_id], request[:result][:cm_user_id], request[:result][:percentage])
+    UpdateUserAssessmentAttemptFromClassMarkerJob.perform_later(params[:test][:test_id], params[:result][:cm_user_id], params[:result][:percentage])
     head :ok
   end
 

--- a/app/controllers/class_marker/webhooks_controller.rb
+++ b/app/controllers/class_marker/webhooks_controller.rb
@@ -1,7 +1,6 @@
 class ClassMarker::WebhooksController < ApplicationController
   skip_before_action :verify_authenticity_token, :authenticate
 
-
   def assessment
     test_id = params.dig(:test, :test_id)
     cm_user_id = params.dig(:result, :cm_user_id)

--- a/app/controllers/concerns/curriculum/rateable.rb
+++ b/app/controllers/concerns/curriculum/rateable.rb
@@ -33,9 +33,9 @@ module Curriculum
       raise NoMethodError unless respond_to?(:client, true)
 
       response = client.update_rating(
-        id: request[:rating_id],
+        id: params[:rating_id],
         key: :comment,
-        value: request[:comment].gsub('"', '\"')
+        value: params[:comment].gsub('"', '\"')
       )
 
       render json: {
@@ -48,11 +48,11 @@ module Curriculum
       raise NoMethodError unless respond_to?(:client, true)
 
       response = client.update_rating(
-        id: request[:rating_id],
+        id: params[:rating_id],
         key: :choices,
-        value: request[:rating_choices]
+        value: params[:rating_choices]
       )
-      response.rating_id = request[:rating_id]
+      response.rating_id = params[:rating_id]
       render json: {
         origin: __method__.to_s,
         data: response

--- a/app/controllers/dynamics/webhooks_controller.rb
+++ b/app/controllers/dynamics/webhooks_controller.rb
@@ -4,7 +4,7 @@ module Dynamics
     before_action :verify_bearer_token
 
     def user
-      stem_achiever_contact_no = request[:stem_achiever_contact_no]&.downcase
+      stem_achiever_contact_no = params[:stem_achiever_contact_no]&.downcase
       user = User.find_by(stem_achiever_contact_no:)
 
       Sentry.capture_message("Dynamics webhook failed as no user found with contact_no: #{stem_achiever_contact_no || "nil"}") unless user

--- a/spec/support/class_marker/missing_params_webhook.json
+++ b/spec/support/class_marker/missing_params_webhook.json
@@ -1,0 +1,223 @@
+{
+  "payload_type": "single_user_test_results_link",
+  "payload_status": "live",
+  "test": {
+    "test_id": 100,
+    "test_name": "Sample Test Name"
+  },
+  "link": {
+    "link_id": 101,
+    "link_name": "Sample Link Name",
+    "link_url_id": "sample_quiz_id_123"
+  },
+  "result": {
+    "link_result_id": 8127364,
+    "first": "John",
+    "last": "Smith",
+    "email": "john@example.com",
+    "percentage": "",
+    "points_scored": 9.0,
+    "points_available": 12.0,
+    "requires_grading": "Yes",
+    "time_started": 1436263522,
+    "time_finished": 1436264122,
+    "duration": "00:05:20",
+    "percentage_passmark": 50,
+    "passed": true,
+    "feedback": "Thanks for completing our Exam!",
+    "give_certificate_only_when_passed": false,
+    "certificate_url": "https://www.classmarker.com/pdf/certificate/SampleCertificate.pdf",
+    "view_results_url": "https://www.classmarker.com/view/results/?required_parameters_here",
+    "access_code_question": "What is your Employee ID?",
+    "access_code_used": "12345",
+    "extra_info_question": "Which sales department are you assigned to?",
+    "extra_info_answer": "New York Product 7 Divisiaon",
+    "extra_info2_question": "Extra Information Question 2 here",
+    "extra_info2_answer": "Extra Information Answer 2 here",
+    "extra_info3_question": "Extra Information Question 3 here",
+    "extra_info3_answer": "Extra Information Answer 3 here",
+    "extra_info4_question": "Extra Information Question 4 here",
+    "extra_info4_answer": "Extra Information Answer 4 here",
+    "extra_info5_question": "Extra Information Question 5 here",
+    "extra_info5_answer": "Extra Information Answer 5 here",
+    "cm_user_id": "123456",
+    "ip_address": "192.168.0.1"
+  },
+  "questions": [
+    {
+      "question_id": 3542854,
+      "question_type": "multiplechoice",
+      "category_id": 1,
+      "points_available": 2,
+      "question": "What is the first step for treating a skin burn?",
+      "options": {
+        "A": "Apply oil or butter",
+        "B": "Nothing should be done",
+        "C": "Soak in water for five minutes",
+        "D": "Apply antibiotic ointment"
+      },
+      "correct_option": "C",
+      "points_scored": 2,
+      "user_response": "C",
+      "result": "correct",
+      "feedback": "Great, and remember, never use oil on Skin burns!"
+    },
+    {
+      "question_id": 10254859,
+      "question_type": "multiplechoice",
+      "category_id": 2,
+      "points_available": 2,
+      "question": "Select the options you should take when the fire alarm sounds:",
+      "options": {
+        "A": "Call you manager to see if you can leave the building",
+        "B": "Exit the building immediately",
+        "C": "Use the Lifts to exit faster",
+        "D": "Use the stairwell to exit"
+      },
+      "correct_option": "B,D",
+      "points_scored": 1,
+      "user_response": "B",
+      "result": "partial_correct",
+      "feedback": "That is incorrect, the correct answers are A and C"
+    },
+    {
+      "question_id": 5485962,
+      "question_type": "truefalse",
+      "category_id": 3,
+      "points_available": 1,
+      "question": "Our Support staff work 7 day a week",
+      "options": {
+        "A": "True",
+        "B": "False"
+      },
+      "correct_option": "A",
+      "points_scored": 1,
+      "user_response": "A",
+      "result": "correct",
+      "feedback": "That is correct, we provide 7 day support"
+    },
+    {
+      "question_id": 3896152,
+      "question_type": "freetext",
+      "category_id": 5,
+      "points_available": 1,
+      "question": "Our company website is: www.______.com",
+      "options": {
+        "exact_match": [
+          {
+            "content": "example"
+          },
+          {
+            "content": "example.com"
+          },
+          {
+            "content": "www.example.com"
+          },
+          {
+            "content": "http://www.example.com"
+          },
+          {
+            "content": "https://www.example.com"
+          }
+        ]
+      },
+      "points_scored": 1,
+      "user_response": "example",
+      "result": "correct",
+      "feedback": "Correct, always send our customers to our main website: www.example.com"
+    },
+    {
+      "question_id": 6403973,
+      "question_type": "matching",
+      "category_id": 2,
+      "points_available": 4,
+      "question": "Match the options below:",
+      "points_scored": 3,
+      "options": {
+        "A": {
+          "clue": "Product faulty",
+          "match": "Exchange or Refund",
+          "correct_option": "A",
+          "user_response": "A"
+        },
+        "B": {
+          "clue": "Customer mis-used and broke product",
+          "match": "No refund",
+          "correct_option": "B",
+          "user_response": "B"
+        },
+        "C": {
+          "clue": "Customer broke factory seal",
+          "match": "No refund",
+          "correct_option": "B",
+          "user_response": "B"
+        },
+        "D": {
+          "clue": "Incorrect product size purchased",
+          "match": "Exchange",
+          "correct_option": "D",
+          "user_response": "A"
+        },
+        "E": {
+          "match": "Have customer removed by security"
+        }
+      },
+      "result": "partial_correct",
+      "feedback": "Please check your incorrect matches"
+    },
+    {
+      "question_id": 444564,
+      "question_type": "essay",
+      "category_id": 5,
+      "points_available": 1,
+      "question": "Describe some advantages of having test papers graded instantly:",
+      "points_scored": 0,
+      "user_response": "Users can see their results instantly, grading is accurate, save time from manual grading",
+      "result": "requires_grading",
+      "custom_feedback": "",
+      "feedback": "Generic feedback here"
+    },
+    {
+      "question_id": 442810,
+      "question_type": "grammar",
+      "category_id": 3,
+      "points_available": 1,
+      "question": "The car was parkked over their!",
+      "answer": "The car was parked over there!",
+      "points_scored": 1,
+      "user_response": "The car was parked over there!",
+      "result": "correct",
+      "feedback": "Well done!"
+    }
+  ],
+  "category_results": [
+    {
+      "category_id": 1,
+      "name": "Health and Safety",
+      "percentage": 66.7,
+      "points_available": 6,
+      "points_scored": 4
+    },
+    {
+      "category_id": 2,
+      "name": "Exit Procedure",
+      "percentage": 100,
+      "points_available": 2,
+      "points_scored": 2
+    },
+    {
+      "category_id": 3,
+      "name": "General Knowledge",
+      "percentage": 100,
+      "points_available": 2,
+      "points_scored": 2
+    },
+    {
+      "category_id": 5,
+      "name": "Sales",
+      "percentage": 50,
+      "points_available": 2,
+      "points_scored": 1
+    }
+  ]
+}


### PR DESCRIPTION
## Status

* Current Status: Ready for (front-end / tech) review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/3074

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?
The following controllers were using the `request` object in the response:
- class_marker/webhooks_controller.rb
- dynamics/webhooks_controller.rb
- concerns/curriculum/rateable.rb

This is outdated and we should be using `params`.

As part of this tech debt, I've added some additional checking into the classmarker controller to ensure the required data is present before proceeding to the job.