### PR TITLE
Create new secondary standalone activities

### DIFF
--- a/app/controllers/certificates/secondary_certificate_controller.rb
+++ b/app/controllers/certificates/secondary_certificate_controller.rb
@@ -14,7 +14,13 @@ module Certificates
       @pathways = Pathway.ordered_by_programme(@programme.slug).not_legacy
       @available_pathways_for_user = @pathways.filter { |pathway| pathway.slug != user_pathway.slug }
 
-      @professional_development_groups = @programme.programme_activity_groupings.not_community.order(:sort_key)
+      @cqf_group = ProgrammeActivityGroupings::CqfAssessment.find_by(programme: @programme)
+      @pd_group = ProgrammeActivityGroupings::ProfessionalDevelopmentActivity.find_by(programme: @programme)
+
+      standalone_grouping_ids = [@cqf_group.id, @pd_group.id]
+
+      @professional_development_groups = @programme.programme_activity_groupings.not_community
+        .where.not(id: standalone_grouping_ids).order(:sort_key)
       @community_groups = @programme.programme_activity_groupings.community.order(:sort_key)
 
       assign_recommended_activities

--- a/app/models/programme_activity_groupings/cqf_assessment.rb
+++ b/app/models/programme_activity_groupings/cqf_assessment.rb
@@ -1,0 +1,2 @@
+class ProgrammeActivityGroupings::CqfAssessment < ProgrammeActivityGrouping
+end

--- a/app/models/programme_activity_groupings/professional_development_activity.rb
+++ b/app/models/programme_activity_groupings/professional_development_activity.rb
@@ -1,0 +1,2 @@
+class ProgrammeActivityGroupings::ProfessionalDevelopmentActivity < ProgrammeActivityGrouping
+end

--- a/app/views/certificates/pathways/_recommended_courses.html.erb
+++ b/app/views/certificates/pathways/_recommended_courses.html.erb
@@ -4,8 +4,8 @@
       <p class="govuk-!-margin-top-0">
           <button data-action="expander#toggleAll"
                   data-expander-target="expanderButton"
-                  start-expanded="true"
-                  aria-expanded="true"
+                  start-expanded="<%= defined?(start_expanded) ? start_expanded : true %>"
+                  aria-expanded="<%= defined?(start_expanded) ? start_expanded : true %>"
                   class="govuk-body expander__button recommended-courses-wrapper_expander-button"
                   data-event-action="click"
                   data-event-label="Show additional courses"

--- a/app/views/certificates/secondary_certificate/_community_activity_list.html.erb
+++ b/app/views/certificates/secondary_certificate/_community_activity_list.html.erb
@@ -5,5 +5,6 @@
   <%= render CommunityActivityListComponent.new(
     programme_activity_grouping: group,
     community_achievements: @community_achievements,
+    number_to_show: 3
   ) %>
 <% end%>

--- a/app/views/certificates/secondary_certificate/_community_activity_list.html.erb
+++ b/app/views/certificates/secondary_certificate/_community_activity_list.html.erb
@@ -5,6 +5,5 @@
   <%= render CommunityActivityListComponent.new(
     programme_activity_grouping: group,
     community_achievements: @community_achievements,
-    number_to_show: 3
   ) %>
 <% end%>

--- a/app/views/certificates/secondary_certificate/_professional_development_groups_list.html.erb
+++ b/app/views/certificates/secondary_certificate/_professional_development_groups_list.html.erb
@@ -14,7 +14,8 @@
         <%= render partial: 'certificates/pathways/recommended_courses', locals: {
           event_category: 'primary enrolled',
           pathway: @user_pathway,
-          recommended_activities: @recommended_activities
+          recommended_activities: @recommended_activities,
+          start_expanded: false
         } %>
       </div>
     </li>

