### PR TITLE
Remove Subject knowledge certificate reference from secondary dashboa…

### DIFF
--- a/app/views/certificates/secondary_certificate/show.html.erb
+++ b/app/views/certificates/secondary_certificate/show.html.erb
@@ -5,10 +5,7 @@
   <%= render ProgressBarComponent.new(programme: @programme) %>
   <%= render GovGridRowComponent.new(padding: {top: 0, bottom: 0}) do |row| %>
     <%= row.with_column("two-thirds") do %>
-      <p class="govuk-body-m"><%= t(
-        '.introduction.html',
-        subject_knowledge: link_to('Subject knowledge certificate', cs_accelerator_path)
-      ) %></p>
+      <p class="govuk-body-m"><%= t('.introduction.html') %></p>
       <%= render 'professional_development_groups_list' %>
       <%= render 'standalone_activity_group', group: @cqf_group %>
       <%= render 'standalone_activity_group', group: @pd_group %>

--- a/config/locales/views/certificates/secondary_certificate/show.en.yml
+++ b/config/locales/views/certificates/secondary_certificate/show.en.yml
@@ -4,7 +4,7 @@ en:
       show:
         page_title: "Secondary certificate - Teach Computing"
         introduction:
-          html: "These courses and activities have been picked so you can develop your teaching and enrich pupils' experience of the computing curriculum. You'll also get the opportunity to engage with the wider support network available in secondary computing.<br><br>Through the required training and activities, and by completing the %{subject_knowledge}, you'll achieve our Teach secondary computing certificate, demonstrating your commitment to improving computing education in your school."
+          html: "These courses and activities have been picked so you can develop your teaching and enrich pupils' experience of the computing curriculum. You'll also get the opportunity to engage with the wider support network available in secondary computing.<br><br>Through the required training and activities, you'll achieve our Teach secondary computing certificate, demonstrating your commitment to improving computing education in your school."
         feedback_text: "What can we do better?"
         support_aside:
           hub_link_text: "Contact your local Computing Hub"


### PR DESCRIPTION
- Removes the "and by completing the Subject knowledge certificate" clause from the intro paragraph shown to enrolled users on `/certificate/secondary-certificate`, and the now-unused `subject_knowledge`/`cs_accelerator_path` link from the view.