### PR TITLE
Remove dead how_to_enrol locale keys from pathway show view

### DIFF
--- a/config/locales/views/certificates/pathways/show.en.yml
+++ b/config/locales/views/certificates/pathways/show.en.yml
@@ -7,8 +7,3 @@ en:
           description: Our learning pathways provide a set of recommended courses and activities to help get the right outcomes for you. Complete a tailored selection of courses and engagement activities to receive your certificate.
         download_pdf: "Download our <b>%{title}</b> pathway PDF to reference as you progress through the certificate."
         download_pdf_cta: "%{link} (PDF)"
-        how_to_enrol: How to enrol
-        how_to_enrol_1: "Successfully complete %{link}"
-        how_to_enrol_2: Enrol with the click of a button
-        how_to_enrol_3: Complete the required professional development, engagement, and community activities to recieve your qualification
-        how_to_enrol_link: "the %{programme_name} programme"


### PR DESCRIPTION
- Removes the 5 `how_to_enrol*` locale keys from `config/locales/views/certificates/pathways/show.en.yml` - confirmed dead, unreferenced anywhere in the codebase.
- The "How to enrol" aside on pathway pages has rendered from `@pathway.enrol_copy` (seed-driven) since August 2023 these locale keys were superseded at that point and never wired back up.
- Addresses ENG-1264 as scoped: the ticket's original ask targeted content that isn't actually live, so this is a cleanup rather than a copy change - the real enrol copy is already correct via ENG-1534's seed update.