### PR TITLE
Secondary certificate dashboard evidence guide

### DIFF
--- a/app/helpers/external_link_helper.rb
+++ b/app/helpers/external_link_helper.rb
@@ -222,4 +222,8 @@ module ExternalLinkHelper
   def local_hub_professional_development_form_url
     "https://forms.office.com/pages/responsepage.aspx?id=8MSlGfdLSE2oGxZmua5L9VL53rMMyRtKnHXwxiNRaSRUMDcwVElaTFBFWlY0QkI2M1lZVzNBQktYUCQlQCN0PWcu"
   end
+
+  def secondary_certificate_evidence_guide_url
+    "https://media.teachcomputing.org/Teach_secondary_computing_certificate_Evidence_Guide_V1_2_37745edb6b.pdf"
+  end
 end

--- a/app/views/certificates/secondary_certificate/_community_activity_list.html.erb
+++ b/app/views/certificates/secondary_certificate/_community_activity_list.html.erb
@@ -1,0 +1,9 @@
+<% @community_groups.each do |group| %>
+  <p id="<%= group.id %>" class="govuk-body ncce-activity-list__title <%= add_group_complete_icon_class(current_user, group) %>">
+    <strong>Choose at least <%= group.required_for_completion.humanize %> activity</strong> to <%= group.title.downcase %>
+  </p>
+  <%= render CommunityActivityListComponent.new(
+    programme_activity_grouping: group,
+    community_achievements: @community_achievements,
+  ) %>
+<% end%>

--- a/app/views/certificates/secondary_certificate/_professional_development_groups_list.html.erb
+++ b/app/views/certificates/secondary_certificate/_professional_development_groups_list.html.erb
@@ -1,7 +1,7 @@
 <p id="<%= @professional_development_groups.first&.id %>" class="govuk-body ncce-activity-list__title govuk-!-margin-top-8 <%= add_groups_complete_icon_class(current_user, @professional_development_groups) %>">
   <%= t('.development.title.html') %>
 </p>
-<ul class="govuk-list ncce-activity-list ncce-activity-list--programme" role="list">
+<ul class="govuk-list ncce-activity-list ncce-activity-list--programme">
   <li class="ncce-activity-list__item">
     <div class="ncce-activity-list__item-content">
       <%= t('.any_course_prompt') %>

--- a/app/views/certificates/secondary_certificate/_professional_development_groups_list.html.erb
+++ b/app/views/certificates/secondary_certificate/_professional_development_groups_list.html.erb
@@ -34,13 +34,3 @@
     </li>
   <% end %>
 </ul>
-
-<% @community_groups.each do |group| %>
-  <p id="<%= group.id %>" class="govuk-body ncce-activity-list__title <%= add_group_complete_icon_class(current_user, group) %>">
-    <strong>Choose at least <%= group.required_for_completion.humanize %> activity</strong> to <%= group.title.downcase %>
-  </p>
-  <%= render CommunityActivityListComponent.new(
-    programme_activity_grouping: group,
-    community_achievements: @community_achievements,
-  ) %>
-<% end %>

--- a/app/views/certificates/secondary_certificate/show.html.erb
+++ b/app/views/certificates/secondary_certificate/show.html.erb
@@ -3,32 +3,41 @@
 <%= render 'pages/certification/hero' %>
 <div class="ncce-programmes-activity">
   <%= render ProgressBarComponent.new(programme: @programme) %>
