### PR TITLE
Remove Twitter links from completion pages

### DIFF
--- a/app/views/certificates/a_level/complete.html.erb
+++ b/app/views/certificates/a_level/complete.html.erb
@@ -34,15 +34,10 @@
           <h2 class="govuk-heading-m ncce-aside__title">Share your achievement</h2>
           <p class="govuk-body-s ncce-aside__text">
             Share your certificate on social media. Follow us on
-            <a href="https://twitter.com/WeAreComputing?ref_src=twsrc%5Etfw" class="ncce-link" data-related="WeAreComputing" data-lang="en" data-show-count="false" data-dnt="true" target="_blank">X</a>,
             <a href="https://www.facebook.com/WeAreComputing/" class="ncce-link" data-related="WeAreComputing" data-lang="en" data-dnt="true" target="_blank">Facebook</a>
             or
             <a href="https://www.linkedin.com/company/national-centre-for-computing-education" class="ncce-link" data-related="WeAreComputing" data-lang="en" data-dnt="true" target="_blank">LinkedIn</a>
             and tag us when sharing your achievement.
-          </p>
-          <p class="govuk-body-s ncce-aside__text">
-            <a href="https://twitter.com/intent/tweet?text=<%=CGI.escape "I have completed the A-Level programme from @WeAreComputing. Find out more #{about_a_level_url}"%>" class="govuk-link ncce-link complete__social complete__social--twitter" data-size="large" data-related="WeAreComputing" data-lang="en" data-dnt="true">Share on X</a>
-            <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
           </p>
           <p class="govuk-body-s ncce-aside__text">
             <a href="https://www.facebook.com/sharer/sharer.php?u=<%=CGI.escape about_a_level_url %>" target="_blank" class="govuk-link ncce-link complete__social complete__social--facebook">Share on Facebook</a>

--- a/app/views/certificates/cs_accelerator/complete.html.erb
+++ b/app/views/certificates/cs_accelerator/complete.html.erb
@@ -1,6 +1,5 @@
 <% meta_tag :title, 'KS3 and GCSE - Teach Computing' %>
 <%= render 'pages/certification/hero', full_width: true  %>
-<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 <div class="light-grey-bg">
   <div class="govuk-width-container">
     <div class="govuk-main-wrapper govuk-main-wrapper--xl">
