### PR TITLE
Fix showPage index for empty comment submission in rating controller

### DIFF
--- a/app/webpacker/javascript/controllers/rating_controller.js
+++ b/app/webpacker/javascript/controllers/rating_controller.js
@@ -52,7 +52,7 @@ export default class extends Controller {
     const comment = ev.currentTarget.elements.namedItem('comment')
     if (comment && !comment.value) {
       this.preventFormSubmission(ev)
-      this.showPage(5)
+      this.showPage(4)
     }
   }
 


### PR DESCRIPTION
Fixes a bug where the curriculum resource feedback widget showed a blank box instead of the "Thank you for your feedback!" message after a user submitted the comment step with an empty textarea.

`onCommentBeforeSend` in `rating_controller.js` called `this.showPage(5)`, but the widget only has 5 pages (indices 0–4). Since no page matched index 5, the `rating_page--current` class was removed from every page, leaving the widget blank. 

Changed `this.showPage(5)` to `this.showPage(4)` in `app/webpacker/javascript/controllers/rating_controller.js`, matching the existing correct pattern in `onChoicesBeforeSend`'s equivalent empty-input guard.