-  <div class="govuk-width-container">
-    <div class="govuk-main-wrapper govuk-!-padding-top-0">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <p class="govuk-body-m"><%= t(
-            '.introduction.html',
-            subject_knowledge: link_to('Subject knowledge certificate', cs_accelerator_path)
-          ) %></p>
-          <%= render 'achievement_list' %>
-        </div>
-        <div class="govuk-grid-column-one-third">
-          <%= render partial: 'pathway_aside', locals: {
-            available_pathways_for_user: @available_pathways_for_user
-          } if @user_pathway %>
-          <%= render AsideComponent.new(
-            title: t('.support_aside.title'),
-            class_name: 'help-aside',
-            text: t('.support_aside.text.html',
-              email_link: mail_to('info@teachcomputing.org', 'info@teachcomputing.org', class: 'ncce-link', data: tracking_data('Email'))
-            ))
-          %>
-          <div class="ncce-aside--borderless">
-            <%= render FeedbackComponent.new(heading: t('.feedback_text'), area: :secondary_certificate) %>
-          </div>
-        </div>
+  <%= render GovGridRowComponent.new(padding: {top: 0, bottom: 0}) do |row| %>
+    <%= row.with_column("two-thirds") do %>
+      <p class="govuk-body-m"><%= t(
+        '.introduction.html',
+        subject_knowledge: link_to('Subject knowledge certificate', cs_accelerator_path)
+      ) %></p>
+      <%= render 'professional_development_groups_list' %>
+    <% end %>
+    <%= row.with_column("one-third") do %>
+      <%= render partial: 'pathway_aside', locals: {
+        available_pathways_for_user: @available_pathways_for_user
+      } if @user_pathway %>
+      <%= render AsideComponent.new(
+        title: t('.support_aside.title'),
+        class_name: 'help-aside',
+        text: t('.support_aside.text.html',
+          email_link: mail_to('info@teachcomputing.org', 'info@teachcomputing.org', class: 'ncce-link', data: tracking_data('Email'))
+        ))
+      %>
+      <div class="ncce-aside--borderless govuk-!-margin-bottom-6">
+        <%= render FeedbackComponent.new(heading: t('.feedback_text'), area: :secondary_certificate) %>
       </div>
-    </div>
-  </div>
+    <% end %>
+  <% end %>
+  <%= render GovGridRowComponent.new(padding: {top: 0}) do |row| %>
+    <%= row.with_column("two-thirds") do %>
+      <%= render 'community_activity_list' %>
+    <% end %>
+    <%= row.with_column("one-third") do %>
+      <%= render AsideComponent.new(
+        title: t('.evidence_guide_aside.title'),
+        class_name: 'help-aside',
+        text: t('.evidence_guide_aside.text'),
+        link: {text: t('.evidence_guide_aside.link_text'), url: secondary_certificate_evidence_guide_url}
+      )%>
+    <% end %>
+  <% end %>
 </div>

--- a/config/locales/views/certificates/secondary_certificate/_professional_development_groups_list.en.yml
+++ b/config/locales/views/certificates/secondary_certificate/_professional_development_groups_list.en.yml
@@ -1,7 +1,7 @@
 en:
   certificates:
     secondary_certificate:
-      achievement_list:
+      professional_development_groups_list:
         development:
           title:
             html: "<strong>Participate in professional development</strong>"

--- a/config/locales/views/certificates/secondary_certificate/show.en.yml
+++ b/config/locales/views/certificates/secondary_certificate/show.en.yml
@@ -11,3 +11,7 @@ en:
           title: "Need some help?"
           text:
             html: "For support with this certificate or technical issues:<br />%{email_link}"
+        evidence_guide_aside:
+          title: "More on making positive impact on young people and supporting professional community."
+          text: "Explore examples and tips on submitting evidence for activities in each activity section."
+          link_text: "Teach secondary computing certificate evidence guide"

--- a/spec/helpers/external_link_helper_spec.rb
+++ b/spec/helpers/external_link_helper_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe ExternalLinkHelper do
     cas_communities_url
     local_hub_professional_development_form_url
     stem_primary_ambassadors_url
+    secondary_certificate_evidence_guide_url
   ].each do |external_link_method|
     describe "##{external_link_method}" do
       it "should return a string" do

--- a/spec/views/certificates/secondary-certificate/show.html_spec.rb
+++ b/spec/views/certificates/secondary-certificate/show.html_spec.rb
@@ -61,4 +61,8 @@ RSpec.describe("certificates/secondary_certificate/show", type: :view) do
   it "has feedback form" do
     expect(rendered).to have_css(".feedback-component__heading", text: "What can we do better?")
   end
+
+  it "has the evidence guide" do
+    expect(rendered).to have_css(".aside-component__heading", text: "More on making positive impact on young people and supporting professional community.")
+  end
 end


### PR DESCRIPTION
eng-1271

- Add new aside component to show the secondary evidence guide
- Some refactoring of the certificate page
  - Replaced `govuk` containers with the `GovGridRowComponent`
  - Moved CPD activity list and community activity lists into separate partials