### PR TITLE
Remove pathway text from secondary certificate page

### DIFF
--- a/app/views/pages/enrolment/secondary_certificate.html.erb
+++ b/app/views/pages/enrolment/secondary_certificate.html.erb
@@ -48,13 +48,7 @@
             </li>
             <li><%= t('.how_does_it_work_2') %></li>
             <li><%= t('.how_does_it_work_3') %></li>
-            <li>
-              <%= t(
-                    '.how_does_it_work_4',
-                    link: link_to('the Key stage 3 and GCSE Computer Science subject knowledge programme', '#')
-              ).html_safe %>
-            </li>
-            <li><%= t('.how_does_it_work_5') %></li>
+            <li><%= t('.how_does_it_work_4') %></li>
           </ul>
         </section>
       </div>

--- a/config/locales/views/pages/enrolment/secondary_certificate.yml
+++ b/config/locales/views/pages/enrolment/secondary_certificate.yml
@@ -17,8 +17,7 @@ en:
         how_does_it_work_1: "%{create_an_account} or %{log_in} to your existing account"
         how_does_it_work_2: "see which of our pathways best matches your needs and enrol on the right one for you"
         how_does_it_work_3: "complete a tailored selection of courses and engagement activities"
-        how_does_it_work_4: "successfully complete the %{link}"
-        how_does_it_work_5: "receive a nationally recognised certificate, awarded by BCS, The Chartered Institute for IT"
+        how_does_it_work_4: "receive a nationally recognised certificate, awarded by BCS, The Chartered Institute for IT"
         hub_aside:
           title: "Subject Expert support"
           text: "Our network of Computing Hubs are here to help you, providing local training and support for teachers across England."


### PR DESCRIPTION
- Removes the stale "successfully complete the Key stage 3 and GCSE Computer Science subject knowledge programme" bullet from the "How does the programme work?" section on the public `/secondary-certificate` enrolment page.