### PR TITLE
Update secondary pathway seeds

### DIFF
--- a/app/controllers/certificates/pathways_controller.rb
+++ b/app/controllers/certificates/pathways_controller.rb
@@ -12,7 +12,7 @@ class Certificates::PathwaysController < ApplicationController
     @recommended_community_activity_ids = @recommended_community_activities.map { _1.activity.id }
     @recommended_activities = recommended_activities - @recommended_community_activities
 
-    @cpd_group = @programme.programme_activity_groupings.not_community.first
+    @cpd_group = @programme.programme_activity_groupings.not_community.order(:sort_key).first
     @community_groups = @programme.programme_activity_groupings.community.order(:sort_key)
   end
 

--- a/db/seeds/pathways/secondary_certificate.rb
+++ b/db/seeds/pathways/secondary_certificate.rb
@@ -23,7 +23,6 @@ programme.pathways.find_or_initialize_by(slug: "curriculum-leadership").tap do |
     "Enrol with the click of the button",
     "Complete the required professional development",
     "Complete engagement activities to support your learning",
-    'Successfully complete the <a href="https://teachcomputing.org/subject-knowledge">Subject knowledge certificate</a>',
     "Receive your certificate"
   ]
 
@@ -41,12 +40,11 @@ programme.pathways.find_or_initialize_by(slug: "curriculum-leadership").tap do |
   end
 
   activities = [
-    # Make a positive impact on young people in computing
+    # Make an impact on young people and professional community
     "raise-aspirations-with-a-stem-ambassador-visit",
     "participate-fully-in-an-ncce-curriculum-enrichment-oppertunity",
     "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit-secondary",
     "download-and-use-the-ncce-teaching-and-assessment-resources-in-your-classroom",
-    # Support your professional community
     "gain-accreditation-as-a-professional-development-leader",
     "support-other-teachers-and-earn-a-stem-community-participation-badge-secondary",
     "undertake-the-initial-assessment-of-your-school-using-computing-quality-framework-secondary",
@@ -85,7 +83,6 @@ programme.pathways.find_or_initialize_by(slug: "supporting-other-teachers").tap 
     "Enrol with the click of the button",
     "Complete the required professional development",
     "Complete engagement activities to support your learning",
-    'Successfully complete the <a href="https://teachcomputing.org/subject-knowledge">Subject knowledge certificate</a>',
     "Receive your certificate"
   ]
 
@@ -106,7 +103,7 @@ programme.pathways.find_or_initialize_by(slug: "supporting-other-teachers").tap 
     "participate-fully-in-an-ncce-curriculum-enrichment-oppertunity",
     "download-and-use-the-ncce-teaching-and-assessment-resources-in-your-classroom",
     "join-the-ib-encouraging-girls-into-cs-programme-and-become-an-ibc",
-    # Support your professional community
+    # Make an impact on young people and professional community
     "gain-accreditation-as-a-professional-development-leader",
     "undertake-the-initial-assessment-of-your-school-using-computing-quality-framework-secondary",
     "lead-your-school-into-a-computing-cluster-and-develop-an-action-plan-with-a-cluster-advisor",
@@ -145,7 +142,6 @@ programme.pathways.find_or_initialize_by(slug: "championing-diversity-and-inclus
     "Enrol with the click of the button",
     "Complete the required professional development",
     "Complete engagement activities to support your learning",
-    'Successfully complete the <a href="https://teachcomputing.org/subject-knowledge">Subject knowledge certificate</a>',
     "Receive your certificate"
   ]
 
@@ -168,7 +164,7 @@ programme.pathways.find_or_initialize_by(slug: "championing-diversity-and-inclus
     "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit-secondary",
     "download-and-use-isaac-computer-science-classroom-resources-and-displays",
     "complete-the-i-belong-programme-as-a-school",
-    # Support your professional community
+    # Make an impact on young people and professional community
     "gain-accreditation-as-a-professional-development-leader",
     "support-other-teachers-and-earn-a-stem-community-participation-badge-secondary",
     "work-with-local-business-and-industry-to-inspire-inclusive-computing",
@@ -208,7 +204,6 @@ programme.pathways.find_or_initialize_by(slug: "raising-student-attainment").tap
     "Enrol with the click of the button",
     "Complete the required professional development",
     "Complete engagement activities to support your learning",
-    'Successfully complete the <a href="https://teachcomputing.org/subject-knowledge">Subject knowledge certificate</a>',
     "Receive your certificate"
   ]
 
@@ -230,7 +225,7 @@ programme.pathways.find_or_initialize_by(slug: "raising-student-attainment").tap
     "participate-fully-in-an-ncce-curriculum-enrichment-oppertunity",
     "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit-secondary",
     "download-and-use-the-ncce-teaching-and-assessment-resources-in-your-classroom",
-    # Support your local professional community
+    # Make an impact on young people and professional community
     "gain-accreditation-as-a-professional-development-leader",
     "support-other-teachers-and-earn-a-stem-community-participation-badge-secondary",
     "undertake-the-initial-assessment-of-your-school-using-computing-quality-framework-secondary",
@@ -268,7 +263,6 @@ programme.pathways.find_or_initialize_by(slug: "developing-teachers").tap do |pa
     "Enrol with the click of the button",
     "Complete the required professional development",
     "Complete engagement activities to support your learning",
-    'Successfully complete the <a href="https://teachcomputing.org/subject-knowledge">Subject knowledge certificate</a>',
     "Receive your certificate"
   ]
 
@@ -289,7 +283,7 @@ programme.pathways.find_or_initialize_by(slug: "developing-teachers").tap do |pa
     "raise-aspirations-with-a-stem-ambassador-visit",
     "participate-fully-in-an-ncce-curriculum-enrichment-oppertunity",
     "implement-your-professional-development-in-the-classroom-and-evaluate-via-the-impact-toolkit-secondary",
-    # Support your lcal professional community
+    # Make an impact on young people and professional community
     "gain-accreditation-as-a-professional-development-leader",
     "support-other-teachers-and-earn-a-stem-community-participation-badge-secondary",
     "work-with-local-business-and-industry-to-inspire-inclusive-computing"


### PR DESCRIPTION
Remove the "Successfully complete the Subject knowledge certificate" enrol_copy bullet from all 5 secondary pathways, since KS3/CS Accelerator completion is no longer required (ENG-1260). Also update stale comments left over from the ENG-1531 community grouping merge.

Order programme_activity_groupings by sort_key before taking the first non-community group in `Certificates::PathwaysController#show`. Secondary now has 3 non-community groupings (All courses, CQF, PD) instead of 1, so relying on default row order was no longer safe to guarantee "All courses" is picked.