@@ -73,13 +72,7 @@
             title: t('.share_aside.title'),
             class_name: 'share-aside',
             text: t('.share_aside.text.html',
-              twitter_follow_link: link_to(
-                t('.share_aside.follow.twitter'),
-                'https://twitter.com/WeAreComputing?ref_src=twsrc%5Etfw',
-                class: 'ncce-link',
-                data: tracking_data('follow on social').merge(related: 'WeAreComputing', dnt: true, lang: 'en'),
-                target: '_blank'
-              ),
+
               facebook_follow_link: link_to(
                 t('.share_aside.follow.facebook'),
                 'https://www.facebook.com/WeAreComputing/',
@@ -92,13 +85,6 @@
                 'https://www.linkedin.com/company/national-centre-for-computing-education',
                 class: 'ncce-link',
                 data: tracking_data('follow on social').merge(related: 'WeAreComputing', dnt: true, lang: 'en'),
-                target: '_blank'
-              ),
-              twitter_share_link: link_to(
-                t('.share_aside.share.twitter'),
-                'https://twitter.com/intent/tweet?text=I%20have%20completed%20the%20Computer%20Science%20Accelerator%20from%20%40WeAreComputing.%20Sign%20up:%20https://teachcomputing.org%2Fsubject-knowledge',
-                class: 'govuk-link ncce-link complete_social complete_social--x',
-                data: tracking_data('share on social').merge(related: 'WeAreComputing', dnt: true, lang: 'en', size: 'large'),
                 target: '_blank'
               ),
               facebook_share_link: link_to(

--- a/app/views/certificates/i_belong/complete.html.erb
+++ b/app/views/certificates/i_belong/complete.html.erb
@@ -62,19 +62,11 @@
           <h2 class="govuk-heading-m ncce-aside__title">Share your success</h2>
           <p class="govuk-body ncce-aside__text--s">Share your certificate on social media.</p>
           <p class="govuk-body ncce-aside__text">Follow us on
-            <a href="https://twitter.com/WeAreComputing?ref_src=twsrc%5Etfw"
-              class="ncce-link" data-related="WeAreComputing" data-lang="en"
-              data-show-count="false" data-dnt="true" target="_blank">X</a>, <a href="https://www.facebook.com/WeAreComputing/"
+            <a href="https://www.facebook.com/WeAreComputing/"
               class="ncce-link" data-related="WeAreComputing" data-lang="en"
               data-dnt="true" target="_blank" rel="noopener">Facebook</a> or <a href="https://www.linkedin.com/company/national-centre-for-computing-education"
               class="ncce-link" data-related="WeAreComputing" data-lang="en" data-dnt="true" target="_blank" rel="noopener">LinkedIn</a>
            and tag us when sharing your achievement</p>
-           <p class="govuk-body govuk-!-margin-bottom-2">
-            <a href="https://twitter.com/intent/tweet?text=<%=CGI.escape "I have completed the I Belong programme from @WeAreComputing. Find out more #{about_i_belong_url}"%>"
-              class="govuk-link ncce-link complete__social complete__social--twitter" data-size="large"
-              data-related="WeAreComputing" data-lang="en" data-dnt="true">Share on X</a>
-            <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-          </p>
 					<p class="govuk-body govuk-!-margin-bottom-2"><a href="https://www.facebook.com/sharer/sharer.php?u=<%=CGI.escape about_i_belong_url %>" target="_blank" class="govuk-link ncce-link complete__social complete__social--facebook">Share on Facebook</a></p>
 					<p class="govuk-body govuk-!-margin-bottom-2"><a href="https://www.linkedin.com/shareArticle?mini=true&url=<%=CGI.escape about_i_belong_url %>" rel="noopener" target="_blank"class="govuk-link ncce-link complete__social complete__social--linkedin">Share on LinkedIn</a></p>
         </div>

--- a/app/views/certificates/secondary_certificate/complete.html.erb
+++ b/app/views/certificates/secondary_certificate/complete.html.erb
@@ -29,19 +29,11 @@
           <h2 class="govuk-heading-m ncce-aside__title">Share your success</h2>
           <p class="govuk-body ncce-aside__text--s">Do you know someone who would benefit from this programme? Invite them to join and discuss what you’ve learnt with someone you know.</p>
           <p class="govuk-body ncce-aside__text">Follow us on
-            <a href="https://twitter.com/WeAreComputing?ref_src=twsrc%5Etfw"
-              class="ncce-link" data-related="WeAreComputing" data-lang="en"
-              data-show-count="false" data-dnt="true" target="_blank">Twitter</a>, <a href="https://www.facebook.com/WeAreComputing/"
+            <a href="https://www.facebook.com/WeAreComputing/"
               class="ncce-link" data-related="WeAreComputing" data-lang="en"
               data-dnt="true" target="_blank">Facebook</a> or <a href="https://www.linkedin.com/company/national-centre-for-computing-education"
               class="ncce-link" data-related="WeAreComputing" data-lang="en" data-dnt="true" target="_blank">LinkedIn</a>
            and tag us when sharing your achievement</p>
-           <p class="govuk-body govuk-!-margin-bottom-2">
-            <a href="https://twitter.com/intent/tweet?text=<%=CGI.escape "I have completed the Teach secondary computing programme from @WeAreComputing. Find out more #{secondary_url}"%>"
-              class="govuk-link ncce-link complete__social complete__social--twitter" data-size="large"
-              data-related="WeAreComputing" data-lang="en" data-dnt="true">Share on Twitter</a>
-            <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-          </p>
 					<p class="govuk-body govuk-!-margin-bottom-2"><a href="https://www.facebook.com/sharer/sharer.php?u=<%=CGI.escape secondary_url %>" target="_blank" class="govuk-link ncce-link complete__social complete__social--facebook">Share on Facebook</a></p>
 					<p class="govuk-body govuk-!-margin-bottom-2"><a href="https://www.linkedin.com/shareArticle?mini=true&url=<%=CGI.escape secondary_url %>" rel="noopener" target="_blank"class="govuk-link ncce-link complete__social complete__social--linkedin">Share on LinkedIn</a></p>
         </div>

--- a/config/locales/views/certificates/cs_accelerator/complete.en.yml
+++ b/config/locales/views/certificates/cs_accelerator/complete.en.yml
@@ -17,14 +17,12 @@ en:
           title: "Share your success"
           text:
             html: "Do you know someone who would benefit from this programme? Invite them to join, and discuss what you've learnt with someone you know.<br><br>
-            Follow us on %{twitter_follow_link}, %{facebook_follow_link} or %{linkedin_follow_link} and tag us when sharing your achievement<br><br>
-            %{twitter_share_link}%{facebook_share_link}%{linkedin_share_link}"
+            Follow us on %{facebook_follow_link} or %{linkedin_follow_link} and tag us when sharing your achievement<br><br>
+            %{facebook_share_link}%{linkedin_share_link}"
           follow:
-            twitter: "Twitter"
             facebook: "Facebook"
             linkedin: "LinkedIn"
           share:
-            twitter: "Share on Twitter"
             facebook: "Share on Facebook"
             linkedin: "Share on LinkedIn"
         next_steps:

--- a/spec/views/certificates/a_level/complete_spec.rb
+++ b/spec/views/certificates/a_level/complete_spec.rb
@@ -26,10 +26,6 @@ RSpec.describe("certificates/a_level/complete", type: :view) do
     expect(rendered).to have_css(".govuk-body-l", text: "Next steps for your development")
   end
 
-  it "has the X share button" do
-    expect(rendered).to have_link("Share on X", href: "https://twitter.com/intent/tweet?text=#{CGI.escape "I have completed the A-Level programme from @WeAreComputing. Find out more #{about_a_level_url}"}")
-  end
-
   it "has the Facebook share button" do
     expect(rendered).to have_link("Share on Facebook", href: "https://www.facebook.com/sharer/sharer.php?u=#{CGI.escape about_a_level_url}")
   end

--- a/spec/views/certificates/cs_accelerator/complete.html_spec.rb
+++ b/spec/views/certificates/cs_accelerator/complete.html_spec.rb
@@ -71,12 +71,8 @@ RSpec.describe("certificates/cs_accelerator/complete") do
       expect(rendered).to have_link("Download our GCSE Specification Map", href: "https://static.teachcomputing.org/GCSE_specifications_to_CSA_course_map.pdf")
     end
 
-    it "has the Twitter section" do
+    it "has a share section" do
       expect(rendered).to have_css(".share-aside .aside-component__heading", text: "Share your success")
-    end
-
-    it "has the Twitter share button" do
-      expect(rendered).to have_link("Share on Twitter", href: "https://twitter.com/intent/tweet?text=I%20have%20completed%20the%20Computer%20Science%20Accelerator%20from%20%40WeAreComputing.%20Sign%20up:%20https://teachcomputing.org%2Fsubject-knowledge")
     end
 
     it "has the Facebook share button" do

--- a/spec/views/certificates/i_belong/complete_spec.rb
+++ b/spec/views/certificates/i_belong/complete_spec.rb
@@ -29,10 +29,6 @@ RSpec.describe("certificates/i_belong/complete", type: :view) do
     expect(rendered).to have_css(".govuk-body-l", text: "Next steps for you")
   end
 
-  it "has the Twitter share button" do
-    expect(rendered).to have_link("Share on X", href: "https://twitter.com/intent/tweet?text=#{CGI.escape "I have completed the I Belong programme from @WeAreComputing. Find out more #{about_i_belong_url}"}")
-  end
-
   it "has the Facebook share button" do
     expect(rendered).to have_link("Share on Facebook", href: "https://www.facebook.com/sharer/sharer.php?u=#{CGI.escape about_i_belong_url}")
   end

--- a/spec/views/certificates/secondary-certificate/complete.html_spec.rb
+++ b/spec/views/certificates/secondary-certificate/complete.html_spec.rb
@@ -31,12 +31,8 @@ RSpec.describe("certificates/secondary_certificate/complete", type: :view) do
     expect(rendered).to have_css(".ncce-programmes-activity__title", text: "Your learning journey")
   end
 
-  it "has the Twitter section" do
+  it "has a share section" do
     expect(rendered).to have_css(".ncce-aside__title", text: "Share your success")
-  end
-
-  it "has the Twitter share button" do
-    expect(rendered).to have_link("Share on Twitter", href: "https://twitter.com/intent/tweet?text=#{CGI.escape "I have completed the Teach secondary computing programme from @WeAreComputing. Find out more #{secondary_url}"}")
   end
 
   it "has the Facebook share button" do


### PR DESCRIPTION
Removing references/links to Twitter/X when certificates are completed:
- I Belong
- KS3
- A Level
- Secondary