--- a/app/views/certificates/secondary_certificate/_standalone_activity_group.html.erb
+++ b/app/views/certificates/secondary_certificate/_standalone_activity_group.html.erb
@@ -1,0 +1,11 @@
+<% title_classes = ["govuk-body", "ncce-activity-list__title"] %>
+<% title_classes << "govuk-!-margin-top-8" if local_assigns[:margin_top] %>
+<% title_classes << add_group_complete_icon_class(current_user, group) %>
+
+<p id="<%= group.id %>" class="<%= title_classes.select(&:present?).join(" ") %>">
+  <strong><%= group.title %></strong>
+</p>
+<%= render CommunityActivityListComponent.new(
+  programme_activity_grouping: group,
+  community_achievements: @community_achievements
+) %>

--- a/app/views/certificates/secondary_certificate/_standalone_activity_group.html.erb
+++ b/app/views/certificates/secondary_certificate/_standalone_activity_group.html.erb
@@ -1,5 +1,4 @@
 <% title_classes = ["govuk-body", "ncce-activity-list__title"] %>
-<% title_classes << "govuk-!-margin-top-8" if local_assigns[:margin_top] %>
 <% title_classes << add_group_complete_icon_class(current_user, group) %>
 
 <p id="<%= group.id %>" class="<%= title_classes.select(&:present?).join(" ") %>">

--- a/app/views/certificates/secondary_certificate/show.html.erb
+++ b/app/views/certificates/secondary_certificate/show.html.erb
@@ -9,6 +9,8 @@
         '.introduction.html',
         subject_knowledge: link_to('Subject knowledge certificate', cs_accelerator_path)
       ) %></p>
+      <%= render 'standalone_activity_group', group: @cqf_group, margin_top: true %>
+      <%= render 'standalone_activity_group', group: @pd_group %>
       <%= render 'professional_development_groups_list' %>
     <% end %>
     <%= row.with_column("one-third") do %>

--- a/app/views/certificates/secondary_certificate/show.html.erb
+++ b/app/views/certificates/secondary_certificate/show.html.erb
@@ -9,9 +9,9 @@
         '.introduction.html',
         subject_knowledge: link_to('Subject knowledge certificate', cs_accelerator_path)
       ) %></p>
-      <%= render 'standalone_activity_group', group: @cqf_group, margin_top: true %>
-      <%= render 'standalone_activity_group', group: @pd_group %>
       <%= render 'professional_development_groups_list' %>
+      <%= render 'standalone_activity_group', group: @cqf_group %>
+      <%= render 'standalone_activity_group', group: @pd_group %>
     <% end %>
     <%= row.with_column("one-third") do %>
       <%= render partial: 'pathway_aside', locals: {

--- a/db/seeds/activities/community.rb
+++ b/db/seeds/activities/community.rb
@@ -316,6 +316,27 @@ Activity.find_or_initialize_by(slug: "participate-fully-in-an-ncce-curriculum-en
   }]
 end.save!
 
+Activity.find_or_initialize_by(slug: "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit-secondary").tap do |activity|
+  activity.title = "Implement and evaluate your professional development in the classroom"
+  activity.credit = 10
+  activity.slug = "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit-secondary"
+  activity.category = "community"
+  activity.provider = "stem-learning"
+  activity.self_certifiable = true
+  activity.description = "Think not only about your actions but also about <a href='https://www.stem.org.uk/about-us/impact-and-evaluation/impact-toolkit'>collecting evidence</a> of how the changes you make impact you, your colleagues, and your students. Use the available <a href='https://community.stem.org.uk/helpfaqs/cpdtools'>CPD implementation tools and techniques</a> to evaluate this impact."
+  activity.public_copy_description = "Think not only about your actions but also about <a href='https://www.stem.org.uk/about-us/impact-and-evaluation/impact-toolkit'>collecting evidence</a> of how the changes you make impact you, your colleagues, and your students. Use the available <a href='https://community.stem.org.uk/helpfaqs/cpdtools'>CPD implementation tools and techniques</a> to evaluate this impact."
+  activity.public_copy_title_url = impact_toolkit_url
+  activity.self_verification_info = nil
+  activity.public_copy_evidence = [{
+    brief: "Evidence guidance:",
+    bullets: [
+      "Add information on how you’ve implemented what you’ve learnt from CPD into your classroom.",
+      "Explain how the changes you made have impacted you, your colleagues, and your students.",
+      "If you applied knowledge from a residential course, explain how you used the <a href='https://www.stem.org.uk/about-us/impact-and-evaluation/impact-toolkit'>Impact Toolkit</a> to evaluate your learning. For some courses you may also be asked to make an action plan and reflect on the impact of your CPD after the course."
+    ]
+  }]
+end.save!
+
 Activity.find_or_initialize_by(slug: "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit").tap do |activity|
   activity.title = "Implement and evaluate your professional development in the classroom"
   activity.credit = 10
