### PR TITLE
Ensure case insensitivity in activity code lookup for course redirection

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -32,7 +32,7 @@ class CoursesController < ApplicationController
     begin
       @course = Achiever::Course::Template.find_by_activity_code(params[:id])
     rescue ActiveRecord::RecordNotFound
-      activity = Activity.find_by!(stem_activity_code: params[:id])
+      activity = Activity.find_by!(stem_activity_code: params[:id].upcase)
 
       if activity.replaced_by
         return redirect_to course_path(id: activity.replaced_by.stem_activity_code, name: activity.replaced_by.title.parameterize)


### PR DESCRIPTION
When a URL like `/courses/cp242` is requested, the controller first tries to find the course in Dynamics. That lookup calls `.upcase` on the input, so lowercase codes like co242 always work for active courses.

When Dynamics raises `RecordNotFound` (because CP242 is a withdrawn template), the controller falls back to looking up the Activity record in the local database. This is passed `params[:id]`, without upcasing.

Uppercase CP242 worked because the database value and the lookup value were identical strings.

Adding `.upcase` to `params[:id]` in the fallback lookup means "cp242" becomes "CP242" before hitting the database, matching the stored record. The redirect logic then runs as normal.

ENG-1382