### PR TITLE
Show draft pages in preview (GraphQL: request status: DRAFT)

### DIFF
--- a/app/services/cms/providers/strapi/graphql_client.rb
+++ b/app/services/cms/providers/strapi/graphql_client.rb
@@ -24,7 +24,7 @@ module Cms
         def one(resource_class, resource_id = nil, preview: false, preview_key: nil)
           query = Queries::BaseQuery.new(resource_class)
           begin
-            response = @connection.execute(query.single_query(resource_id))
+            response = @connection.execute(query.single_query(resource_id, preview:))
           rescue => e
             Sentry.capture_exception(e)
             raise ActiveRecord::RecordNotFound

--- a/app/services/cms/providers/strapi/queries/base_query.rb
+++ b/app/services/cms/providers/strapi/queries/base_query.rb
@@ -85,18 +85,20 @@ module Cms
             GRAPHQL
           end
 
-          def single_query(id = nil)
+          def single_query(id = nil, preview: false)
             filters = {}
             if @collection_class.is_collection
               raise StandardError if id.nil?
               filters[resource_filter] = {eq: id}
             end
-            filter_string = if filters.any?
-              "(#{query_string(:filters, filters)})"
-            end
+            args = []
+            args << query_string(:filters, filters) if filters.any?
+            # Ask Strapi for the draft version so unpublished pages are visible in preview.
+            args << "status: DRAFT" if preview
+            arg_string = "(#{args.join(" ")})" if args.any?
             <<~GRAPHQL.freeze
               query {
-                #{resource_name} #{filter_string} {
+                #{resource_name} #{arg_string} {
                   #{"documentId" if @collection_class.is_collection}
                   updatedAt
                   createdAt

--- a/spec/services/cms/providers/strapi/queries/base_query_spec.rb
+++ b/spec/services/cms/providers/strapi/queries/base_query_spec.rb
@@ -64,5 +64,34 @@ RSpec.describe Cms::Providers::Strapi::Queries::BaseQuery do
     it "should include filter" do
       expect(single_query).to include("filters: { slug: { eq: \"test-key\" } }")
     end
+
+    context "with preview" do
+      it "requests draft content for a collection" do
+        query = described_class.new(Cms::Collections::Blog).single_query("test-key", preview: true)
+        expect(query).to match(/status:\s*DRAFT/)
+      end
+
+      it "still includes the slug filter alongside the draft status" do
+        query = described_class.new(Cms::Collections::Blog).single_query("test-key", preview: true)
+        expect(query).to include("filters: { slug: { eq: \"test-key\" } }")
+        expect(query).to match(/status:\s*DRAFT/)
+      end
+
+      it "requests draft content for a single type that has no filters" do
+        query = described_class.new(Cms::Singles::Homepage).single_query(nil, preview: true)
+        expect(query).to match(/status:\s*DRAFT/)
+      end
+    end
+
+    context "without preview" do
+      it "does not request draft content for a single type" do
+        query = described_class.new(Cms::Singles::Homepage).single_query
+        expect(query).not_to match(/status:/)
+      end
+
+      it "does not request draft content for a collection" do
+        expect(single_query).not_to match(/status:/)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

Editors preview unpublished changes by visiting a page with `?preview=true`. This works for pages that are already published (so it shows pending edits), but **a page that exists only as a draft does not appear in preview at all** — the request 404s.

## Root cause

The `preview` flag is read and threaded all the way to the Strapi client, but on the **GraphQL path (which is what the app uses** — `STRAPI_CONNECTION_TYPE="graphql"`) it is dropped before it reaches Strapi:

- `GraphqlClient#one` accepts `preview:`/`preview_key:` but builds the query with `single_query(resource_id)` — preview is never passed in (`app/services/cms/providers/strapi/graphql_client.rb`).
- `BaseQuery#single_query` emits no publication status, so Strapi v5's GraphQL API applies its default, `status: PUBLISHED` (`app/services/cms/providers/strapi/queries/base_query.rb`).
- A homepage/single resource that only has a draft therefore returns nothing → `RecordNotFound`.

The REST client *does* handle this (`params[:publicationState] = "preview"`), but that path isn't in use (and `publicationState` is stale Strapi v4 syntax anyway).

## Fix

`single_query` now appends `status: DRAFT` to the query arguments when `preview` is set, alongside any existing `filters:`, and `GraphqlClient#one` passes `preview:` through. Verified against the checked-in schema that the `homepage` query accepts `status: PublicationStatus` and that the enum defines `DRAFT`.

```graphql
# before:  query { homepage { ... } }                # PUBLISHED only
# after:   query { homepage (status: DRAFT) { ... } } # when ?preview=true
```