@@ -732,6 +753,26 @@ Activity.find_or_initialize_by(slug: "gain-accreditation-as-a-professional-devel
     bullets: [
       "Reflect on what makes CPD effective and how its impact can be evaluated as well as the strategies and tools you’ll need when <a href='#{leading_professional_development_url}'>leading learning</a> with teachers.",
       "Include the title of the specific <a href='#{leading_professional_development_url}'>accreditation</a> that you have gained."
+    ]
+  }]
+end.save!
+
+Activity.find_or_initialize_by(slug: "undertake-the-initial-assessment-of-your-school-using-computing-quality-framework-secondary").tap do |activity|
+  activity.title = "Undertake the initial assessment of your school using <a href='#{computing_quality_framework_url}'>Computing Quality Framework</a>"
+  activity.credit = 10
+  activity.slug = "undertake-the-initial-assessment-of-your-school-using-computing-quality-framework-secondary"
+  activity.category = "community"
+  activity.provider = "stem-learning"
+  activity.self_certifiable = true
+  activity.description = "Review your <a href='#{computing_quality_framework_url}'>school’s progress</a> in developing an exemplary computing curriculum and work towards achieving the <a href='#{computing_quality_framework_url}'>Computing Quality Mark.</a>"
+  activity.public_copy_description = "Review your <a href='#{computing_quality_framework_url}'>school’s progress</a> in developing an exemplary computing curriculum and work towards achieving the <a href='#{computing_quality_framework_url}'>Computing Quality Mark.</a>"
+  activity.public_copy_title_url = computing_quality_framework_url
+  activity.self_verification_info = nil
+  activity.public_copy_evidence = [{
+    brief: "Evidence guidance:",
+    bullets: [
+      "How were you involved in the initial assessment?",
+      "Include your average level across all benchmarks of the CQF. You can also add a link to a sharing folder with a screenshot of your school’s initial assessment graph. Make sure the viewing permissions are open to anyone with the link."
     ]
   }]
 end.save!

--- a/db/seeds/pathways/secondary_certificate.rb
+++ b/db/seeds/pathways/secondary_certificate.rb
@@ -44,12 +44,12 @@ programme.pathways.find_or_initialize_by(slug: "curriculum-leadership").tap do |
     # Make a positive impact on young people in computing
     "raise-aspirations-with-a-stem-ambassador-visit",
     "participate-fully-in-an-ncce-curriculum-enrichment-oppertunity",
-    "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit",
+    "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit-secondary",
     "download-and-use-the-ncce-teaching-and-assessment-resources-in-your-classroom",
     # Support your professional community
     "gain-accreditation-as-a-professional-development-leader",
     "support-other-teachers-and-earn-a-stem-community-participation-badge-secondary",
-    "undertake-the-initial-assessment-of-your-school-using-computing-quality-framework",
+    "undertake-the-initial-assessment-of-your-school-using-computing-quality-framework-secondary",
     "work-with-your-local-computing-hub-to-develop-a-school-level-action-plan-for-professional-development",
     "lead-your-school-into-a-computing-cluster-and-develop-an-action-plan-with-a-cluster-advisor",
     "join-and-present-at-your-local-computing-at-school-community"
@@ -108,7 +108,7 @@ programme.pathways.find_or_initialize_by(slug: "supporting-other-teachers").tap 
     "join-the-ib-encouraging-girls-into-cs-programme-and-become-an-ibc",
     # Support your professional community
     "gain-accreditation-as-a-professional-development-leader",
