### PR TITLE
Bump Rails configuration defaults from 7.1 to 8.1

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ module TeachComputing
     config.action_dispatch.cookies_same_site_protection = :lax
 
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.1
+    config.load_defaults 8.1
 
     # Keep Rails UJS remote form behavior until Phase 3 (importmap/turbo migration).
     config.action_view.form_with_generates_remote_forms = true


### PR DESCRIPTION
Bump `config.load_defaults` from 7.1 → 8.1 in config/application.rb, adopting all Rails 7.2, 8.0, and 8.1 framework defaults now that the app runs on Rails 8.1.3 (gem was upgraded in #1743, but defaults were never bumped alongside it).
 
- Worked through each of the 13 new defaults individually via the generated new_framework_defaults_*.rb initializers, verified each against the codebase/specs, then folded them into load_defaults 8.1 and removed the initializer files.
- `active_record.raise_on_missing_required_finder_order_columns` - raises on unordered .first/.second etc. No existing code hit this.
- `action_controller.action_on_path_relative_redirect = :raise` - blocks relative redirects without a leading slash (open-redirect protection). Audited all `redirect_to` calls. Every non-helper redirect (request.fullpath.sub, model #path methods) already produces safe paths.
- `active_job.enqueue_after_transaction_commit = :default` - Sidekiq-backed jobs now defer enqueuing until the enclosing transaction commits (safer against race conditions). Verified against all specs using `have_enqueued_job/assert_enqueued_*`.
- `Regexp.timeout = 1` - global ReDoS mitigation.
- `config.yjit` - now uses Rails 8.1's environment-aware default (!Rails.env.local?), off in dev/test, on in staging/production.
- `active_storage.web_image_content_types` (+webp), `active_record.postgresql_adapter_decode_dates`, `escape_json_responses/escape_js_separators_in_json`, `render_tracker`, `remove_hidden_field_autocomplete`, `strict_freshness`, `validate_migration_timestamps` - all audited against actual usage (no raw SQL date queries, no inline JSON-in-<script> embedding, no ActiveStorage variant logic keyed to content type, no autocomplete assertions in specs).

***Verification***
- Full RSpec suite: 3981 examples, 0 failures
- bin/rails runner boot check confirms settings are live (e.g. raise_on_missing_required_finder_order_columns → true).
- standardrb clean on the changed file.
- Brakeman: 0 warnings, 0 errors (unrelated pre-existing obsolete ignore entries, no diff on brakeman.ignore).