-    "undertake-the-initial-assessment-of-your-school-using-computing-quality-framework",
+    "undertake-the-initial-assessment-of-your-school-using-computing-quality-framework-secondary",
     "lead-your-school-into-a-computing-cluster-and-develop-an-action-plan-with-a-cluster-advisor",
     "join-and-present-at-your-local-computing-at-school-community",
     "support-other-teachers-and-earn-a-stem-community-participation-badge-secondary"
@@ -165,7 +165,7 @@ programme.pathways.find_or_initialize_by(slug: "championing-diversity-and-inclus
   activities = [
     "raise-aspirations-with-a-stem-ambassador-visit",
     "participate-fully-in-an-ncce-curriculum-enrichment-oppertunity",
-    "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit",
+    "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit-secondary",
     "download-and-use-isaac-computer-science-classroom-resources-and-displays",
     "complete-the-i-belong-programme-as-a-school",
     # Support your professional community
@@ -228,12 +228,12 @@ programme.pathways.find_or_initialize_by(slug: "raising-student-attainment").tap
   activities = [
     "raise-aspirations-with-a-stem-ambassador-visit",
     "participate-fully-in-an-ncce-curriculum-enrichment-oppertunity",
-    "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit",
+    "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit-secondary",
     "download-and-use-the-ncce-teaching-and-assessment-resources-in-your-classroom",
     # Support your local professional community
     "gain-accreditation-as-a-professional-development-leader",
     "support-other-teachers-and-earn-a-stem-community-participation-badge-secondary",
-    "undertake-the-initial-assessment-of-your-school-using-computing-quality-framework",
+    "undertake-the-initial-assessment-of-your-school-using-computing-quality-framework-secondary",
     "work-with-your-local-computing-hub-to-develop-a-school-level-action-plan-for-professional-development",
     "lead-your-school-into-a-computing-cluster-and-develop-an-action-plan-with-a-cluster-advisor",
     "join-and-present-at-your-local-computing-at-school-community"
@@ -288,7 +288,7 @@ programme.pathways.find_or_initialize_by(slug: "developing-teachers").tap do |pa
   activities = [
     "raise-aspirations-with-a-stem-ambassador-visit",
     "participate-fully-in-an-ncce-curriculum-enrichment-oppertunity",
-    "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit",
+    "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit-secondary",
     # Support your lcal professional community
     "gain-accreditation-as-a-professional-development-leader",
     "support-other-teachers-and-earn-a-stem-community-participation-badge-secondary",

--- a/db/seeds/programme_activity_groupings/secondary_certificate.rb
+++ b/db/seeds/programme_activity_groupings/secondary_certificate.rb
@@ -2,11 +2,8 @@ secondary = Programme.secondary_certificate
 
 puts "Creating Programme Activity Groupings for Secondary"
 
-## The numbering of the groupings starts at 2 for historical reasons: group_one with sort_key 1 existed when users were required
-## to complete 2 courses, one from each of groups 1 and 2.
-
 secondary.programme_activity_groupings.find_or_initialize_by(title: "All courses").becomes!(ProgrammeActivityGroupings::CreditCounted).tap do |group|
-  group.sort_key = 2
+  group.sort_key = 0
   group.cms_slug = "secondary-all-courses"
   group.required_for_completion = 1
   group.programme_id = secondary.id
@@ -26,13 +23,13 @@ secondary.programme_activity_groupings.find_by(title: "Develop your subject know
 secondary.programme_activity_groupings.find_by(title: "Develop your teaching practice")&.destroy
 secondary.programme_activity_groupings.find_by(title: "Develop computing in your community")&.destroy
 
-secondary.programme_activity_groupings.find_or_initialize_by(title: "Undertake the initial assessment of your school using Computing Quality Framework").becomes!(ProgrammeActivityGroupings::CqfAssessment).tap do |group|
-  group.sort_key = 0
-  group.cms_slug = "secondary-cqf"
+secondary.programme_activity_groupings.find_or_initialize_by(cms_slug: "secondary-cqf").becomes!(ProgrammeActivityGroupings::CqfAssessment).tap do |group|
+  group.title = "Progress through the Computing Quality Framework"
+  group.sort_key = 1
   group.required_for_completion = 1
   group.programme_id = secondary.id
   group.community = false
-  group.progress_bar_title = "Complete the Computing Quality Framework assessment"
+  group.progress_bar_title = "Progress through the CQF"
   group.web_copy_course_requirements = "Complete this activity"
 
   group.save!
@@ -41,9 +38,9 @@ secondary.programme_activity_groupings.find_or_initialize_by(title: "Undertake t
   maybe_attach_activity_to_grouping(group, "undertake-the-initial-assessment-of-your-school-using-computing-quality-framework-secondary", 1, legacy: false)
 end.save!
 
-secondary.programme_activity_groupings.find_or_initialize_by(title: "Implement and evaluate your professional development in the classroom").becomes!(ProgrammeActivityGroupings::ProfessionalDevelopmentActivity).tap do |group|
-  group.sort_key = 1
-  group.cms_slug = "secondary-pd-activity"
+secondary.programme_activity_groupings.find_or_initialize_by(cms_slug: "secondary-pd-activity").becomes!(ProgrammeActivityGroupings::ProfessionalDevelopmentActivity).tap do |group|
+  group.title = "Implement and evaluate your professional development in the classroom"
+  group.sort_key = 2
   group.required_for_completion = 1
   group.programme_id = secondary.id
   group.community = false

--- a/db/seeds/programme_activity_groupings/secondary_certificate.rb
+++ b/db/seeds/programme_activity_groupings/secondary_certificate.rb
@@ -26,6 +26,36 @@ secondary.programme_activity_groupings.find_by(title: "Develop your subject know
 secondary.programme_activity_groupings.find_by(title: "Develop your teaching practice")&.destroy
 secondary.programme_activity_groupings.find_by(title: "Develop computing in your community")&.destroy
 
+secondary.programme_activity_groupings.find_or_initialize_by(title: "Undertake the initial assessment of your school using Computing Quality Framework").becomes!(ProgrammeActivityGroupings::CqfAssessment).tap do |group|
+  group.sort_key = 0
+  group.cms_slug = "secondary-cqf"
+  group.required_for_completion = 1
+  group.programme_id = secondary.id
+  group.community = false
+  group.progress_bar_title = "Complete the Computing Quality Framework assessment"
+  group.web_copy_course_requirements = "Complete this activity"
+
+  group.save!
+
+  maybe_detach_activity_from_grouping(group, "undertake-the-initial-assessment-of-your-school-using-computing-quality-framework")
+  maybe_attach_activity_to_grouping(group, "undertake-the-initial-assessment-of-your-school-using-computing-quality-framework-secondary", 1, legacy: false)
+end.save!
+
+secondary.programme_activity_groupings.find_or_initialize_by(title: "Implement and evaluate your professional development in the classroom").becomes!(ProgrammeActivityGroupings::ProfessionalDevelopmentActivity).tap do |group|
+  group.sort_key = 1
+  group.cms_slug = "secondary-pd-activity"
+  group.required_for_completion = 1
+  group.programme_id = secondary.id
+  group.community = false
+  group.progress_bar_title = "Implement and evaluate your professional development"
+  group.web_copy_course_requirements = "Complete this activity"
+
+  group.save!
+
+  maybe_detach_activity_from_grouping(group, "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit")
+  maybe_attach_activity_to_grouping(group, "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit-secondary", 1, legacy: false)
+end.save!
+
 secondary.programme_activity_groupings.find_or_initialize_by(title: "Make a positive impact on young people in computing").tap do |group|
   group.title = "Make a positive impact on young people in computing"
   group.sort_key = 3
@@ -42,7 +72,6 @@ secondary.programme_activity_groupings.find_or_initialize_by(title: "Make a posi
   activities = [
     {slug: "raise-aspirations-with-a-stem-ambassador-visit", legacy: false},
     {slug: "participate-fully-in-an-ncce-curriculum-enrichment-oppertunity", legacy: false},
-    {slug: "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit", legacy: false},
     {slug: "download-and-use-isaac-computer-science-classroom-resources-and-displays", legacy: false},
     {slug: "download-and-use-the-ncce-teaching-and-assessment-resources-in-your-classroom", legacy: false},
     {slug: "complete-the-i-belong-programme-as-a-school", legacy: false},
@@ -78,7 +107,6 @@ secondary.programme_activity_groupings.find_or_initialize_by(title: "Support you
     {slug: "work-with-local-business-and-industry-to-inspire-inclusive-computing", legacy: false},
     {slug: "join-and-present-at-your-local-computing-at-school-community", legacy: false},
     {slug: "become-an-i-belong-champion", legacy: false},
-    {slug: "undertake-the-initial-assessment-of-your-school-using-computing-quality-framework", legacy: false},
     {slug: "support-other-teachers-and-earn-a-stem-community-participation-badge-secondary", legacy: false},
 
     # Legacy activities

--- a/db/seeds/programme_activity_groupings/secondary_certificate.rb
+++ b/db/seeds/programme_activity_groupings/secondary_certificate.rb
@@ -29,7 +29,7 @@ secondary.programme_activity_groupings.find_or_initialize_by(cms_slug: "secondar
   group.required_for_completion = 1
   group.programme_id = secondary.id
   group.community = false
-  group.progress_bar_title = "Progress through the CQF"
+  group.progress_bar_title = "Progress through the Computing Quality Framework"
   group.web_copy_course_requirements = "Complete this activity"
 
   group.save!

--- a/spec/factories/programme_activity_groupings/cqf_assessments.rb
+++ b/spec/factories/programme_activity_groupings/cqf_assessments.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :programme_activity_groupings_cqf_assessment, class: "ProgrammeActivityGroupings::CqfAssessment" do
+    title { "Undertake the CQF assessment" }
+    required_for_completion { 1 }
+    sort_key { 0 }
+    programme
+    progress_bar_title { "Progress Bar Title" }
+    sequence(:cms_slug) { |n| "programme-activity-grouping-cqf-assessment-#{n}" }
+
+    trait :with_activities do
+      after(:create) do |programme_activity_grouping|
+        create :programme_activity, programme_activity_grouping: programme_activity_grouping, programme: programme_activity_grouping.programme
+      end
+    end
+  end
+end

--- a/spec/factories/programme_activity_groupings/professional_development_activities.rb
+++ b/spec/factories/programme_activity_groupings/professional_development_activities.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :programme_activity_groupings_professional_development_activity, class: "ProgrammeActivityGroupings::ProfessionalDevelopmentActivity" do
+    title { "Implement and evaluate your professional development" }
+    required_for_completion { 1 }
+    sort_key { 1 }
+    programme
+    progress_bar_title { "Progress Bar Title" }
+    sequence(:cms_slug) { |n| "programme-activity-grouping-pd-activity-#{n}" }
+
+    trait :with_activities do
+      after(:create) do |programme_activity_grouping|
+        create :programme_activity, programme_activity_grouping: programme_activity_grouping, programme: programme_activity_grouping.programme
+      end
+    end
+  end
+end

--- a/spec/requests/certificates/secondary_certificate/show_spec.rb
+++ b/spec/requests/certificates/secondary_certificate/show_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe Certificates::SecondaryCertificateController do
   let!(:cs_accelerator) { create(:cs_accelerator) }
   let(:secondary_certificate) { create(:secondary_certificate) }
   let(:secondary_certificate_groupings) { create_list(:programme_activity_grouping, 3, programme_id: secondary_certificate.id) }
+  let(:cqf_group) {
+    create(:programme_activity_groupings_cqf_assessment, :with_activities, programme_id: secondary_certificate.id)
+  }
+  let(:pd_group) {
+    create(:programme_activity_groupings_professional_development_activity, :with_activities, programme_id: secondary_certificate.id)
+  }
   let(:secondary_enrolment) { create(:user_programme_enrolment, programme_id: secondary_certificate.id, user_id: user.id) }
 
   describe "#show" do
@@ -12,6 +18,8 @@ RSpec.describe Certificates::SecondaryCertificateController do
       before do
         secondary_certificate
         secondary_certificate_groupings
+        cqf_group
+        pd_group
         allow_any_instance_of(AuthenticationHelper)
           .to receive(:current_user).and_return(user)
       end
@@ -33,6 +41,16 @@ RSpec.describe Certificates::SecondaryCertificateController do
         it "assigns programme_activity_groupings" do
           expect(assigns(:community_groups)).to all(be_a(ProgrammeActivityGrouping))
           expect(assigns(:professional_development_groups)).to all(be_a(ProgrammeActivityGrouping))
+        end
+
+        it "assigns cqf_group and pd_group separately from professional_development_groups" do
+          expect(assigns(:cqf_group)).to be_a(ProgrammeActivityGrouping)
+          expect(assigns(:pd_group)).to be_a(ProgrammeActivityGrouping)
+          expect(assigns(:professional_development_groups)).not_to include(assigns(:cqf_group), assigns(:pd_group))
+        end
+
+        it "renders the standalone activity group partial for CQF and PD" do
+          expect(response).to render_template(partial: "certificates/secondary_certificate/_standalone_activity_group", count: 2)
         end
       end
 

--- a/spec/views/certificates/secondary-certificate/show.html_spec.rb
+++ b/spec/views/certificates/secondary-certificate/show.html_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe("certificates/secondary_certificate/show", type: :view) do
   let(:secondary_certificate) { create(:secondary_certificate) }
   let(:professional_development_groups) { create_list(:programme_activity_grouping, 2, :with_activities, sort_key: 1, programme: secondary_certificate) }
   let(:community_groups) { create_list(:programme_activity_grouping, 2, :with_activities, sort_key: 4, community: true, programme: secondary_certificate) }
+  let(:cqf_group) { create(:programme_activity_groupings_cqf_assessment, :with_activities, programme: secondary_certificate) }
+  let(:pd_group) { create(:programme_activity_groupings_professional_development_activity, :with_activities, programme: secondary_certificate) }
   let(:pathway) { create(:pathway, programme: secondary_certificate, title: "Developing", pdf_link: "developing.pdf") }
   let(:pathway_2) { create(:pathway, programme: secondary_certificate, title: "Specialising", pdf_link: "specialising.pdf") }
   let(:pathways) { [pathway, pathway_2] }
@@ -17,6 +19,8 @@ RSpec.describe("certificates/secondary_certificate/show", type: :view) do
     assign(:online_achievements, [])
     assign(:professional_development_groups, professional_development_groups)
     assign(:community_groups, community_groups)
+    assign(:cqf_group, cqf_group)
+    assign(:pd_group, pd_group)
 
     upe = create(:user_programme_enrolment, user_id: user.id, programme_id: secondary_certificate.id, pathway_id: pathway.id)
     recommended_activities = upe.pathway.pathway_activities
@@ -34,7 +38,7 @@ RSpec.describe("certificates/secondary_certificate/show", type: :view) do
   end
 
   it "has correct list setup" do
-    expect(rendered).to have_css(".ncce-activity-list--programme", count: 3)
+    expect(rendered).to have_css(".ncce-activity-list--programme", count: 5)
   end
 
   it "has an intro" do
@@ -51,7 +55,7 @@ RSpec.describe("certificates/secondary_certificate/show", type: :view) do
   end
 
   it "shows all activities" do
-    expect(rendered).to have_css(".ncce-activity-list__item", count: 4)
+    expect(rendered).to have_css(".ncce-activity-list__item", count: 6)
   end
 
   it "has support information" do


### PR DESCRIPTION
- CQF and the "implement and evaluate your professional development" activity are extracted from their existing activity groupings and shown as standalone dashboard sections on the secondary certificate page, above the professional development groups list
- Each is modelled as a single-activity `ProgrammeActivityGrouping` (new `CqfAssessment`/`ProfessionalDevelopmentActivity `STI subclasses) rather than a new component - reuses
  the existing community activity list/component
- Both activities are duplicated with a `-secondary` slug so completion tracking is independent per programme (previously shared with the Primary certificate)

I've also included a UI tweak to the show page:
- Collapse the professional development component on page load - previously, the component loaded expanded. With the 2 new activity components introduced in this ticket, they rendered far down the page. Loading collapsed allows the users to quickly see the objectives easier without having to scroll too far down the page